### PR TITLE
Fix staging remote PATH expansion

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -69,7 +69,7 @@ jobs:
             export INFISICAL_CLIENT_ID='${{ secrets.INFISICAL_CLIENT_ID }}'
             export INFISICAL_CLIENT_SECRET='${{ secrets.INFISICAL_CLIENT_SECRET }}'
             export INFISICAL_PROJECT_ID='${{ secrets.INFISICAL_PROJECT_ID }}'
-            export PATH='/home/ua/.local/bin:/usr/local/bin:\$PATH'
+            export PATH=\"/home/ua/.local/bin:/usr/local/bin:/usr/bin:/bin:\$PATH\"
 
             run_as_ua() {
               ua_home=\$(getent passwd ua | cut -d: -f6)

--- a/docs/deployment/ci_cd_pipeline.md
+++ b/docs/deployment/ci_cd_pipeline.md
@@ -80,6 +80,7 @@ Allow `tag:ci-gha` to reach `tag:vps` on TCP/22 in your current ACL/grants model
 - This provides the `nlm` CLI and `notebooklm-mcp` server binaries expected by the NotebookLM runtime.
 - The deployed runtime PATH must include `/home/ua/.local/bin` so those binaries are discoverable by gateway-executed Bash commands and MCP registration.
 - Staging deploy must execute `uv` tool installation under the real `ua` home directory (`sudo -H -u ua` / `HOME=$ua_home`) so NotebookLM tools land in the service user's tool path.
+- In the staging SSH deploy script, PATH must be quoted for remote expansion, not shipped as a literal `$PATH`, or basic commands like `getent`/`cut` can disappear from the remote shell.
 
 ## Review and Promotion Rule
 


### PR DESCRIPTION
Summary:
- fix the staging SSH deploy PATH export so the remote shell expands PATH correctly
- preserve access to core remote commands while still prepending the ua tool directory
- document the literal-PATH failure mode in the deployment docs

Root cause:
The staging SSH command exported PATH with a literal dollar-PATH string inside single quotes, which dropped /usr/bin and /bin from the remote shell. That broke getent and cut before the NotebookLM install check could complete.
