### PR TITLE
fix(types): add type hints to untyped public function signatures

### DIFF
--- a/src/universal_agent/services/capacity_governor.py
+++ b/src/universal_agent/services/capacity_governor.py
@@ -186,7 +186,7 @@ class CapacityGovernor:
     # ------------------------------------------------------------------
 
     @asynccontextmanager
-    async def acquire_slot(self, context: str = ""):
+    async def acquire_slot(self, context: str = "") -> None:
         """Acquire a capacity slot for an agent execution.
 
         Usage:

--- a/src/universal_agent/services/claude_code_intel.py
+++ b/src/universal_agent/services/claude_code_intel.py
@@ -276,7 +276,7 @@ def run_sync(
                     from universal_agent.services.csi_url_judge import enrich_urls, build_linked_context
                     enrich_dir = packet_dir / "url_enrichment"
                     
-                    def enrich_post(post):
+                    def enrich_post(post: dict[str, Any]) -> tuple[str, str | None]:
                         post_id = str(post.get("id") or "").strip()
                         post_links = extract_links(post)
                         if not post_links:
@@ -306,7 +306,7 @@ def run_sync(
                     logger.warning("csi_url_judge module not available; skipping URL enrichment")
 
             # --- 2. Concurrent Post Classification ---
-            def classify_worker(post):
+            def classify_worker(post: dict[str, Any]) -> dict[str, Any]:
                 return classify_post(
                     post,
                     handle=cfg.handle,

--- a/src/universal_agent/services/dag_governor.py
+++ b/src/universal_agent/services/dag_governor.py
@@ -34,7 +34,7 @@ class DagConcurrencyGovernor:
         cls._instance = None
         
     @asynccontextmanager
-    async def acquire_slot(self):
+    async def acquire_slot(self) -> None:
         """Acquire a concurrency slot for DAG execution."""
         await self._semaphore.acquire()
         try:

--- a/src/universal_agent/services/proactive_task_builder.py
+++ b/src/universal_agent/services/proactive_task_builder.py
@@ -7,12 +7,13 @@ proactive_codie, proactive_tutorial_builds, and proactive_convergence.
 from __future__ import annotations
 
 from typing import Any
+import sqlite3
 
 from universal_agent import task_hub
 
 
 def queue_proactive_task(
-    conn,
+    conn: sqlite3.Connection,
     *,
     task_id: str,
     source_kind: str,

--- a/src/universal_agent/services/todo_dispatch_service.py
+++ b/src/universal_agent/services/todo_dispatch_service.py
@@ -459,14 +459,14 @@ class ToDoDispatchService:
         self.execution_callback = execution_callback
         self.event_callback = event_callback
 
-    async def start(self):
+    async def start(self) -> None:
         if self.running:
             return
         self.running = True
         self.task = asyncio.create_task(self._scheduler_loop())
         logger.info("📋 ToDo Dispatch Service started")
 
-    async def stop(self):
+    async def stop(self) -> None:
         if not self.running:
             return
         self.running = False
@@ -478,7 +478,7 @@ class ToDoDispatchService:
                 pass
         logger.info("📋 ToDo Dispatch Service stopped")
         
-    def register_session(self, session: GatewaySession):
+    def register_session(self, session: GatewaySession) -> None:
         metadata = session.metadata if isinstance(session.metadata, dict) else {}
         session_role = str(metadata.get("session_role") or "").strip().lower()
         if session_role not in {"todo_execution", "todo"}:
@@ -494,7 +494,7 @@ class ToDoDispatchService:
                 "wake_pending": session.session_id in self.wake_sessions,
             })
 
-    def unregister_session(self, session_id: str):
+    def unregister_session(self, session_id: str) -> None:
         if session_id in self.active_sessions:
             del self.active_sessions[session_id]
         if self.event_callback:


### PR DESCRIPTION
## Summary
- Adds missing type annotations to public function signatures across 5 service modules
- Today's CODIE proactive cleanup theme: **add type hints to untyped public function signatures**

## Changed Files
| File | Changes |
|---|---|
| `proactive_task_builder.py` | Typed `conn` parameter as `sqlite3.Connection` |
| `claude_code_intel.py` | Typed `enrich_post` and `classify_worker` inner function params + returns |
| `todo_dispatch_service.py` | Added `-> None` return to `start`, `stop`, `register_session`, `unregister_session` |
| `capacity_governor.py` | Added `-> None` return to `acquire_slot` |
| `dag_governor.py` | Added `-> None` return to `acquire_slot` |

## Tests Run
- `tests/unit/test_proactive_codie.py`: 3/3 passed

## Risks
- Very low. Type annotations are purely additive and do not change runtime behavior.
- `from __future__ import annotations` is already present in all files, so no forward-reference issues.

## Rollback
- Revert this PR. No schema or config changes.

Generated by CODIE proactive code quality pipeline (theme: type hints, 2026-04-29)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kjdragan/universal_agent/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
