### PR TITLE
Repair staging ownership and stale venv

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -64,6 +64,13 @@ jobs:
             cd \$STAGING_DIR
             git fetch origin develop
             git reset --hard origin/develop
+
+            echo '--> Transferring ownership to service user before dependency sync...'
+            if command -v sudo >/dev/null 2>&1; then
+              sudo chown -R ua:ua \$STAGING_DIR
+            else
+              chown -R ua:ua \$STAGING_DIR
+            fi
             
             echo '--> Provisioning Infisical environment...'
             export INFISICAL_CLIENT_ID='${{ secrets.INFISICAL_CLIENT_ID }}'
@@ -84,6 +91,18 @@ jobs:
                 HOME=\"\$ua_home\" /bin/bash -lc \"\$1\"
               fi
             }
+
+            echo '--> Checking whether the existing venv is usable by ua...'
+            if [ -e \"\$STAGING_DIR/.venv/bin/python3\" ]; then
+              if ! run_as_ua \"readlink -f \\\"\$STAGING_DIR/.venv/bin/python3\\\" >/dev/null 2>&1\"; then
+                echo '--> Existing venv interpreter is not accessible to ua; removing stale .venv for clean rebuild...'
+                if command -v sudo >/dev/null 2>&1; then
+                  sudo rm -rf \"\$STAGING_DIR/.venv\"
+                else
+                  rm -rf \"\$STAGING_DIR/.venv\"
+                fi
+              fi
+            fi
 
             echo '--> Ensuring Python 3.12 runtime for uv...'
             run_as_ua \"export PATH=\\\"\$HOME/.local/bin:/usr/local/bin:\$PATH\\\"; uv python install 3.12\"

--- a/docs/deployment/ci_cd_pipeline.md
+++ b/docs/deployment/ci_cd_pipeline.md
@@ -195,16 +195,16 @@ then CI identity is not matching the required non-interactive SSH policy. Verify
   ```
 - Verify the `.env` file exists in the installation directory.
 
-### Production `uv sync` Fails With Python Interpreter Permission Errors
+### Staging Or Production `uv sync` Fails With Python Interpreter Permission Errors
 
-If production deploy logs show either:
+If staging or production deploy logs show either:
 
 - `failed to canonicalize path /opt/universal_agent/.venv/bin/python3: Permission denied`
 - `Failed to execute /opt/universal_agent/.venv/bin/python3: Permission denied`
 
 then the existing `.venv` was created against a Python interpreter path that the `ua` service user cannot traverse.
 
-Current production workflow behavior:
+Current deploy workflow behavior:
 
 1. chowns the repo to `ua`
 2. checks whether `ua` can resolve `.venv/bin/python3`


### PR DESCRIPTION
Summary:
- chown the staging checkout back to ua after reset
- remove a stale staging .venv when the ua service user cannot resolve its interpreter
- align staging deploy repair behavior with the existing production deploy guardrail

Root cause:
The staging node still had a root-owned checkout and stale virtualenv, so uv could not canonicalize .venv/bin/python3 as ua and even writing the bootstrap .env file failed with permission denied.
