### PR TITLE
refactor: remove dead routing wrappers and backward-compat aliases

### DIFF
--- a/src/universal_agent/main.py
+++ b/src/universal_agent/main.py
@@ -913,10 +913,10 @@ from universal_agent.identity import (
 )
 from universal_agent.harness import ask_user_questions, present_plan_summary
 from universal_agent.routing import (
-    is_system_intent as _is_system_intent_new,
-    is_tool_required_intent as _is_tool_required_intent_new,
-    is_memory_intent as _is_memory_intent_new,
-    is_context_only_intent as _is_context_only_intent_new,
+    is_system_intent,
+    is_tool_required_intent,
+    is_memory_intent,
+    is_context_only_intent,
     ROUTE_SIMPLE,
     ROUTE_STANDARD,
     ROUTE_SYSTEM,
@@ -7707,27 +7707,11 @@ async def run_conversation(
 
 
 # Route constants now imported from universal_agent.routing
-
-
-def _is_system_intent(query: str) -> bool:
-    """Detect cron/heartbeat/system-utility queries — delegates to routing module."""
-    return _is_system_intent_new(query)
-
-
-def _is_memory_intent(query: str) -> bool:
-    """Detect memory-related queries — delegates to routing module."""
-    return _is_memory_intent_new(query)
-
-
-def _is_context_only_intent(query: str) -> bool:
-    """Detect context-only queries — delegates to routing module."""
-    return _is_context_only_intent_new(query)
-
-
-def _is_tool_required_intent(query: str) -> bool:
-    """Detect tool-required queries — delegates to routing module."""
-    return _is_tool_required_intent_new(query)
-
+# Direct aliases — routing functions imported above (removed redundant wrapper layer)
+_is_system_intent = is_system_intent
+_is_memory_intent = is_memory_intent
+_is_context_only_intent = is_context_only_intent
+_is_tool_required_intent = is_tool_required_intent
 
 async def classify_query(client: ClaudeSDKClient, query: str) -> str:
     """Classify a query into one of three routes: SIMPLE, STANDARD, or SYSTEM.

--- a/src/universal_agent/services/agent_router.py
+++ b/src/universal_agent/services/agent_router.py
@@ -17,10 +17,8 @@ Design principles:
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Agent identifiers (kept for downstream compatibility)
@@ -57,31 +55,3 @@ def route_all_to_simone(
         }
     return {AGENT_SIMONE: list(claimed_tasks)}
 
-
-# ---------------------------------------------------------------------------
-# Backward-compatible aliases
-# ---------------------------------------------------------------------------
-
-def route_claimed_tasks(
-    claimed_tasks: list[dict[str, Any]],
-    **_kwargs: Any,
-) -> dict[str, list[dict[str, Any]]]:
-    """Backward-compatible wrapper — delegates to ``route_all_to_simone``.
-
-    Accepts and ignores legacy kwargs (available_agents, etc.) for
-    call-site compatibility.
-    """
-    return route_all_to_simone(claimed_tasks)
-
-
-async def route_claimed_tasks_llm(
-    claimed_tasks: list[dict[str, Any]],
-    **_kwargs: Any,
-) -> dict[str, list[dict[str, Any]]]:
-    """Backward-compatible async wrapper — delegates to ``route_all_to_simone``.
-
-    The LLM-powered routing is no longer needed; Simone herself is the
-    intelligent router. This async shim remains so existing callers
-    don't break.
-    """
-    return route_all_to_simone(claimed_tasks)

--- a/src/universal_agent/services/dispatch_service.py
+++ b/src/universal_agent/services/dispatch_service.py
@@ -43,8 +43,8 @@ def _enrich_with_routing(claimed: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if not claimed:
         return claimed
     try:
-        from universal_agent.services.agent_router import route_claimed_tasks
-        route_claimed_tasks(claimed)
+        from universal_agent.services.agent_router import route_all_to_simone
+        route_all_to_simone(claimed)
     except Exception as exc:
         log.debug("Agent routing enrichment unavailable: %s", exc)
     return claimed

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -3,17 +3,12 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 
 from universal_agent.services.agent_router import (
     AGENT_SIMONE,
-    AGENT_CODER,
-    AGENT_GENERAL,
     route_all_to_simone,
-    route_claimed_tasks,
-    route_claimed_tasks_llm,
 )
 from universal_agent.vp.coder_runtime import CoderVPRuntime
 
@@ -45,29 +40,6 @@ def test_route_all_to_simone():
         assert task["_routing"]["agent_id"] == AGENT_SIMONE
         assert task["_routing"]["should_delegate"] is False
         assert task["_routing"]["confidence"] == "orchestrator"
-
-
-def test_route_claimed_tasks_alias():
-    """The legacy alias should behave identically to route_all_to_simone."""
-    tasks = [_task(title="Fix auth bug")]
-    buckets = route_claimed_tasks(tasks, available_agents={AGENT_CODER, AGENT_GENERAL})
-
-    assert AGENT_SIMONE in buckets
-    assert len(buckets) == 1
-    assert len(buckets[AGENT_SIMONE]) == 1
-    assert tasks[0]["_routing"]["agent_id"] == AGENT_SIMONE
-
-
-@pytest.mark.asyncio
-async def test_route_claimed_tasks_llm_alias():
-    """The legacy async LLM alias should also route everything to Simone."""
-    tasks = [_task(title="Deep research")]
-    buckets = await route_claimed_tasks_llm(tasks)
-
-    assert AGENT_SIMONE in buckets
-    assert len(buckets) == 1
-    assert len(buckets[AGENT_SIMONE]) == 1
-    assert tasks[0]["_routing"]["agent_id"] == AGENT_SIMONE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Proactive CODIE cleanup targeting dead code and stale compatibility layers in the routing/dispatch pipeline.

- **main.py**: Removed 4 redundant wrapper functions (`_is_system_intent`, `_is_memory_intent`, `_is_context_only_intent`, `_is_tool_required_intent`) that imported routing functions with `_new` suffix then wrapped them with the original names. Replaced with direct module-level aliases — same behavior, 16 fewer lines of indirection.
- **agent_router.py**: Removed backward-compat wrappers (`route_claimed_tasks`, `route_claimed_tasks_llm`) that simply delegated to `route_all_to_simone`. Updated the sole caller (`dispatch_service.py`) to use the canonical function directly. Also removed unused `logger` import.
- **dispatch_service.py**: Updated to call `route_all_to_simone` directly instead of the removed alias.
- **tests/test_agent_router.py** *(Devin Review fix)*: Removed imports and tests for the deleted `route_claimed_tasks` / `route_claimed_tasks_llm` aliases, plus unused `AGENT_CODER`, `AGENT_GENERAL`, and `Path` imports. Without this fix the entire test module would fail with `ImportError` at collection time.

**Net result**: -74 lines, zero behavior changes.

## Review & Testing Checklist for Human
- [ ] Run `pytest tests/test_agent_router.py -v` — all 16 tests should pass
- [ ] Verify no other files import `route_claimed_tasks` or `route_claimed_tasks_llm` (grep confirms none)

### Notes
- The Devin Review bug (comment #2 on this PR) correctly identified that the original commit deleted the backward-compat wrappers but forgot to update the test file that imported them. The fix commit removes the two orphaned test functions and their now-unused imports.


Link to Devin session: https://app.devin.ai/sessions/c6f09be324c04bf8b254b402842206aa
Requested by: @Kjdragan
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kjdragan/universal_agent/pull/129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
