### PR TITLE
refactor(dag): extract magic status strings into named constants

### DIFF
--- a/src/universal_agent/services/dag_handlers.py
+++ b/src/universal_agent/services/dag_handlers.py
@@ -15,7 +15,7 @@ import logging
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict
 
-from universal_agent.services.dag_runner import DagState
+from universal_agent.services.dag_runner import DagState, STATUS_FAILED, STATUS_SUCCESS
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ def make_subprocess_handler(
         command = str(node.get("command") or "").strip()
         if not command:
             return {
-                "status": "failed",
+                "status": STATUS_FAILED,
                 "error": f"Node '{node['id']}' has no 'command' field.",
             }
 
@@ -68,12 +68,12 @@ def make_subprocess_handler(
         }
 
         if exit_code != 0:
-            result["status"] = "failed"
+            result["status"] = STATUS_FAILED
             result["error"] = (
                 f"Command exited with code {exit_code}: {stderr[:500]}"
             )
         else:
-            result["status"] = "success"
+            result["status"] = STATUS_SUCCESS
 
         return result
 
@@ -103,7 +103,7 @@ def make_llm_binary_classifier_handler(
         prompt = str(node.get("prompt") or "").strip()
         if not prompt:
             return {
-                "status": "failed",
+                "status": STATUS_FAILED,
                 "error": f"Node '{node['id']}' has no 'prompt' field.",
             }
 
@@ -126,7 +126,7 @@ def make_llm_binary_classifier_handler(
         except Exception as exc:
             logger.error("LLM call failed for node '%s': %s", node["id"], exc)
             return {
-                "status": "failed",
+                "status": STATUS_FAILED,
                 "error": f"LLM call failed: {exc}",
             }
 
@@ -154,7 +154,7 @@ def make_llm_binary_classifier_handler(
         )
 
         return {
-            "status": "success",
+            "status": STATUS_SUCCESS,
             "result": binary_result,
             "context_update": {
                 "classifier_raw": cleaned,

--- a/src/universal_agent/services/dag_runner.py
+++ b/src/universal_agent/services/dag_runner.py
@@ -9,11 +9,20 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_MAX_ITERATIONS = int(os.getenv("UA_DAG_MAX_ITERATIONS", "50") or 50)
 
+# Named status constants -- single source of truth for DAG lifecycle states.
+STATUS_PENDING = "pending"
+STATUS_RUNNING = "running"
+STATUS_COMPLETED = "completed"
+STATUS_FAILED = "failed"
+STATUS_WAITING_ON_HUMAN = "waiting_on_human"
+STATUS_SUCCESS = "success"
+STATUS_ERROR = "error"
+
 
 @dataclass
 class DagState:
     """State of a DAG execution."""
-    status: str = "pending"  # pending, running, completed, waiting_on_human, failed
+    status: str = STATUS_PENDING  # pending, running, completed, waiting_on_human, failed
     current_node: Optional[str] = None
     context: Dict[str, Any] = field(default_factory=dict)
     history: List[Dict[str, Any]] = field(default_factory=list)
@@ -80,20 +89,20 @@ class DagRunner:
     async def run(self, initial_state: Optional[DagState] = None) -> DagState:
         """Run the DAG state machine until completion, failure, or human gate."""
         state = initial_state or DagState(
-            status="running",
+            status=STATUS_RUNNING,
             current_node=self.workflow_def.get("start"),
         )
 
-        if state.status == "pending":
-            state.status = "running"
+        if state.status == STATUS_PENDING:
+            state.status = STATUS_RUNNING
 
         iteration = 0
 
-        while state.status == "running" and state.current_node:
+        while state.status == STATUS_RUNNING and state.current_node:
             # ── Safety valve: prevent infinite loops ──
             iteration += 1
             if iteration > self.max_iterations:
-                state.status = "failed"
+                state.status = STATUS_FAILED
                 state.context["error"] = (
                     f"DAG execution exceeded max iterations ({self.max_iterations}). "
                     "Possible infinite loop detected."
@@ -107,7 +116,7 @@ class DagRunner:
 
             node = self.nodes.get(state.current_node)
             if not node:
-                state.status = "failed"
+                state.status = STATUS_FAILED
                 state.context["error"] = (
                     f"Node '{state.current_node}' not found in workflow."
                 )
@@ -117,15 +126,15 @@ class DagRunner:
             logger.info("DAG node executing: id=%s type=%s", node["id"], node_type)
 
             if node_type == "human_gate":
-                state.status = "waiting_on_human"
+                state.status = STATUS_WAITING_ON_HUMAN
                 state.history.append(
-                    {"node_id": node["id"], "status": "waiting_on_human"}
+                    {"node_id": node["id"], "status": STATUS_WAITING_ON_HUMAN}
                 )
                 break
 
             handler = self.handlers.get(node_type)
             if not handler:
-                state.status = "failed"
+                state.status = STATUS_FAILED
                 state.context["error"] = (
                     f"No handler registered for node type '{node_type}'."
                 )
@@ -138,15 +147,15 @@ class DagRunner:
                 if "context_update" in result:
                     state.context.update(result["context_update"])
 
-                if result.get("status") == "failed":
-                    state.status = "failed"
+                if result.get("status") == STATUS_FAILED:
+                    state.status = STATUS_FAILED
                     state.context["error"] = result.get(
                         "error", "Node execution failed."
                     )
-                    state.history.append({"node_id": node["id"], "status": "failed"})
+                    state.history.append({"node_id": node["id"], "status": STATUS_FAILED})
                     break
 
-                state.history.append({"node_id": node["id"], "status": "success"})
+                state.history.append({"node_id": node["id"], "status": STATUS_SUCCESS})
 
                 # Advance to next node
                 next_node = self._get_next_node(state.current_node, result)
@@ -154,19 +163,19 @@ class DagRunner:
                     state.current_node = next_node
                 else:
                     state.current_node = None
-                    state.status = "completed"
+                    state.status = STATUS_COMPLETED
 
             except Exception as e:
-                state.status = "failed"
+                state.status = STATUS_FAILED
                 state.context["error"] = str(e)
-                state.history.append({"node_id": node["id"], "status": "error"})
+                state.history.append({"node_id": node["id"], "status": STATUS_ERROR})
                 logger.exception(
                     "DAG node '%s' raised an exception", node["id"]
                 )
                 break
 
-        if state.status == "running" and not state.current_node:
-            state.status = "completed"
+        if state.status == STATUS_RUNNING and not state.current_node:
+            state.status = STATUS_COMPLETED
 
         logger.info(
             "DAG execution finished: status=%s nodes_visited=%d",


### PR DESCRIPTION
## Summary

Extract hardcoded status strings into module-level named constants in the DAG execution subsystem.

## What Changed

**`dag_runner.py`** — Added 7 named constants and replaced all 19 bare status string literals:
- `STATUS_PENDING`, `STATUS_RUNNING`, `STATUS_COMPLETED`, `STATUS_FAILED`
- `STATUS_WAITING_ON_HUMAN`, `STATUS_SUCCESS`, `STATUS_ERROR`

**`dag_handlers.py`** — Imported `STATUS_FAILED` and `STATUS_SUCCESS` from `dag_runner`, replaced 5 bare string literals.

## Changed Files
- `src/universal_agent/services/dag_runner.py` (+15/-10)
- `src/universal_agent/services/dag_handlers.py` (+7/-5)

## Test Results
```
10 passed in 0.20s
```
All existing unit tests pass with no modifications.

## Notes
- Purely mechanical refactoring — no behavior change
- String values remain identical (backward compatible)
- Constants are importable from `dag_runner` for any future consumers
- No new files created; no test files modified