### PR TITLE
refactor: dead code cleanup - deprecated wrappers and stale compat layers

### DIFF
--- a/src/universal_agent/heartbeat_service.py
+++ b/src/universal_agent/heartbeat_service.py
@@ -2110,10 +2110,12 @@ class HeartbeatService:
             _reflection_ctx_text = ""
             if _is_reflection_mode:
                 try:
+                    from universal_agent.services.proactive_budget import (
+                        has_daily_budget as has_nightly_budget,
+                        increment_daily_proactive_count as _increment_nightly_task_count,
+                    )
                     from universal_agent.services.reflection_engine import (
                         build_reflection_context,
-                        has_nightly_budget,
-                        _increment_nightly_task_count,
                     )
                     ref_conn = connect_runtime_db(get_activity_db_path())
                     ref_conn.row_factory = sqlite3.Row  # type: ignore[name-defined]

--- a/src/universal_agent/main.py
+++ b/src/universal_agent/main.py
@@ -913,10 +913,10 @@ from universal_agent.identity import (
 )
 from universal_agent.harness import ask_user_questions, present_plan_summary
 from universal_agent.routing import (
-    is_system_intent as _is_system_intent_new,
-    is_tool_required_intent as _is_tool_required_intent_new,
-    is_memory_intent as _is_memory_intent_new,
-    is_context_only_intent as _is_context_only_intent_new,
+    is_system_intent,
+    is_tool_required_intent,
+    is_memory_intent,
+    is_context_only_intent,
     ROUTE_SIMPLE,
     ROUTE_STANDARD,
     ROUTE_SYSTEM,
@@ -7707,27 +7707,11 @@ async def run_conversation(
 
 
 # Route constants now imported from universal_agent.routing
-
-
-def _is_system_intent(query: str) -> bool:
-    """Detect cron/heartbeat/system-utility queries — delegates to routing module."""
-    return _is_system_intent_new(query)
-
-
-def _is_memory_intent(query: str) -> bool:
-    """Detect memory-related queries — delegates to routing module."""
-    return _is_memory_intent_new(query)
-
-
-def _is_context_only_intent(query: str) -> bool:
-    """Detect context-only queries — delegates to routing module."""
-    return _is_context_only_intent_new(query)
-
-
-def _is_tool_required_intent(query: str) -> bool:
-    """Detect tool-required queries — delegates to routing module."""
-    return _is_tool_required_intent_new(query)
-
+# Direct aliases — routing functions imported above (removed redundant wrapper layer)
+_is_system_intent = is_system_intent
+_is_memory_intent = is_memory_intent
+_is_context_only_intent = is_context_only_intent
+_is_tool_required_intent = is_tool_required_intent
 
 async def classify_query(client: ClaudeSDKClient, query: str) -> str:
     """Classify a query into one of three routes: SIMPLE, STANDARD, or SYSTEM.

--- a/src/universal_agent/services/agent_router.py
+++ b/src/universal_agent/services/agent_router.py
@@ -17,10 +17,8 @@ Design principles:
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
-logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Agent identifiers (kept for downstream compatibility)
@@ -57,31 +55,3 @@ def route_all_to_simone(
         }
     return {AGENT_SIMONE: list(claimed_tasks)}
 
-
-# ---------------------------------------------------------------------------
-# Backward-compatible aliases
-# ---------------------------------------------------------------------------
-
-def route_claimed_tasks(
-    claimed_tasks: list[dict[str, Any]],
-    **_kwargs: Any,
-) -> dict[str, list[dict[str, Any]]]:
-    """Backward-compatible wrapper — delegates to ``route_all_to_simone``.
-
-    Accepts and ignores legacy kwargs (available_agents, etc.) for
-    call-site compatibility.
-    """
-    return route_all_to_simone(claimed_tasks)
-
-
-async def route_claimed_tasks_llm(
-    claimed_tasks: list[dict[str, Any]],
-    **_kwargs: Any,
-) -> dict[str, list[dict[str, Any]]]:
-    """Backward-compatible async wrapper — delegates to ``route_all_to_simone``.
-
-    The LLM-powered routing is no longer needed; Simone herself is the
-    intelligent router. This async shim remains so existing callers
-    don't break.
-    """
-    return route_all_to_simone(claimed_tasks)

--- a/src/universal_agent/services/dispatch_service.py
+++ b/src/universal_agent/services/dispatch_service.py
@@ -43,8 +43,8 @@ def _enrich_with_routing(claimed: list[dict[str, Any]]) -> list[dict[str, Any]]:
     if not claimed:
         return claimed
     try:
-        from universal_agent.services.agent_router import route_claimed_tasks
-        route_claimed_tasks(claimed)
+        from universal_agent.services.agent_router import route_all_to_simone
+        route_all_to_simone(claimed)
     except Exception as exc:
         log.debug("Agent routing enrichment unavailable: %s", exc)
     return claimed

--- a/src/universal_agent/services/reflection_engine.py
+++ b/src/universal_agent/services/reflection_engine.py
@@ -34,14 +34,6 @@ from universal_agent.services.proactive_budget import (
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Legacy aliases (kept for backward compat with old tests / heartbeat refs)
-# ---------------------------------------------------------------------------
-DEFAULT_REFLECTION_START_HOUR = 22
-DEFAULT_REFLECTION_END_HOUR = 7
-DEFAULT_MAX_NIGHTLY_TASKS = DEFAULT_DAILY_BUDGET
-
-
 def _parse_int_env(key: str, default: int) -> int:
     raw = (os.getenv(key) or "").strip()
     if not raw:
@@ -50,24 +42,6 @@ def _parse_int_env(key: str, default: int) -> int:
         return int(raw)
     except (ValueError, TypeError):
         return default
-
-
-# Re-export the shared budget key for backward-compat test access
-_NIGHTLY_TASK_COUNTER_KEY = "reflection_nightly_counter"  # legacy
-
-
-def is_reflection_hours(
-    *,
-    now: Optional[datetime] = None,
-    start_hour: Optional[int] = None,
-    end_hour: Optional[int] = None,
-) -> bool:
-    """DEPRECATED: Reflection now runs 24/7.  Always returns True.
-
-    Kept for backward compatibility with existing heartbeat code that
-    imports this function.  Will be removed in a future cleanup.
-    """
-    return True
 
 
 def is_reflection_enabled() -> bool:
@@ -81,21 +55,6 @@ def is_reflection_enabled() -> bool:
     # Fall through — follow UA_HEARTBEAT_AUTONOMOUS_ENABLED
     auto_raw = (os.getenv("UA_HEARTBEAT_AUTONOMOUS_ENABLED") or "").strip().lower()
     return auto_raw not in {"0", "false", "no", "off"}
-
-
-def _get_nightly_task_count(conn: sqlite3.Connection) -> int:
-    """DEPRECATED: Delegates to shared proactive_budget module."""
-    return get_daily_proactive_count(conn)
-
-
-def _increment_nightly_task_count(conn: sqlite3.Connection, increment: int = 1) -> int:
-    """DEPRECATED: Delegates to shared proactive_budget module."""
-    return increment_daily_proactive_count(conn, increment)
-
-
-def has_nightly_budget(conn: sqlite3.Connection) -> bool:
-    """DEPRECATED: Delegates to shared proactive_budget module."""
-    return has_daily_budget(conn)
 
 
 # ---------------------------------------------------------------------------

--- a/src/universal_agent/utils/composio_discovery.py
+++ b/src/universal_agent/utils/composio_discovery.py
@@ -194,29 +194,3 @@ def discover_connected_toolkits_with_meta(composio_client: Any, user_id: str) ->
         results.append(fetch_toolkit_meta(composio_client, slug))
         
     return results
-
-def discover_composio_apps(composio_client: Any) -> List[str]:
-    """
-    DEPRECATED: Use discover_connected_toolkits(session) instead.
-    Connect to Composio and discover all active toolkits (apps) via client.
-    """
-    if not composio_client:
-        return []
-        
-    discovered_apps = []
-    try:
-        connections_response = composio_client.connected_accounts.list()
-        
-        if hasattr(connections_response, 'items'):
-            for item in connections_response.items:
-                 if hasattr(item, 'toolkit') and item.toolkit and hasattr(item.toolkit, 'slug'):
-                     discovered_apps.append(item.toolkit.slug)
-        
-        discovered_apps = list(set(discovered_apps))
-        discovered_apps.sort()
-        
-    except Exception as e:
-        print(f"⚠️ [Discovery] Failed to fetch active Composio apps: {e}")
-        return []
-        
-    return discovered_apps

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -3,17 +3,12 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 
 from universal_agent.services.agent_router import (
     AGENT_SIMONE,
-    AGENT_CODER,
-    AGENT_GENERAL,
     route_all_to_simone,
-    route_claimed_tasks,
-    route_claimed_tasks_llm,
 )
 from universal_agent.vp.coder_runtime import CoderVPRuntime
 
@@ -45,29 +40,6 @@ def test_route_all_to_simone():
         assert task["_routing"]["agent_id"] == AGENT_SIMONE
         assert task["_routing"]["should_delegate"] is False
         assert task["_routing"]["confidence"] == "orchestrator"
-
-
-def test_route_claimed_tasks_alias():
-    """The legacy alias should behave identically to route_all_to_simone."""
-    tasks = [_task(title="Fix auth bug")]
-    buckets = route_claimed_tasks(tasks, available_agents={AGENT_CODER, AGENT_GENERAL})
-
-    assert AGENT_SIMONE in buckets
-    assert len(buckets) == 1
-    assert len(buckets[AGENT_SIMONE]) == 1
-    assert tasks[0]["_routing"]["agent_id"] == AGENT_SIMONE
-
-
-@pytest.mark.asyncio
-async def test_route_claimed_tasks_llm_alias():
-    """The legacy async LLM alias should also route everything to Simone."""
-    tasks = [_task(title="Deep research")]
-    buckets = await route_claimed_tasks_llm(tasks)
-
-    assert AGENT_SIMONE in buckets
-    assert len(buckets) == 1
-    assert len(buckets[AGENT_SIMONE]) == 1
-    assert tasks[0]["_routing"]["agent_id"] == AGENT_SIMONE
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reflection_engine.py
+++ b/tests/test_reflection_engine.py
@@ -2,9 +2,8 @@
 Test suite for the overnight reflection engine.
 
 Tests verify:
-1. Time-window logic (is_reflection_hours)
 2. Feature flag checks (is_reflection_enabled)
-3. Nightly budget tracking
+3. Daily budget tracking
 4. Context building (prompt generation)
 5. Integration with heartbeat guard policy
 """
@@ -19,19 +18,18 @@ from unittest import mock
 import pytest
 
 from universal_agent.services.reflection_engine import (
-    is_reflection_hours,
     is_reflection_enabled,
-    has_nightly_budget,
-    _increment_nightly_task_count,
-    _get_nightly_task_count,
     build_reflection_context,
     _get_recent_completions,
     _get_stalled_brainstorms,
     _get_open_task_count,
     _format_reflection_prompt,
-    DEFAULT_MAX_NIGHTLY_TASKS,
-    DEFAULT_REFLECTION_START_HOUR,
-    DEFAULT_REFLECTION_END_HOUR,
+)
+from universal_agent.services.proactive_budget import (
+    has_daily_budget,
+    increment_daily_proactive_count,
+    get_daily_proactive_count,
+    DEFAULT_DAILY_BUDGET,
 )
 from universal_agent import task_hub
 
@@ -82,55 +80,6 @@ def _insert_task(
 
 
 # ===========================================================================
-# is_reflection_hours
-# ===========================================================================
-
-class TestIsReflectionHours:
-
-    def test_late_night_default_window(self):
-        """11 PM should be within default 10PM-7AM window."""
-        now = datetime(2026, 3, 26, 23, 30)
-        assert is_reflection_hours(now=now) is True
-
-    def test_midnight_default_window(self):
-        """Midnight should be within default window."""
-        now = datetime(2026, 3, 27, 0, 0)
-        assert is_reflection_hours(now=now) is True
-
-    def test_early_morning_default_window(self):
-        """5 AM should be within default window."""
-        now = datetime(2026, 3, 27, 5, 0)
-        assert is_reflection_hours(now=now) is True
-
-    def test_daytime_outside_window(self):
-        """3 PM should be outside default window."""
-        now = datetime(2026, 3, 26, 15, 0)
-        assert is_reflection_hours(now=now) is False
-
-    def test_boundary_start_hour(self):
-        """Exactly 10 PM should be within window."""
-        now = datetime(2026, 3, 26, 22, 0)
-        assert is_reflection_hours(now=now) is True
-
-    def test_boundary_end_hour(self):
-        """Exactly 7 AM should be outside window (it's < 7)."""
-        now = datetime(2026, 3, 27, 7, 0)
-        assert is_reflection_hours(now=now) is False
-
-    def test_just_before_end(self):
-        """6:59 AM should be within window."""
-        now = datetime(2026, 3, 27, 6, 59)
-        assert is_reflection_hours(now=now) is True
-
-    def test_custom_window(self):
-        """Custom window 14-18 should work (no midnight crossing)."""
-        now = datetime(2026, 3, 26, 15, 0)
-        assert is_reflection_hours(now=now, start_hour=14, end_hour=18) is True
-        now = datetime(2026, 3, 26, 19, 0)
-        assert is_reflection_hours(now=now, start_hour=14, end_hour=18) is False
-
-
-# ===========================================================================
 # is_reflection_enabled
 # ===========================================================================
 
@@ -168,40 +117,40 @@ class TestIsReflectionEnabled:
 # Nightly Budget
 # ===========================================================================
 
-class TestNightlyBudget:
+class TestDailyBudget:
 
     def test_initial_budget_available(self, db_conn):
         """Fresh DB should have full budget."""
-        assert has_nightly_budget(db_conn) is True
+        assert has_daily_budget(db_conn) is True
 
     def test_budget_increments(self, db_conn):
         """Incrementing should reduce remaining budget."""
-        count = _increment_nightly_task_count(db_conn, increment=1)
+        count = increment_daily_proactive_count(db_conn, increment=1)
         assert count == 1
-        assert _get_nightly_task_count(db_conn) == 1
+        assert get_daily_proactive_count(db_conn) == 1
 
     def test_budget_exhaustion(self, db_conn):
         """After max increments, budget should be exhausted."""
-        for _ in range(DEFAULT_MAX_NIGHTLY_TASKS):
-            _increment_nightly_task_count(db_conn, increment=1)
-        assert has_nightly_budget(db_conn) is False
+        for _ in range(DEFAULT_DAILY_BUDGET):
+            increment_daily_proactive_count(db_conn, increment=1)
+        assert has_daily_budget(db_conn) is False
 
-    @mock.patch.dict(os.environ, {"UA_REFLECTION_MAX_NIGHTLY_TASKS": "3"}, clear=False)
+    @mock.patch.dict(os.environ, {"UA_PROACTIVE_DAILY_BUDGET": "3"}, clear=False)
     def test_custom_max_tasks(self, db_conn):
         """Custom max should be respected."""
         for _ in range(3):
-            _increment_nightly_task_count(db_conn, increment=1)
-        assert has_nightly_budget(db_conn) is False
+            increment_daily_proactive_count(db_conn, increment=1)
+        assert has_daily_budget(db_conn) is False
 
     def test_budget_resets_on_new_day(self, db_conn):
         """Budget should reset when the date changes."""
-        task_hub._set_setting(db_conn, "reflection_nightly_counter", {
+        task_hub._set_setting(db_conn, "proactive_daily_budget_counter", {
             "date": "2020-01-01",  # Old date
             "count": 999,
         })
         # Should return 0 because date doesn't match today
-        assert _get_nightly_task_count(db_conn) == 0
-        assert has_nightly_budget(db_conn) is True
+        assert get_daily_proactive_count(db_conn) == 0
+        assert has_daily_budget(db_conn) is True
 
 
 # ===========================================================================
@@ -270,7 +219,7 @@ class TestReflectionPrompt:
             memory_context=[],
             budget_remaining=10,
         )
-        assert "Overnight Reflection Mode" in text
+        assert "Autonomous Ideation Mode" in text
         assert "10" in text  # budget
 
     def test_stalled_brainstorms_section(self):
@@ -312,7 +261,7 @@ class TestBuildReflectionContext:
         assert "stalled_brainstorms" in ctx
         assert "reflection_prompt_text" in ctx
         assert len(ctx["recent_completions"]) == 1
-        assert "Overnight Reflection Mode" in ctx["reflection_prompt_text"]
+        assert "Autonomous Ideation Mode" in ctx["reflection_prompt_text"]
 
 
 # ===========================================================================
@@ -325,47 +274,40 @@ class TestGuardPolicyReflection:
         "UA_HEARTBEAT_AUTONOMOUS_ENABLED": "1",
         "UA_REFLECTION_ENABLED": "1",
     }, clear=False)
-    def test_reflection_mode_activates_during_night(self):
-        """Guard policy should enable reflection_mode when queue is empty at night."""
+    def test_reflection_mode_activates_when_enabled(self):
+        """Guard policy should enable reflection_mode when queue is empty and reflection is enabled (24/7)."""
         from universal_agent.heartbeat_service import _heartbeat_guard_policy
 
-        with mock.patch(
-            "universal_agent.services.reflection_engine.is_reflection_hours",
-            return_value=True,
-        ):
-            policy = _heartbeat_guard_policy(
-                actionable_count=0,
-                brainstorm_candidate_count=0,
-                system_event_count=0,
-                has_exec_completion=False,
-                has_heartbeat_content=False,
-                pending_question_count=0,
-            )
-            assert policy["reflection_mode"] is True
-            assert policy["skip_reason"] is None  # Should NOT skip
+        policy = _heartbeat_guard_policy(
+            actionable_count=0,
+            brainstorm_candidate_count=0,
+            system_event_count=0,
+            has_exec_completion=False,
+            has_heartbeat_content=False,
+            pending_question_count=0,
+        )
+        assert policy["reflection_mode"] is True
+        assert policy["skip_reason"] is None  # Should NOT skip
 
     @mock.patch.dict(os.environ, {
         "UA_HEARTBEAT_AUTONOMOUS_ENABLED": "1",
         "UA_REFLECTION_ENABLED": "1",
     }, clear=False)
-    def test_reflection_mode_off_during_day(self):
-        """Guard policy should skip when queue empty during daytime."""
+    def test_reflection_mode_24x7_always_active_when_enabled(self):
+        """Reflection is 24/7 — when enabled, activates regardless of time of day."""
         from universal_agent.heartbeat_service import _heartbeat_guard_policy
 
-        with mock.patch(
-            "universal_agent.services.reflection_engine.is_reflection_hours",
-            return_value=False,
-        ):
-            policy = _heartbeat_guard_policy(
-                actionable_count=0,
-                brainstorm_candidate_count=0,
-                system_event_count=0,
-                has_exec_completion=False,
-                has_heartbeat_content=False,
-                pending_question_count=0,
-            )
-            assert policy["reflection_mode"] is False
-            assert policy["skip_reason"] == "no_actionable_work"
+        policy = _heartbeat_guard_policy(
+            actionable_count=0,
+            brainstorm_candidate_count=0,
+            system_event_count=0,
+            has_exec_completion=False,
+            has_heartbeat_content=False,
+            pending_question_count=0,
+        )
+        # Reflection is 24/7, so with UA_REFLECTION_ENABLED=1 it should activate
+        assert policy["reflection_mode"] is True
+        assert policy["skip_reason"] is None
 
     @mock.patch.dict(os.environ, {
         "UA_HEARTBEAT_AUTONOMOUS_ENABLED": "1",

--- a/tests/unit/test_proactive_pipeline_phase1.py
+++ b/tests/unit/test_proactive_pipeline_phase1.py
@@ -420,7 +420,7 @@ class TestReflectionBudgetRename:
     """Tests for the nightly→daily budget rename in reflection_engine."""
 
     def test_daily_budget_key_exists(self):
-        """Module should expose _DAILY_BUDGET_KEY, not _NIGHTLY_TASK_COUNTER_KEY."""
+        """Module should expose _DAILY_BUDGET_KEY."""
         from universal_agent.services import proactive_budget
         assert hasattr(proactive_budget, "_DAILY_BUDGET_KEY")
 


### PR DESCRIPTION
## Summary
CODIE proactive cleanup pipeline identified and removed dead code and stale compatibility layers across the codebase.

**3 commits, net -199 lines:**

### Commit 1: Remove dead routing wrappers and backward-compat aliases
- main.py: eliminated 4 wrapper functions that imported routing functions with _new suffix then wrapped them with original names. Replaced with direct module-level aliases.
- agent_router.py: removed backward-compat wrappers (route_claimed_tasks, route_claimed_tasks_llm) that just delegated to route_all_to_simone.

### Commit 2: Fix broken test imports from prior cleanup
- test_agent_router.py: removed dead imports and tests for deleted route_claimed_tasks wrappers.

### Commit 3: Remove deprecated wrappers, legacy constants, and stale tests
- composio_discovery.py: removed deprecated discover_composio_apps() (zero callers)
- reflection_engine.py: removed deprecated budget wrappers, is_reflection_hours (always returned True), and stale constants
- heartbeat_service.py: migrated to import canonical proactive_budget functions directly
- Tests updated to use canonical imports throughout

## Changed files
- src/universal_agent/main.py
- src/universal_agent/services/agent_router.py
- src/universal_agent/services/dispatch_service.py
- src/universal_agent/services/reflection_engine.py
- src/universal_agent/heartbeat_service.py
- src/universal_agent/utils/composio_discovery.py
- tests/test_agent_router.py
- tests/test_reflection_engine.py
- tests/unit/test_proactive_pipeline_phase1.py

## Tests run
89 tests pass across all affected modules.

## Risks
Low. Pure removals of deprecated/dead code with callers migrated to canonical functions. No behavior changes.

## Rollback
Revert the PR. No data migration or config changes involved.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kjdragan/universal_agent/pull/130" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
