### PR TITLE
docs: fix 59 P1 issues — nightly drift 2026-03-16

### DIFF
--- a/docs/Documentation_Status.md
+++ b/docs/Documentation_Status.md
@@ -1,6 +1,6 @@
 # Documentation Status
 
-**Last updated:** 2026-03-12
+**Last updated:** 2026-03-16
 
 ## ⚠️ MANDATORY: Documentation Rules
 
@@ -19,10 +19,15 @@ Written from source code review — these describe the system as it actually exi
 | 01 | System Architecture Overview — component map, services, data stores, deployment topology |
 | 02 | Gateway, Sessions & Execution — session model, auth surfaces, execution engine, background services |
 | 03 | VP Workers & Delegation — mission lifecycle, cross-machine delegation, factory heartbeat |
+| 04 | Dual Factory and Capability Expansion Brainstorm |
 
+## Root Architecture Docs
+
+| Doc | Subject |
+|-----|---------|
 | 001 | Agent Architecture (agent_core.py vs main.py) — entry points, AgentSetup sync, URW session reuse |
-
-| Glossary | Project terminology and definitions |
+| 002 | SDK Permissions, Hooks & Subagents — permission model, hooks architecture, subagent patterns |
+| 003 | Regression Control and Golden Runs — testing stability, golden run preservation |
 
 ## Canonical Source-of-Truth Documents (03_Operations/)
 
@@ -60,21 +65,85 @@ These are the authoritative references for each subsystem. When any other docume
 |---|---------|
 | 93 | Prioritized Cleanup Plan from Canonical Review |
 | 94 | Architectural Integration Review |
-| 95 | Integration Architectural Decisions (ADRs) |
+| 95 | Heartbeat Issue Mediation and Auto-Triage |
 
-## Deployment and Environment Continuity Docs
+## Deployment and Environment Continuity Docs (06_Deployment_And_Environments/)
 
 | Doc | Subject |
 |-----|---------|
-| 01 | Deployment architecture continuity pointer |
-| 02 | Stage-based Infisical environment and factory bootstrap continuity |
-| 03 | Branch-driven CI/CD continuity |
 | 04 | Branching and release workflow |
 | 05 | Local HQ dev vs desktop worker runtime modes |
 | 06 | Production deploy incident |
 | 07 | Stage-based Infisical and machine bootstrap migration plan |
 
-## Remaining Operational References
+## Run Reviews (03_Run_Reviews/)
+
+| # | Subject |
+|---|---------|
+| 01 | Russia Ukraine Report Session (2026-02-06) |
+| 02 | Cron Breakthrough Briefing (2026-02-08) |
+| 03 | Scheduling Runtime V2 Short Soak Readiness (2026-02-08) |
+| 04 | Scheduling Runtime V2 24h Soak In Progress (2026-02-08) |
+| 05 | Self-Improving Agent Notes (2026-02-13) |
+| 06 | Final Integration Sprint Review (2026-02-14) |
+| 07 | Happy Path Review and Markdown Remediation (2026-02-19) |
+
+## CSI Rebuild (csi-rebuild/)
+
+| Doc | Subject |
+|-----|---------|
+| 00_master_plan.md | CSI rebuild master plan |
+| 01_architecture_v2.md | Revised CSI architecture |
+| 02_interfaces_and_schemas.md | CSI interfaces and schemas |
+| 03_rollout_and_runbooks.md | Rollout plan and runbook index |
+| 04_validation_matrix.md | Validation test matrix |
+| 05_incident_log.md | Incident tracking log |
+| 06_packet_handoff.md | Packet handoff documentation |
+| 07_post_packet10_work_phases.md | Post-packet work phases |
+| 08_rc_soak_ga_gate.md | Release candidate soak gate |
+| status.md | CSI rebuild status tracker |
+| kevin_handoff_for CSI.md | Handoff documentation |
+
+## CSI Rebuild Runbooks (csi-rebuild/runbooks/)
+
+| Doc | Subject |
+|-----|---------|
+| 01_incident_triage.md | Incident triage runbook |
+| 02_remediation_escalation.md | Remediation escalation runbook |
+| 03_rollback.md | Rollback runbook |
+| 04_data_repair.md | Data repair runbook |
+| 05_quick_commands.md | Quick command reference |
+
+## SDK Phases and Integration Docs
+
+| Doc | Subject |
+|-----|---------|
+| 004 | Threads Infisical Sync Workflow |
+| 005 | CSI YouTube Proxy Usage Audit |
+| 006 | CSI Trend Analysis Functional Review and Plan |
+| 007 | CSI Persistence Briefing and Reminder Operations |
+| 008 | Threads Rollout Next Phases |
+| 009 | Threads Phase 2 Permission Readiness Runbook |
+| 010 | Threads Phase 2/3 Closeout Go/No-Go Report |
+| 011 | SDK Phase 5 Accelerated Canary Rollout |
+| 012 | NotebookLM Integration |
+
+## Reference Docs
+
+| Doc | Subject |
+|-----|---------|
+| ZAI_OPENAI_COMPATIBLE_SETUP.md | ZAI API setup guide |
+| durability_test_matrix.md | Durability testing matrix |
+| notebooklm_vps_infisical_runbook.md | NotebookLM VPS setup |
+| Glossary.md | Project terminology |
+
+## Reports (reports/)
+
+| Doc | Subject |
+|-----|---------|
+| todolist-task-pipeline-audit-2026-03-11.md | Todoist pipeline audit |
+
+## Remaining Operational References (03_Operations/)
 
 | Doc | Subject |
 |-----|---------|

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,9 +23,13 @@ The canonical deployment contract is maintained in `docs/deployment/`, not in ol
 
 ### 1. [Architecture](01_Architecture)
 
-> Architecture docs have been consolidated. See `docs/Documentation_Status.md` for current references.
+- **[System Architecture Overview](01_Architecture/01_System_Architecture_Overview.md)**: Component map, services, data stores, deployment topology.
+- **[Gateway, Sessions & Execution](01_Architecture/02_Gateway_Sessions_And_Execution.md)**: Session model, auth surfaces, execution engine, background services.
+- **[VP Workers & Delegation](01_Architecture/03_VP_Workers_And_Delegation.md)**: Mission lifecycle, cross-machine delegation, factory heartbeat.
+- **[Dual Factory and Capability Expansion Brainstorm](01_Architecture/04_Dual_Factory_And_Capability_Expansion_Brainstorm.md)**: Factory expansion concepts.
 - **[Agent Architecture: agent_core.py vs main.py](001_AGENT_ARCHITECTURE.md)**: Entry point comparison, AgentSetup synchronization, URW session management.
-
+- **[SDK Permissions, Hooks & Subagents](002_SDK_PERMISSIONS_HOOKS_SUBAGENTS.md)**: Permission model, hooks architecture, subagent patterns.
+- **[Regression Control and Golden Runs](003_REGRESSION_CONTROL_AND_GOLDEN_RUNS.md)**: Testing stability, golden run preservation.
 
 ### 2. [Subsystems](02_Subsystems)
 
@@ -87,6 +91,60 @@ The canonical deployment contract is maintained in `docs/deployment/`, not in ol
 
 - **[Decisions](05_Archive/Decisions)**: Critical architectural decision records (ADRs).
 - **[Glossary.md](Glossary.md)**: Project terminology.
+
+### 7. [Run Reviews](03_Run_Reviews)
+
+- **[Session: Russia Ukraine Report (2026-02-06)](03_Run_Reviews/01_Session_20260206_160425_Russia_Ukraine_Report.md)**: First major report session.
+- **[Session: Cron Breakthrough Briefing (2026-02-08)](03_Run_Reviews/02_Session_20260208_Cron_Breakthrough_Briefing.md)**: Cron scheduling breakthrough.
+- **[Scheduling Runtime V2 Short Soak Readiness (2026-02-08)](03_Run_Reviews/03_Scheduling_Runtime_V2_Short_Soak_Readiness_2026-02-08.md)**: Short soak prep.
+- **[Scheduling Runtime V2 24h Soak In Progress (2026-02-08)](03_Run_Reviews/04_Scheduling_Runtime_V2_24h_Soak_In_Progress_2026-02-08.md)**: 24h soak status.
+- **[Self-Improving Agent Notes (2026-02-13)](03_Run_Reviews/05_Self_Improving_Agent_Notes_2026-02-13.md)**: Agent self-improvement patterns.
+- **[Final Integration Sprint Review (2026-02-14)](03_Run_Reviews/06_Final_Integration_Sprint_Review_2026-02-14.md)**: Integration sprint close.
+- **[Happy Path Review and Markdown Remediation (2026-02-19)](03_Run_Reviews/07_Session_20260218_232750_Happy_Path_Review_and_Markdown_Remediation_2026-02-19.md)**: Happy path validation.
+
+### 8. [CSI Rebuild](csi-rebuild)
+
+- **[Master Plan](csi-rebuild/00_master_plan.md)**: CSI rebuild master plan.
+- **[Architecture v2](csi-rebuild/01_architecture_v2.md)**: Revised CSI architecture.
+- **[Interfaces and Schemas](csi-rebuild/02_interfaces_and_schemas.md)**: CSI interfaces and schemas.
+- **[Rollout and Runbooks](csi-rebuild/03_rollout_and_runbooks.md)**: Rollout plan and runbook index.
+- **[Validation Matrix](csi-rebuild/04_validation_matrix.md)**: Validation test matrix.
+- **[Incident Log](csi-rebuild/05_incident_log.md)**: Incident tracking log.
+- **[Packet Handoff](csi-rebuild/06_packet_handoff.md)**: Packet handoff documentation.
+- **[Post Packet 10 Work Phases](csi-rebuild/07_post_packet10_work_phases.md)**: Post-packet work phases.
+- **[RC Soak GA Gate](csi-rebuild/08_rc_soak_ga_gate.md)**: Release candidate soak gate.
+- **[Status](csi-rebuild/status.md)**: CSI rebuild status tracker.
+- **[Kevin Handoff for CSI](csi-rebuild/kevin_handoff_for CSI.md)**: Handoff documentation.
+
+#### CSI Rebuild Runbooks
+
+- **[Incident Triage](csi-rebuild/runbooks/01_incident_triage.md)**: Incident triage runbook.
+- **[Remediation Escalation](csi-rebuild/runbooks/02_remediation_escalation.md)**: Remediation escalation runbook.
+- **[Rollback](csi-rebuild/runbooks/03_rollback.md)**: Rollback runbook.
+- **[Data Repair](csi-rebuild/runbooks/04_data_repair.md)**: Data repair runbook.
+- **[Quick Commands](csi-rebuild/runbooks/05_quick_commands.md)**: Quick command reference.
+
+### 9. [SDK Phases and Integration Docs](.)
+
+- **[Threads Infisical Sync Workflow](004_THREADS_INFISICAL_SYNC_WORKFLOW.md)**: Infisical sync workflow.
+- **[CSI YouTube Proxy Usage Audit](005_CSI_YOUTUBE_PROXY_USAGE_AUDIT.md)**: Proxy usage audit.
+- **[CSI Trend Analysis Functional Review and Plan](006_CSI_TREND_ANALYSIS_FUNCTIONAL_REVIEW_AND_PLAN.md)**: Trend analysis review.
+- **[CSI Persistence Briefing and Reminder Operations](007_CSI_PERSISTENCE_BRIEFING_AND_REMINDER_OPERATIONS.md)**: Persistence operations.
+- **[Threads Rollout Next Phases](008_THREADS_ROLLOUT_NEXT_PHASES.md)**: Threads rollout phases.
+- **[Threads Phase 2 Permission Readiness Runbook](009_THREADS_PHASE2_PERMISSION_READINESS_RUNBOOK.md)**: Permission readiness.
+- **[Threads Phase 2/3 Closeout Go/No-Go Report](010_THREADS_PHASE2_3_CLOSEOUT_GO_NO_GO_REPORT.md)**: Phase closeout report.
+- **[SDK Phase 5 Accelerated Canary Rollout](011_SDK_PHASE5_ACCELERATED_CANARY_ROLLOUT.md)**: Canary rollout.
+- **[NotebookLM Integration](012_NOTEBOOKLM_INTEGRATION.md)**: NotebookLM integration notes.
+
+### 10. [Reference Docs](.)
+
+- **[ZAI OpenAI Compatible Setup](ZAI_OPENAI_COMPATIBLE_SETUP.md)**: ZAI API setup guide.
+- **[Durability Test Matrix](durability_test_matrix.md)**: Durability testing matrix.
+- **[NotebookLM VPS Infisical Runbook](notebooklm_vps_infisical_runbook.md)**: NotebookLM VPS setup.
+
+### 11. [Reports](reports)
+
+- **[Todoist Task Pipeline Audit (2026-03-11)](reports/todolist-task-pipeline-audit-2026-03-11.md)**: Todoist pipeline audit.
 
 ---
 


### PR DESCRIPTION
Automated P1 doc maintenance.

- Add missing csi-rebuild/* docs to both indexes
- Add missing runbooks/* to both indexes
- Add missing 03_Run_Reviews/* session docs
- Add missing root-level SDK/integration docs (001-012)
- Add missing reference docs (ZAI, durability, notebooklm runbook)
- Add reports/todolist-task-pipeline-audit to both indexes
- Remove broken links to non-existent files
- Consolidate Architecture section with actual existing files