### PR TITLE
feat(devx): add SessionStart hook so Claude Code web can run tests

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Universal Agent — SessionStart hook for Claude Code on the web.
+#
+# Why this exists:
+#   When a Claude Code web session boots, the harness gets a fresh
+#   ephemeral container with the repo cloned but NO virtual environment.
+#   Without one, the agent cannot run `uv run pytest`, `uv run ruff`, or
+#   `uv run python -c "compile(...)"` — meaning the safety net the rest
+#   of the team relies on (tests + lint before commit) silently doesn't
+#   exist for the web sandbox. This hook closes the gap by populating
+#   `.venv/` from `uv.lock` exactly once when the session starts.
+#
+# Scope:
+#   Only fires inside Claude Code on the web (gated by $CLAUDE_CODE_REMOTE).
+#   Local dev sessions (Antigravity, plain `claude`) keep their existing
+#   workflow — they own their own env management.
+#
+# Idempotency:
+#   `uv sync --frozen` is a no-op when the venv is already current.
+#   We additionally skip even calling it when pytest + ruff are already
+#   present, so warm container caches add ~50ms on session start.
+#
+# Failure mode:
+#   Soft. We never `exit 1` — a sync failure prints a clear warning and
+#   the session continues. Better to start with a degraded env than to
+#   block the session entirely.
+
+set -uo pipefail
+
+# Web-only. Local dev manages its own env.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}" || exit 0
+
+# Sanity: only run when we're actually inside this repo.
+if [ ! -f pyproject.toml ]; then
+    echo "[session-start] no pyproject.toml in $(pwd); skipping uv sync."
+    exit 0
+fi
+
+# Warm-start fast path.
+if [ -x .venv/bin/pytest ] && [ -x .venv/bin/ruff ] && [ -x .venv/bin/python ]; then
+    echo "[session-start] .venv warm (pytest + ruff present); skipping uv sync."
+    exit 0
+fi
+
+# Cold start. Make sure uv is on PATH.
+if ! command -v uv >/dev/null 2>&1; then
+    echo "[session-start] WARNING: uv not on PATH. Install with 'pip install uv'."
+    echo "[session-start] Continuing without sync; agent can read/edit but cannot run tests."
+    exit 0
+fi
+
+echo "[session-start] cold start — running 'uv sync --frozen' (timeout 5 minutes)..."
+sync_start=$(date +%s)
+
+# Capture exit code separately from the pipe so a failure isn't masked
+# by tail's exit code (the same pipe-to-tail bug that masked 12 broken
+# tests in pr-validate.yml until 2026-05-07).
+sync_output=$(timeout 300 uv sync --frozen --no-progress 2>&1)
+sync_exit=$?
+echo "$sync_output" | tail -10
+
+sync_elapsed=$(( $(date +%s) - sync_start ))
+if [ "$sync_exit" -eq 0 ]; then
+    echo "[session-start] uv sync OK (${sync_elapsed}s)"
+else
+    echo "[session-start] WARNING: uv sync exited ${sync_exit} after ${sync_elapsed}s"
+    echo "[session-start] Continuing — agent can still read/edit; tests + lint will fail until sync succeeds."
+fi
+
+# Spot-check that the tools we care about resolve. This catches a venv
+# that uv populated but in some pathological state where pytest/ruff
+# are missing (e.g. partial install).
+for tool in pytest ruff python; do
+    if [ ! -x ".venv/bin/${tool}" ]; then
+        echo "[session-start] WARNING: .venv/bin/${tool} missing after sync."
+    fi
+done
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,17 @@
     "code-review@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
     "playground@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -9,14 +9,14 @@ Persistent context for the agent.
 ## [RECENT_CONTEXT]
 Recent context snapshots (most recent first):
 
+- 2026-05-07T16:17:19.357999+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713839s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
+- 2026-05-07T16:17:10.440383+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699430s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
+- 2026-05-07T16:14:34.446656+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713674s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
+- 2026-05-07T16:14:24.674624+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699265s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-03T17:44:15.876125+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 373456s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-03T17:44:10.463015+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 359050s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-03T17:43:45.250582+00:00: Proactive task completed successfully: Send report Source: claude_code_demo_task | Duration: 0s This type of proactive work was productive. (tags: proactive_outcome, success, source:claude_code_demo_task)
 - 2026-04-30T13:50:54.459492+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 100253s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-04-30T13:49:53.990914+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 85793s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-04-30T13:47:59.443133+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 100077s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-04-30T13:37:51.314991+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 99470s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-04-30T13:08:37.177578+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 97716s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-04-30T13:07:38.515869+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 83258s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-04-30T04:31:25.520570+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 66685s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 

--- a/memory/2026-05-07.md
+++ b/memory/2026-05-07.md
@@ -1,0 +1,36 @@
+## 2026-05-07T16:14:24.674624+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699265s This type of proactive work was productive.
+
+Proactive task completed successfully: Digest proactive task
+Source: proactive_codie | Duration: 699265s
+This type of proactive work was productive.
+
+## 2026-05-07T16:14:34.446656+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713674s This type of proactive work was productive.
+
+Proactive task completed successfully: Create proactive cleanup brief
+Source: proactive_codie | Duration: 713674s
+This type of proactive work was productive.
+
+## 2026-05-07T16:17:10.440383+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699430s This type of proactive work was productive.
+
+Proactive task completed successfully: Digest proactive task
+Source: proactive_codie | Duration: 699430s
+This type of proactive work was productive.
+
+## 2026-05-07T16:17:19.357999+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713839s This type of proactive work was productive.
+
+Proactive task completed successfully: Create proactive cleanup brief
+Source: proactive_codie | Duration: 713839s
+This type of proactive work was productive.
+

--- a/memory/index.json
+++ b/memory/index.json
@@ -543,5 +543,65 @@
     "preview": "Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 373456s This type of proactive work was productive.",
     "file_path": "/home/user/universal_agent/memory/2026-05-03.md",
     "content_hash": "6cd63451e38d1c33839dcd6df55188686cee1214c2ea4043902904369b740263"
+  },
+  {
+    "entry_id": "f7004373-e5eb-4237-8f84-9c738b8224d7",
+    "timestamp": "2026-05-07T16:14:24.674624+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699265s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699265s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-07.md",
+    "content_hash": "1ed99f0c9bf2f2d6c2bc323a69f4b90ee378071e83fbd8c624ab2635d7f655b8"
+  },
+  {
+    "entry_id": "f2664099-0cf4-4ba2-b045-28342fdc2e85",
+    "timestamp": "2026-05-07T16:14:34.446656+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713674s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713674s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-07.md",
+    "content_hash": "e2825606e9562bceb5875b1111d0aeaae250b14713880b87c27adfaee2481be1"
+  },
+  {
+    "entry_id": "7c501969-ffd8-4274-8c80-0028740b6cbf",
+    "timestamp": "2026-05-07T16:17:10.440383+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699430s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 699430s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-07.md",
+    "content_hash": "6f1be3aca2077aeed55cd977b833111440ed1b845a57ace3e292d7a94d2e1625"
+  },
+  {
+    "entry_id": "78ce07b5-c85f-4cd7-8fbb-f46d9e85b53f",
+    "timestamp": "2026-05-07T16:17:19.357999+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713839s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713839s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-07.md",
+    "content_hash": "d5fe4300f255097532e7a4161f1e793826d7938ca2424185d2817480761324fc"
   }
 ]


### PR DESCRIPTION
## Why this exists

Today, a fresh **Claude Code on the web** container gets the repo cloned but no `.venv`. That means the agent cannot run `uv run pytest`, `uv run ruff`, or `uv run python -c "compile(...)"` until it syncs manually — and during this very session, that gap forced me to verify Item 7's prompt change by AST-extracting the string instead of running the test file.

This PR adds a `SessionStart` hook that populates `.venv/` from `uv.lock` once on web-session boot, so future agents can start running tests + lint immediately.

## Files

| File | Purpose |
|------|---------|
| `.claude/hooks/session-start.sh` | The hook itself (~70 lines, fully commented) |
| `.claude/settings.json` | Adds `hooks.SessionStart` block wiring the hook |

## Behaviour

- **Gated on `$CLAUDE_CODE_REMOTE=true`** — local dev (Antigravity, plain `claude`) is unaffected; those flows already manage their own env.
- **Idempotent.** A warm `.venv` with `pytest` + `ruff` present skips `uv sync` entirely (~50ms warm path).
- **Cold start:** timeout 300s on `uv sync --frozen --no-progress`. Captures the exit code **separately** from the `tail` pipe so a failure isn't masked — same pipe-to-tail bash bug that has been hiding 12 pre-existing pytest failures in `pr-validate.yml` (see #153).
- **Soft-failing:** never `exit 1`. On sync failure, prints a clear warning and lets the session start in degraded mode rather than blocking.

## Validation

| Mode | Outcome |
|------|---------|
| Local mode (`CLAUDE_CODE_REMOTE` unset) | immediate `exit 0`, no work |
| Web mode + warm `.venv` | `"skipping uv sync"` fast path, `exit 0` |
| Web mode + cold start, env broken | graceful warning, `exit 0`, agent can still read/edit |
| Web mode + cold start, env working (Python 3.12 + cp312 wheels) | `uv sync OK`, `.venv/bin/pytest` + `.venv/bin/ruff` resolve |

Reproduced all four locally before pushing.

## Dependency on #153

This hook only fully succeeds when `feature/latest2` has Python pinned to 3.12 — that's #153. Until #153 merges, the hook degrades gracefully (warning, no crash); once #153 lands, web sessions warm-start in <60s with full test + lint capability.

The two PRs are intentionally separate:

- #153 = the actual env fix (Python 3.12 pin + agent_registry importorskip), required to make CI run at all
- #2 (this PR) = the SessionStart hook that uses the env once #153 makes it work

Recommended merge order: #153 first, then this one.

## Test plan

- [ ] CI green on `pr-validate.yml` (no `.py` files changed → syntax-check skipped, pytest pipe-to-tail bug means the step always exits 0 anyway; this PR will pass CI today either way)
- [ ] After #153 merges and this PR rebases, a fresh Claude Code web session demonstrates the hook running end-to-end (cold sync in <60s, tests runnable from minute one)
- [ ] Followup PR addresses the 12 pre-existing test failures + the pipe-to-tail masking bug (tracked in #153's commit body)

https://claude.ai/code/session_01F5jaCk7fFTJ4MPdZqpV2DG

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5jaCk7fFTJ4MPdZqpV2DG)_