### PR TITLE
chore(codie): remove dead code and stale compatibility layers

### DIFF
--- a/src/universal_agent/delegation/bridge_main.py
+++ b/src/universal_agent/delegation/bridge_main.py
@@ -23,10 +23,7 @@ import logging
 import os
 import re
 import signal
-import sys
 import urllib.parse
-from pathlib import Path
-from typing import Optional
 
 from universal_agent.delegation.redis_bus import (
     MISSION_CONSUMER_GROUP,

--- a/src/universal_agent/delegation/heartbeat.py
+++ b/src/universal_agent/delegation/heartbeat.py
@@ -15,7 +15,7 @@ import platform
 import socket
 import time
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
 import httpx
 

--- a/src/universal_agent/delegation/redis_bus.py
+++ b/src/universal_agent/delegation/redis_bus.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from typing import Any, Optional, Protocol
+from typing import Any, Protocol
 
 from universal_agent.delegation.schema import MissionEnvelope, MissionResultEnvelope
 

--- a/src/universal_agent/delegation/redis_vp_bridge.py
+++ b/src/universal_agent/delegation/redis_vp_bridge.py
@@ -11,13 +11,12 @@ local VP SQLite for execution.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import re
 import sqlite3
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from universal_agent.delegation.redis_bus import (
     ConsumedMission,

--- a/src/universal_agent/execution_engine.py
+++ b/src/universal_agent/execution_engine.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
-from typing import Any, AsyncIterator, Callable, Optional
+from typing import Any, AsyncIterator, Optional
 
 from universal_agent.agent_core import AgentEvent, EventType
 from universal_agent.identity import resolve_user_id

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -67,7 +67,6 @@ from universal_agent.gateway import (
     InProcessGateway,
     GatewaySession,
     GatewayRequest,
-    GatewaySessionSummary,
 )
 from universal_agent.agent_core import AgentEvent, EventType
 from universal_agent.feature_flags import (
@@ -5163,7 +5162,6 @@ _CSI_RECOMMENDATION_TEXT_KEYS = (
 from universal_agent.services.routing_markers import (
     CSI_CODE_RE, CSI_RESEARCH_RE, CSI_WRITER_RE,
     CSI_AGENT_HINTS_RE, CSI_HUMAN_HINTS_RE,
-    CSI_AGENT_RECOMMENDATION_HINTS, CSI_HUMAN_RECOMMENDATION_HINTS,
 )
 
 
@@ -11059,7 +11057,7 @@ def _add_notification(
                 # Check age: only upsert within the upsert window
                 ex_created = str(existing.get("created_at") or "").strip()
                 try:
-                    from datetime import datetime as _dt, timezone as _tz
+                    from datetime import datetime as _dt
                     ex_ts = _dt.fromisoformat(ex_created.replace("Z", "+00:00")).timestamp()
                 except Exception:
                     ex_ts = 0.0

--- a/src/universal_agent/heartbeat_scope_filter.py
+++ b/src/universal_agent/heartbeat_scope_filter.py
@@ -11,7 +11,6 @@ Unmarked content (before the first marker, or between markers) defaults to "all"
 from __future__ import annotations
 
 import re
-from typing import Optional
 
 _SCOPE_MARKER_RE = re.compile(
     r"^\s*<!--\s*scope:(hq|local|all)\s*-->\s*$",

--- a/src/universal_agent/hooks.py
+++ b/src/universal_agent/hooks.py
@@ -1,15 +1,12 @@
-import asyncio
 import sys
 import os
 import uuid
 import json
 import logging
-import inspect
 import time
 import ast
 import re
 from typing import Any, Optional, Callable
-from dataclasses import dataclass
 import shlex
 from pathlib import Path
 from datetime import datetime

--- a/src/universal_agent/services/calendar_task_bridge.py
+++ b/src/universal_agent/services/calendar_task_bridge.py
@@ -28,7 +28,6 @@ Key behaviors:
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import os
 import re

--- a/src/universal_agent/services/capacity_governor.py
+++ b/src/universal_agent/services/capacity_governor.py
@@ -35,7 +35,7 @@ import os
 import random
 import time
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/universal_agent/services/claude_code_intel_cleanup.py
+++ b/src/universal_agent/services/claude_code_intel_cleanup.py
@@ -7,7 +7,6 @@ import shutil
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 
 _HEARTBEAT_ARTIFACT_REL_PATHS = (

--- a/src/universal_agent/services/email_task_bridge.py
+++ b/src/universal_agent/services/email_task_bridge.py
@@ -15,7 +15,6 @@ Key design decisions:
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import os
 import re

--- a/src/universal_agent/services/health_evaluator.py
+++ b/src/universal_agent/services/health_evaluator.py
@@ -8,7 +8,6 @@ it into actionable, noise-free directives for Simone using standard `litellm` ca
 
 import json
 import logging
-import os
 from pathlib import Path
 from typing import Any, Dict
 

--- a/src/universal_agent/services/intelligence_reporter.py
+++ b/src/universal_agent/services/intelligence_reporter.py
@@ -6,7 +6,7 @@ import html
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from universal_agent.services import proactive_artifacts
 from universal_agent.services.proactive_preferences import build_weekly_preference_report, score_artifact_for_review

--- a/src/universal_agent/services/proactive_advisor.py
+++ b/src/universal_agent/services/proactive_advisor.py
@@ -8,7 +8,6 @@ formatted report text as additional prompt context.
 
 from __future__ import annotations
 
-import json
 import logging
 import sqlite3
 from datetime import datetime, timezone

--- a/src/universal_agent/services/proactive_auto_investigator.py
+++ b/src/universal_agent/services/proactive_auto_investigator.py
@@ -11,11 +11,9 @@ memory.
 
 from __future__ import annotations
 
-import json
 import logging
 import sqlite3
 import uuid
-from datetime import datetime, timezone
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/universal_agent/services/proactive_budget.py
+++ b/src/universal_agent/services/proactive_budget.py
@@ -15,7 +15,6 @@ import logging
 import os
 import sqlite3
 from datetime import datetime, timezone
-from typing import Any
 
 from universal_agent import task_hub
 

--- a/src/universal_agent/services/proactive_convergence.py
+++ b/src/universal_agent/services/proactive_convergence.py
@@ -10,7 +10,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from universal_agent import task_hub
 from universal_agent.services.proactive_task_builder import queue_proactive_task
 from universal_agent.services.proactive_artifacts import ARTIFACT_STATUS_CANDIDATE, make_artifact_id, upsert_artifact
 

--- a/src/universal_agent/services/proactive_intelligence_report.py
+++ b/src/universal_agent/services/proactive_intelligence_report.py
@@ -23,7 +23,7 @@ import os
 import sqlite3
 import uuid
 from datetime import datetime, timezone, timedelta
-from typing import Any, Optional
+from typing import Any
 
 from universal_agent import task_hub
 from universal_agent import proactive_signals

--- a/src/universal_agent/services/proactive_tutorial_builds.py
+++ b/src/universal_agent/services/proactive_tutorial_builds.py
@@ -9,7 +9,6 @@ import sqlite3
 from pathlib import Path
 from typing import Any
 
-from universal_agent import task_hub
 from universal_agent.services.proactive_task_builder import queue_proactive_task
 from universal_agent.services.proactive_artifacts import ARTIFACT_STATUS_CANDIDATE, make_artifact_id, upsert_artifact
 

--- a/src/universal_agent/services/signal_curator.py
+++ b/src/universal_agent/services/signal_curator.py
@@ -24,7 +24,6 @@ from universal_agent import task_hub
 from universal_agent import proactive_signals
 from universal_agent.services.proactive_budget import (
     has_daily_budget,
-    get_budget_remaining,
     increment_daily_proactive_count,
 )
 

--- a/src/universal_agent/services/system_load_guard.py
+++ b/src/universal_agent/services/system_load_guard.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 logger = logging.getLogger(__name__)

--- a/src/universal_agent/services/youtube_playlist_watcher.py
+++ b/src/universal_agent/services/youtube_playlist_watcher.py
@@ -33,8 +33,6 @@ from xml.etree import ElementTree as ET
 import httpx
 from universal_agent.artifacts import resolve_artifacts_dir
 from universal_agent.youtube_mode_utils import (
-    MODE_EXPLAINER_ONLY,
-    MODE_EXPLAINER_PLUS_CODE,
     infer_youtube_mode,
 )
 

--- a/src/universal_agent/session_checkpoint.py
+++ b/src/universal_agent/session_checkpoint.py
@@ -17,7 +17,6 @@ Checkpoint captures:
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timezone
 from pathlib import Path

--- a/src/universal_agent/signals_ingest.py
+++ b/src/universal_agent/signals_ingest.py
@@ -12,8 +12,6 @@ from typing import Any
 from pydantic import BaseModel, Field, ValidationError
 
 from universal_agent.youtube_mode_utils import (
-    MODE_EXPLAINER_ONLY,
-    MODE_EXPLAINER_PLUS_CODE,
     infer_youtube_mode as _infer_youtube_learning_mode,
 )
 

--- a/src/universal_agent/trace_utils.py
+++ b/src/universal_agent/trace_utils.py
@@ -1,6 +1,5 @@
 import json
 import os
-from typing import Any
 
 
 def write_trace(trace: dict, workspace_dir: str) -> str:

--- a/src/universal_agent/transcript_builder.py
+++ b/src/universal_agent/transcript_builder.py
@@ -8,7 +8,7 @@ import json
 import ast
 import re
 from datetime import datetime
-from typing import Dict, Any, List
+from typing import Dict, Any
 
 def format_timestamp(iso_str: str) -> str:
     """Format ISO timestamp to readable time string (HH:MM:SS)."""


### PR DESCRIPTION
## Summary

Proactive cleanup pass removing unused imports verified via AST analysis across the src/universal_agent/ codebase. Each removal was confirmed by parsing the AST and checking that the imported name has zero references after the import statement.

## What was removed

### Unused YouTube mode constants
- MODE_EXPLAINER_ONLY and MODE_EXPLAINER_PLUS_CODE from signals_ingest.py and youtube_playlist_watcher.py -- imported but never referenced in any code path.

### Unused typing imports (15 files)
- Any removed from: claude_code_intel_cleanup.py, proactive_budget.py, redis_vp_bridge.py, trace_utils.py
- Optional removed from: bridge_main.py, heartbeat_scope_filter.py, intelligence_reporter.py, proactive_intelligence_report.py, redis_bus.py, redis_vp_bridge.py
- Callable removed from: execution_engine.py, delegation/heartbeat.py
- List removed from: transcript_builder.py

### Unused stdlib imports (10 files)
- import os removed from: session_checkpoint.py, services/health_evaluator.py
- import json removed from: delegation/redis_vp_bridge.py, services/proactive_advisor.py, services/email_task_bridge.py, services/calendar_task_bridge.py, services/proactive_auto_investigator.py
- import sys removed from: delegation/bridge_main.py
- from pathlib import Path removed from: delegation/bridge_main.py
- from datetime import datetime, timezone removed from: services/proactive_auto_investigator.py
- import asyncio, import inspect, from dataclasses import dataclass removed from: hooks.py

### Unused third-party/module imports
- field from dataclasses: services/system_load_guard.py, services/capacity_governor.py
- task_hub from universal_agent: services/proactive_tutorial_builds.py, services/proactive_convergence.py
- get_budget_remaining from proactive_budget: services/signal_curator.py
- GatewaySessionSummary from gateway: gateway_server.py
- CSI_AGENT_RECOMMENDATION_HINTS, CSI_HUMAN_RECOMMENDATION_HINTS from routing_markers: gateway_server.py
- timezone as _tz from local datetime import: gateway_server.py

## Changed files (27)
See the diff for the complete list.

## Tests run and results
- uv run pytest tests/unit/ -q: 1422 passed, 17 failed (all pre-existing on develop), 0 new failures introduced.

## Risk assessment
LOW. All changes are purely removal of unused imports. No behavioral changes, no logic modifications, no API changes.

## Rollback notes
Simple git revert of the single commit on this branch restores all removed imports.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kjdragan/universal_agent/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
