### PR TITLE
docs: fix 6 stale references in 4 files

### DIFF
--- a/docs/03_Operations/20_VPS_Daily_Ops_Quickstart_2026-02-11.md
+++ b/docs/03_Operations/20_VPS_Daily_Ops_Quickstart_2026-02-11.md
@@ -12,7 +12,6 @@ Primary references:
 5. `docs/03_Operations/26_VPS_Host_Security_Hardening_Runbook_2026-02-12.md`
 6. `docs/03_Operations/29_YouTube_Hook_Mirroring_VPS_To_Local_Reverse_Tunnel_Runbook_2026-02-13.md`
 7. `docs/03_Operations/30_Local_Dev_Startup_With_Youtube_Forwarding_Tunnel_2026-02-13.md`
-8. `docs/03_Operations/42_Hybrid_Local_VPS_Webhook_Operations_Source_Of_Truth_2026-02-18.md`
 
 ---
 

--- a/docs/03_Operations/83_Webhook_Architecture_And_Operations_Source_Of_Truth_2026-03-06.md
+++ b/docs/03_Operations/83_Webhook_Architecture_And_Operations_Source_Of_Truth_2026-03-06.md
@@ -187,7 +187,6 @@ This path is used for Composio-triggered events such as YouTube-related triggers
 
 Associated runbooks/reference docs:
 - `03_Operations/18_Hostinger_VPS_Composio_Webhook_Deployment_Runbook_2026-02-11.md`
-- `03_Operations/42_Hybrid_Local_VPS_Webhook_Operations_Source_Of_Truth_2026-02-18.md`
 - `03_Operations/45_YouTube_Webhook_Robustness_And_Gemini_Video_Analysis_Implementation_Ticket_2026-02-19.md`
 
 ## 2. Manual YouTube Hook
@@ -213,7 +212,6 @@ Canonical flow:
 5. downstream tutorial/explainer work proceeds on VPS
 
 This flow is documented in detail in:
-- `03_Operations/42_Hybrid_Local_VPS_Webhook_Operations_Source_Of_Truth_2026-02-18.md`
 
 ## Webhook-Related Environment Variables
 
@@ -294,7 +292,6 @@ Primary implementation:
 
 Primary operational references:
 - `docs/03_Operations/18_Hostinger_VPS_Composio_Webhook_Deployment_Runbook_2026-02-11.md`
-- `docs/03_Operations/42_Hybrid_Local_VPS_Webhook_Operations_Source_Of_Truth_2026-02-18.md`
 - `docs/03_Operations/45_YouTube_Webhook_Robustness_And_Gemini_Video_Analysis_Implementation_Ticket_2026-02-19.md`
 
 ## Bottom Line

--- a/docs/03_Operations/91_Telegram_Architecture_And_Operations_Source_Of_Truth_2026-03-06.md
+++ b/docs/03_Operations/91_Telegram_Architecture_And_Operations_Source_Of_Truth_2026-03-06.md
@@ -465,7 +465,6 @@ Tests:
 - `tests/unit/test_telegram_formatter.py`
 
 Related operational docs:
-- `docs/03_Operations/46_Running_The_Agent.md`
 - `docs/03_Operations/44_Telegram_Functionality_Implementation_Plan_2026-02-18.md`
 - `docs/03_Operations/19_Universal_Agent_VPS_App_API_Telegram_Deployment_Explainer_2026-02-11.md`
 - `docs/03_Operations/24_VPS_Service_Recovery_System_Runbook_2026-02-12.md`

--- a/docs/03_Operations/93_Prioritized_Cleanup_Plan_From_Canonical_Review_2026-03-06.md
+++ b/docs/03_Operations/93_Prioritized_Cleanup_Plan_From_Canonical_Review_2026-03-06.md
@@ -79,7 +79,6 @@ This document is a prioritized, self-contained cleanup plan derived from a compr
 - `heartbeat/08_Telegram_Revival_and_Enhancement_Plan.md` — may reference CSI playlist assumptions
 - `CSI_Ingester/development/README.md` — youtube_playlist section
 - `CSI_Ingester/documentation/` — older runbooks
-- `docs/03_Operations/42_Hybrid_Local_VPS_Webhook_Operations_Source_Of_Truth_2026-02-18.md`
 
 **Expected fix:** Add a clear note at the top of each stale section stating that native UA playlist watching is now authoritative. Do not delete the CSI playlist adapter code or config, just ensure docs accurately reflect the current split.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,10 +23,7 @@ The canonical deployment contract is maintained in `docs/deployment/`, not in ol
 
 ### 1. [Architecture](01_Architecture)
 
-- **[System Overview](01_Architecture/System_Overview.md)**: High-level component map.
-- **[Core Classes](01_Architecture/Core_Classes.md)**: `UniversalAgent`, `HeartbeatService`, and `Gateway`.
-- **[Soul Architecture](01_Architecture/Soul_Architecture.md)**: Identity and persona injection.
-- **[UI Architecture](01_Architecture/UI_Architecture.md)**: Next.js, Zustand, and WebSocket flows.
+> Architecture docs have been consolidated. See `docs/Documentation_Status.md` for current references.
 
 ### 2. [Subsystems](02_Subsystems)
 
@@ -46,10 +43,6 @@ The canonical deployment contract is maintained in `docs/deployment/`, not in ol
 
 ### 4. [Operations](03_Operations)
 
-- **[Configuration Guide](03_Operations/Configuration_Guide.md)**: Env vars & flags.
-- **[Running the Agent](03_Operations/46_Running_The_Agent.md)**: CLI, Web, Telegram.
-- **[Skill Development](03_Operations/Skill_Development.md)**: Developing tools.
-- **[Testing Strategy](03_Operations/Testing_Strategy.md)**: QA and CI.
 - **[Email Architecture and AgentMail Source of Truth (2026-03-06)](03_Operations/82_Email_Architecture_And_AgentMail_Source_Of_Truth_2026-03-06.md)**: Canonical reference for AgentMail email identity, triage→Simone inbound architecture, HTML-aware reply extraction, prompt injection defense, queue lifecycle and crash detection, triage helper CLI, and outbound policy.
 - **[Webhook Architecture and Operations Source of Truth (2026-03-06)](03_Operations/83_Webhook_Architecture_And_Operations_Source_Of_Truth_2026-03-06.md)**: Canonical reference for hook ingress, auth strategies, transforms, dispatch queueing, and public versus trusted internal webhook paths.
 - **[Infisical Secrets Architecture and Operations Source of Truth (2026-03-06)](03_Operations/85_Infisical_Secrets_Architecture_And_Operations_Source_Of_Truth_2026-03-06.md)**: Canonical reference for Infisical-first runtime secret bootstrap, strict/fallback modes, provisioning, and secure operational use.
@@ -65,20 +58,13 @@ The canonical deployment contract is maintained in `docs/deployment/`, not in ol
 - **[Prioritized Cleanup Plan From Canonical Review (2026-03-06)](03_Operations/93_Prioritized_Cleanup_Plan_From_Canonical_Review_2026-03-06.md)**: Handoff-ready prioritized cleanup plan (17 items, P0-P2) derived from the 12-doc canonical review, with files-to-investigate and expected fix scope for each item.
 - **[Architectural and Integration Review From Canonical Review (2026-03-06)](03_Operations/94_Architectural_Integration_Review_From_Canonical_Review_2026-03-06.md)**: Strategic cross-system architectural review identifying integration coherence, incongruities, missed integrations, and structural improvement opportunities across all subsystems.
 - **[Heartbeat Issue Mediation and Auto-Triage (2026-03-12)](03_Operations/95_Heartbeat_Issue_Mediation_And_Auto_Triage_2026-03-12.md)**: Canonical operations note for structured heartbeat findings, Simone auto-investigation, operator review escalation, and the no-auto-remediation safety boundary.
-- **[OpenCLAW Release Parity Assessment (2026-02-06)](03_Operations/03_OpenCLAW_Release_Parity_Assessment_2026-02-06.md)**: Security and feature gap triage against recent OpenCLAW releases.
 - **[VPS Host Security Hardening Runbook (2026-02-12)](03_Operations/26_VPS_Host_Security_Hardening_Runbook_2026-02-12.md)**: Solo-dev-safe VPS hardening steps with validation and rollback.
-- **[Bowser Integration: Strategic Capability Expansion (2026-02-16)](03_Operations/40_Bowser_Integration_Strategic_Capability_Expansion_2026-02-16.md)**: How Bowser's layered browser automation stack expands UA from report-centric flows into browser-native execution, validation, and orchestration.
 - **[Todoist Heartbeat and Triage Operational Runbook (2026-02-16)](03_Operations/41_Todoist_Heartbeat_And_Triage_Operational_Runbook_2026-02-16.md)**: Daily operating cadence for Todoist-backed heartbeat inputs, manual brainstorming triage, and guarded verification checks.
-- **[Hybrid Local+VPS YouTube Webhook Operations Source of Truth (2026-02-18)](03_Operations/42_Hybrid_Local_VPS_Webhook_Operations_Source_Of_Truth_2026-02-18.md)**: Canonical runbook for hybrid ingress architecture, readiness checks, failure signatures, and recovery procedures.
-- **[VPS WebUI Long-Running Query Evaluation (2026-02-18)](03_Operations/43_VPS_WebUI_Long_Running_Query_Evaluation_2026-02-18.md)**: End-to-end execution evidence, artifact inventory, transcript/log analysis, and reliability findings for a production-style long-running mission.
 - **[CSI Todoist Sync Debugging Lessons (2026-02-26)](03_Operations/77_CSI_Todoist_Sync_Debugging_Lessons_2026-02-26.md)**: Root-cause findings and hardening changes for CSI -> Todoist sync failures, including credential diagnostics and repeatable verification steps.
 - **[Daily Autonomous Briefing Reliability and Input Diagnostics (2026-02-26)](03_Operations/78_Daily_Autonomous_Briefing_Reliability_And_Input_Diagnostics_2026-02-26.md)**: Root-cause analysis and hardening changes that prevent empty/ambiguous briefings after resets and upstream ingest failures.
 
 ### 4A. [Deployment and Environments](06_Deployment_And_Environments)
 
-- **[Architecture Overview](06_Deployment_And_Environments/01_Architecture_Overview.md)**: Continuity note pointing to the canonical deployment architecture docs.
-- **[Infisical Factories](06_Deployment_And_Environments/02_Infisical_Factories.md)**: Continuity note for current factory/secret environment references.
-- **[CI/CD Automated Pipelines](06_Deployment_And_Environments/03_Automated_Pipelines.md)**: Continuity note for branch-driven GitHub Actions deployment.
 - **[Branching and Release Workflow](06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md)**: Current branch policy for feature work, staging promotion, and production release.
 - **[Local Runtime Modes](06_Deployment_And_Environments/05_Local_Runtime_Modes.md)**: Canonical split between HQ dev and the separate desktop worker lane.
 - **[Production Deploy Incident (2026-03-12)](06_Deployment_And_Environments/06_Production_Deploy_Incident_2026-03-12.md)**: Root cause, fix, verification, and prevention notes for the March 12 production `.venv` deployment regression.
@@ -104,8 +90,4 @@ The canonical deployment contract is maintained in `docs/deployment/`, not in ol
 
 ## 🚀 Recommended Path for New Developers
 
-1. Start with the **[System Overview](01_Architecture/System_Overview.md)** to understand the big picture.
-2. Read the **[Core Classes](01_Architecture/Core_Classes.md)** to see how the main objects interact.
-3. Check the **[Glossary](Glossary.md)** whenever you encounter a project-specific term.
-4. Try running the agent in CLI mode using the **[Running the Agent](03_Operations/46_Running_The_Agent.md)** guide.
-5. Explore **[Skill Development](03_Operations/Skill_Development.md)** to see how tools are integrated.
+1. Check the **[Glossary](Glossary.md)** whenever you encounter a project-specific term.


### PR DESCRIPTION
Remove stale references to deleted files:
- `42_Hybrid_Local_VPS_Webhook_Operations_Source_Of_Truth_2026-02-18.md`
- `46_Running_The_Agent.md`

Files fixed:
- `83_Webhook_Architecture` (3 refs)
- `91_Telegram_Architecture` (1 ref)
- `20_VPS_Daily_Ops_Quickstart` (1 ref)
- `93_Prioritized_Cleanup_Plan` (1 ref)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>