### PR TITLE
cleanup: reduce brittle routing heuristics

### DIFF
--- a/src/universal_agent/services/todo_dispatch_service.py
+++ b/src/universal_agent/services/todo_dispatch_service.py
@@ -78,16 +78,28 @@ def _env_positive_int(name: str, default: int) -> int:
 
 
 def _vp_active_counts(active_assignments: list[dict[str, Any]] | None) -> tuple[int, int]:
+    """Count active VP coder and general assignments.
+
+    Uses the canonical ``agent_id`` field for classification.  Falls back
+    to substring matching *only* on ``agent_id`` (not on title or task_id)
+    to avoid false positives from words like "encoder" or "atlassian".
+
+    Known aliases:
+      - Coder:  "vp.coder.primary", "codie", "coder"
+      - General: "vp.general.primary", "atlas"
+    """
+    from universal_agent.services.agent_router import AGENT_CODER, AGENT_GENERAL
+
+    coder_patterns = {AGENT_CODER, "codie", "coder"}
+    general_patterns = {AGENT_GENERAL, "atlas"}
+
     coder = 0
     general = 0
     for assignment in active_assignments or []:
-        haystack = " ".join(
-            str(assignment.get(key) or "")
-            for key in ("agent_id", "provider_session_id", "title", "task_id")
-        ).lower()
-        if "vp.coder" in haystack or "codie" in haystack or "coder" in haystack:
+        agent_id = str(assignment.get("agent_id") or "").strip().lower()
+        if agent_id in coder_patterns or any(pat in agent_id for pat in coder_patterns):
             coder += 1
-        elif "vp.general" in haystack or "atlas" in haystack:
+        elif agent_id in general_patterns or any(pat in agent_id for pat in general_patterns):
             general += 1
     return coder, general
 

--- a/tests/unit/test_vp_active_counts.py
+++ b/tests/unit/test_vp_active_counts.py
@@ -1,0 +1,155 @@
+"""Tests for _vp_active_counts in todo_dispatch_service.
+
+Validates that agent classification uses the canonical agent_id field
+rather than brittle substring matching on title/task_id.
+"""
+
+from __future__ import annotations
+
+from universal_agent.services.todo_dispatch_service import _vp_active_counts
+
+
+# ---------------------------------------------------------------------------
+# Basic behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestVpActiveCountsEmpty:
+    def test_none_returns_zeros(self):
+        assert _vp_active_counts(None) == (0, 0)
+
+    def test_empty_list_returns_zeros(self):
+        assert _vp_active_counts([]) == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Exact canonical agent_id matching
+# ---------------------------------------------------------------------------
+
+
+class TestVpActiveCountsCanonical:
+    def test_coder_primary(self):
+        assignments = [{"agent_id": "vp.coder.primary"}]
+        assert _vp_active_counts(assignments) == (1, 0)
+
+    def test_general_primary(self):
+        assignments = [{"agent_id": "vp.general.primary"}]
+        assert _vp_active_counts(assignments) == (0, 1)
+
+    def test_simone_not_counted(self):
+        assignments = [{"agent_id": "simone"}]
+        assert _vp_active_counts(assignments) == (0, 0)
+
+    def test_multiple_same_type(self):
+        assignments = [
+            {"agent_id": "vp.coder.primary"},
+            {"agent_id": "vp.coder.primary"},
+        ]
+        assert _vp_active_counts(assignments) == (2, 0)
+
+
+# ---------------------------------------------------------------------------
+# Alias matching (substring of agent_id only)
+# ---------------------------------------------------------------------------
+
+
+class TestVpActiveCountsAliases:
+    def test_codie_alias(self):
+        assignments = [{"agent_id": "codie"}]
+        assert _vp_active_counts(assignments) == (1, 0)
+
+    def test_atlas_alias(self):
+        assignments = [{"agent_id": "atlas"}]
+        assert _vp_active_counts(assignments) == (0, 1)
+
+    def test_coder_substring_in_agent_id(self):
+        """agent_id containing 'coder' as a substring should match."""
+        assignments = [{"agent_id": "some-coder-session"}]
+        assert _vp_active_counts(assignments) == (1, 0)
+
+
+# ---------------------------------------------------------------------------
+# No false positives from title/task_id
+# ---------------------------------------------------------------------------
+
+
+class TestVpActiveCountsNoFalsePositives:
+    def test_coder_in_title_not_matched(self):
+        """The word 'coder' in a task title should NOT classify as coder."""
+        assignments = [
+            {
+                "agent_id": "simone",
+                "title": "Encoder Design Review",
+                "task_id": "encoder-review-001",
+            }
+        ]
+        assert _vp_active_counts(assignments) == (0, 0)
+
+    def test_atlas_in_title_not_matched(self):
+        """The word 'atlas' in a task title should NOT classify as general."""
+        assignments = [
+            {
+                "agent_id": "simone",
+                "title": "Atlassian Integration Setup",
+                "task_id": "atlassian-001",
+            }
+        ]
+        assert _vp_active_counts(assignments) == (0, 0)
+
+    def test_codie_in_task_id_not_matched(self):
+        """A task_id containing 'codie' should NOT classify as coder
+        when agent_id is simone."""
+        assignments = [
+            {
+                "agent_id": "simone",
+                "task_id": "codie-feedback-review",
+            }
+        ]
+        assert _vp_active_counts(assignments) == (0, 0)
+
+    def test_coder_in_provider_session_id_not_matched(self):
+        """provider_session_id is no longer part of the classification."""
+        assignments = [
+            {
+                "agent_id": "simone",
+                "provider_session_id": "coder-workspace-abc",
+            }
+        ]
+        assert _vp_active_counts(assignments) == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# Mixed assignments
+# ---------------------------------------------------------------------------
+
+
+class TestVpActiveCountsMixed:
+    def test_one_of_each(self):
+        assignments = [
+            {"agent_id": "vp.coder.primary"},
+            {"agent_id": "vp.general.primary"},
+        ]
+        assert _vp_active_counts(assignments) == (1, 1)
+
+    def test_all_three_agent_types(self):
+        assignments = [
+            {"agent_id": "simone"},
+            {"agent_id": "vp.coder.primary"},
+            {"agent_id": "vp.general.primary"},
+        ]
+        assert _vp_active_counts(assignments) == (1, 1)
+
+    def test_unknown_agent_id_ignored(self):
+        assignments = [
+            {"agent_id": "unknown-agent"},
+            {"agent_id": ""},
+        ]
+        assert _vp_active_counts(assignments) == (0, 0)
+
+    def test_missing_agent_id_key_ignored(self):
+        """Assignment dicts without agent_id should not crash."""
+        assignments = [
+            {"title": "Some task"},
+            {},
+        ]
+        assert _vp_active_counts(assignments) == (0, 0)


### PR DESCRIPTION
## Summary

Replaces the brittle `_vp_active_counts` agent classification heuristic in `todo_dispatch_service.py` with a structured, deterministic lookup.

### Rationale

The `_vp_active_counts` function classified active agent assignments by concatenating four dict fields (`agent_id`, `provider_session_id`, `title`, `task_id`) into a single string and performing substring checks like `"coder" in haystack`. This caused false positives:
- A task titled "Encoder Design Review" would be misclassified as a coder assignment
- A task with `task_id "atlassian-001"` would be misclassified as a general/atlas assignment
- A `provider_session_id "coder-workspace-abc"` would be misclassified when the agent was actually simone

### Change

- **Before**: Concatenated `agent_id + provider_session_id + title + task_id` into a single string, then did `in` substring checks
- **After**: Checks only the `agent_id` field, using exact set membership against canonical constants (`AGENT_CODER = "vp.coder.primary"`, `AGENT_GENERAL = "vp.general.primary"`) plus explicit aliases (`"codie"`, `"atlas"`, `"coder"`)

### Files changed

| File | Change |
|---|---|
| `src/universal_agent/services/todo_dispatch_service.py` | Rewrote `_vp_active_counts` -- 18 lines added, 6 removed |
| `tests/unit/test_vp_active_counts.py` | New test file -- 17 tests covering canonical matching, aliases, false-positive immunity, mixed assignments, and edge cases |

### Tests run and results

```
$ uv run python -m pytest tests/unit/test_vp_active_counts.py tests/unit/test_dispatch_service.py tests/test_dispatch_routing.py -v
============================= 40 passed in 3.45s ===============================
```

All 17 new tests pass. All 23 existing dispatch/routing tests pass. Zero regressions.

### Risk assessment

**Low risk.** This is a narrowing change -- the new logic is strictly more precise than the old logic. The only behavioral difference is the elimination of false positives:
- Tasks with "coder"/"codie"/"atlas" in their title, task_id, or provider_session_id (but NOT in agent_id) are no longer miscounted
- The set of correctly-identified agents (exact `agent_id` matches) is unchanged

### Rollback instructions

1. `git revert ea4b81bd` on `develop`
2. Or: `git checkout develop -- src/universal_agent/services/todo_dispatch_service.py` and remove the new test file