### PR TITLE
docs: fix 3 P1 orphan issues — e2e test

### DIFF
--- a/docs/Documentation_Status.md
+++ b/docs/Documentation_Status.md
@@ -20,6 +20,10 @@ Written from source code review — these describe the system as it actually exi
 | 02 | Gateway, Sessions & Execution — session model, auth surfaces, execution engine, background services |
 | 03 | VP Workers & Delegation — mission lifecycle, cross-machine delegation, factory heartbeat |
 
+| 001 | Agent Architecture (agent_core.py vs main.py) — entry points, AgentSetup sync, URW session reuse |
+
+| Glossary | Project terminology and definitions |
+
 ## Canonical Source-of-Truth Documents (03_Operations/)
 
 These are the authoritative references for each subsystem. When any other document conflicts, **the canonical doc wins**.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@ The canonical deployment contract is maintained in `docs/deployment/`, not in ol
 ### 1. [Architecture](01_Architecture)
 
 > Architecture docs have been consolidated. See `docs/Documentation_Status.md` for current references.
+- **[Agent Architecture: agent_core.py vs main.py](001_AGENT_ARCHITECTURE.md)**: Entry point comparison, AgentSetup synchronization, URW session management.
+
 
 ### 2. [Subsystems](02_Subsystems)
 


### PR DESCRIPTION
Automated P1 doc maintenance.

- Add 001_AGENT_ARCHITECTURE.md to docs/README.md Architecture section
- Add 001_AGENT_ARCHITECTURE.md to docs/Documentation_Status.md Architecture table  
- Add Glossary entry to docs/Documentation_Status.md (was already in README.md)

Note: CSI_Architecture.md at root level does not exist; canonical CSI doc is in 03_Operations/ (item 92) and is already indexed.