### PR TITLE
fix(dispatch): close vp_mission Kanban-mirror claim hole (Followup #3)

### DIFF
--- a/src/universal_agent/services/dispatch_service.py
+++ b/src/universal_agent/services/dispatch_service.py
@@ -196,11 +196,18 @@ def dispatch_sweep(
     workflow_attempt_id: Optional[str] = None,
     provider_session_id: Optional[str] = None,
     workspace_dir: Optional[str] = None,
+    forbidden_source_kinds: Optional[list[str]] = None,
 ) -> list[dict[str, Any]]:
     """Generic sweep dispatch — wraps claim_next_dispatch_tasks.
 
     This is the heartbeat's drop-in replacement: it rebuilds the queue and
     claims the top N tasks regardless of trigger_type.
+
+    ``forbidden_source_kinds`` plumbs through to the claim-time SQL filter so
+    a caller can exclude task source_kinds that are inappropriate for its
+    runtime. Notably, ``daemon_simone_todo`` should pass
+    ``forbidden_source_kinds=["vp_mission"]`` so it won't claim VP-mirror
+    rows that should be executed by VP workers (Followup #3 backstop).
     """
     claimed = task_hub.claim_next_dispatch_tasks(
         conn,
@@ -210,5 +217,6 @@ def dispatch_sweep(
         workflow_attempt_id=workflow_attempt_id,
         provider_session_id=provider_session_id,
         workspace_dir=workspace_dir,
+        forbidden_source_kinds=forbidden_source_kinds,
     )
     return _enrich_with_routing(claimed)

--- a/src/universal_agent/services/todo_dispatch_service.py
+++ b/src/universal_agent/services/todo_dispatch_service.py
@@ -723,13 +723,23 @@ class ToDoDispatchService:
             max_per_sweep = TODO_DISPATCH_MAX_PER_SWEEP
             with connect_runtime_db(activity_db_path) as conn:
                 for _ in range(max_per_sweep):
-                    # Claim one task at a time with deferred workspace
+                    # Claim one task at a time with deferred workspace.
+                    #
+                    # forbidden_source_kinds: vp_mission rows are Kanban-visibility
+                    # mirrors of work owned by VP workers (vp.coder.primary etc).
+                    # daemon_simone_todo must NOT claim them — that's what produced
+                    # the 2026-05-07 rogue-branch incident when reopen_stale_delegations
+                    # flipped a stale vp_mission mirror to OPEN. The producer-side
+                    # fix (agent_ready=False on the mirror) plus this dispatcher-side
+                    # backstop together close the recurrence path. See
+                    # docs/operations/2026-05-07_open_followups.md Followup #3.
                     batch = dispatch_sweep(
                         conn,
                         agent_id=f"todo:{session.session_id}",
                         limit=1,
                         provider_session_id=session.session_id,
                         workspace_dir=None,
+                        forbidden_source_kinds=["vp_mission"],
                     )
                     if not batch:
                         break

--- a/src/universal_agent/task_hub.py
+++ b/src/universal_agent/task_hub.py
@@ -1557,7 +1557,19 @@ def claim_next_dispatch_tasks(
     provider_session_id: Optional[str] = None,
     workspace_dir: Optional[str] = None,
     trigger_types: Optional[list[str]] = None,
+    forbidden_source_kinds: Optional[list[str]] = None,
 ) -> list[dict[str, Any]]:
+    """Claim up to `limit` agent-ready, eligible tasks from the dispatch queue.
+
+    The optional ``forbidden_source_kinds`` parameter is a backstop against
+    a specific failure mode: VP missions get mirrored into Task Hub for
+    Kanban visibility (``tools/vp_orchestration.py``), and if their
+    ``agent_ready`` field were ever True (or flipped True by some future
+    code path), a non-VP claimer (e.g. ``daemon_simone_todo``) could pick
+    them up. The producer-side fix is ``agent_ready=False`` on the mirror
+    write; this dispatcher-side filter is the defense-in-depth backstop.
+    See ``docs/operations/2026-05-07_open_followups.md`` Followup #3.
+    """
     ensure_schema(conn)
     rebuild_summary = rebuild_dispatch_queue(conn)
     queue_build_id = str(rebuild_summary.get("queue_build_id") or "")
@@ -1572,12 +1584,28 @@ def claim_next_dispatch_tasks(
 
     # Build trigger_type filter clause
     if trigger_types:
-        placeholders = ",".join("?" for _ in trigger_types)
-        trigger_filter = f"AND i.trigger_type IN ({placeholders})"
-        params: tuple = (queue_build_id, TASK_STATUS_OPEN, TASK_STATUS_REVIEW) + tuple(trigger_types) + (claim_limit,)
+        trigger_placeholders = ",".join("?" for _ in trigger_types)
+        trigger_filter = f"AND i.trigger_type IN ({trigger_placeholders})"
+        trigger_params: tuple = tuple(trigger_types)
     else:
         trigger_filter = ""
-        params = (queue_build_id, TASK_STATUS_OPEN, TASK_STATUS_REVIEW, claim_limit)
+        trigger_params = ()
+
+    # Build forbidden_source_kinds filter clause
+    if forbidden_source_kinds:
+        fsk_placeholders = ",".join("?" for _ in forbidden_source_kinds)
+        forbidden_filter = f"AND i.source_kind NOT IN ({fsk_placeholders})"
+        forbidden_params: tuple = tuple(forbidden_source_kinds)
+    else:
+        forbidden_filter = ""
+        forbidden_params = ()
+
+    params: tuple = (
+        (queue_build_id, TASK_STATUS_OPEN, TASK_STATUS_REVIEW)
+        + trigger_params
+        + forbidden_params
+        + (claim_limit,)
+    )
 
     rows = conn.execute(
         f"""
@@ -1588,6 +1616,7 @@ def claim_next_dispatch_tasks(
           AND q.eligible = 1
           AND i.status IN (?, ?)
           {trigger_filter}
+          {forbidden_filter}
         ORDER BY q.rank ASC
         LIMIT ?
         """,

--- a/src/universal_agent/tools/vp_orchestration.py
+++ b/src/universal_agent/tools/vp_orchestration.py
@@ -293,7 +293,16 @@ async def _vp_dispatch_mission_impl(args: dict[str, Any]) -> dict[str, Any]:
                     "source_ref": vp_id,
                     "mirror_status": "external",
                     "trigger_type": "vp_dispatch",
-                    "agent_ready": True,
+                    # vp_mission rows are visibility mirrors only — VP workers
+                    # claim by mission_id directly, NOT through the dispatch
+                    # sweep. Setting agent_ready=False keeps the row out of
+                    # the queue eligibility check (task_hub.py:1387) so a
+                    # non-VP claimer (e.g. daemon_simone_todo) can't pick it
+                    # up if reopen_stale_delegations flips status back to
+                    # OPEN. Closes the recurrence path that produced the
+                    # 2026-05-07 rogue-branch incident — see
+                    # docs/operations/2026-05-07_open_followups.md Followup #3.
+                    "agent_ready": False,
                     "metadata": {
                         "vp_id": vp_id,
                         "mission_type": mission_type,

--- a/tests/unit/test_dispatch_source_kind_isolation.py
+++ b/tests/unit/test_dispatch_source_kind_isolation.py
@@ -1,0 +1,265 @@
+"""Tests for the source_kind isolation gate on dispatch claims.
+
+These tests cover the two-layer fix described in
+``docs/operations/2026-05-07_open_followups.md`` Followup #3:
+
+  Layer 1 (producer):  vp_orchestration.py mirrors VP missions to Task Hub
+                        with agent_ready=False, so they're not eligible for
+                        the dispatch queue regardless of who calls
+                        claim_next_dispatch_tasks.
+
+  Layer 2 (dispatcher): claim_next_dispatch_tasks accepts an optional
+                        forbidden_source_kinds parameter and filters at
+                        SQL time. Defense-in-depth backstop for any other
+                        path that might surface a vp_mission row as
+                        agent_ready=True.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services.dispatch_service import dispatch_sweep
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    task_hub.ensure_schema(conn)
+    return conn
+
+
+def _insert_task(conn: sqlite3.Connection, task_id: str, **overrides) -> dict:
+    item = {
+        "task_id": task_id,
+        "title": f"Test {task_id}",
+        "status": task_hub.TASK_STATUS_OPEN,
+        "source_kind": "internal",
+        "agent_ready": True,
+        "labels": ["agent-ready"],
+    }
+    item.update(overrides)
+    # task_hub.upsert_item:980-982 re-promotes agent_ready=True when the
+    # "agent-ready" label is present. If the caller explicitly disabled
+    # agent_ready, drop the auto-added label so the explicit setting wins.
+    if not item.get("agent_ready"):
+        item["labels"] = [
+            label for label in (item.get("labels") or []) if label != "agent-ready"
+        ]
+    return task_hub.upsert_item(conn, item)
+
+
+def _claimed_task_ids(claimed: list[dict]) -> set[str]:
+    return {str(item.get("task_id") or "") for item in claimed}
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — producer-side: agent_ready=False keeps vp_mission out of the queue
+# ---------------------------------------------------------------------------
+
+
+class TestProducerSideAgentReadyFalse:
+    """When the vp_orchestration mirror writes agent_ready=False, the row is
+    not eligible for the dispatch queue and won't be returned by
+    claim_next_dispatch_tasks regardless of the caller's filter."""
+
+    def test_vp_mission_with_agent_ready_false_is_not_claimed(self):
+        conn = _make_conn()
+        # Mirror a VP mission as the new producer-side fix writes it
+        _insert_task(
+            conn,
+            "vp-mission-test-1",
+            source_kind="vp_mission",
+            agent_ready=False,
+            status=task_hub.TASK_STATUS_OPEN,
+        )
+        # Sanity: insert a normal claimable task so claim has SOMETHING to find
+        _insert_task(conn, "internal-test-1", source_kind="internal")
+
+        claimed = task_hub.claim_next_dispatch_tasks(conn, limit=10)
+        ids = _claimed_task_ids(claimed)
+        assert "vp-mission-test-1" not in ids
+        assert "internal-test-1" in ids
+
+    def test_vp_mission_open_after_reopen_stays_unclaimable_when_agent_ready_false(self):
+        """reopen_stale_delegations only sets status/seizure_state — it does
+        NOT touch agent_ready. So a mirror that started as agent_ready=False
+        stays uneligible even after reopen flips it back to OPEN."""
+        conn = _make_conn()
+        # Insert as DELEGATED (where reopen_stale_delegations operates)
+        _insert_task(
+            conn,
+            "vp-mission-test-2",
+            source_kind="vp_mission",
+            agent_ready=False,
+            status=task_hub.TASK_STATUS_DELEGATED,
+        )
+        # Force update_at into the past so reopen sees it as stale
+        conn.execute(
+            "UPDATE task_hub_items SET updated_at = '2020-01-01T00:00:00+00:00' WHERE task_id = ?",
+            ("vp-mission-test-2",),
+        )
+        reopened = task_hub.reopen_stale_delegations(conn, stale_hours=1.0)
+        assert any(t["task_id"] == "vp-mission-test-2" for t in reopened)
+
+        # Status is now OPEN, but agent_ready survived as False
+        row = task_hub.get_item(conn, "vp-mission-test-2")
+        assert row is not None
+        assert row["status"] == task_hub.TASK_STATUS_OPEN
+        assert bool(row["agent_ready"]) is False
+
+        # Therefore not claimable
+        claimed = task_hub.claim_next_dispatch_tasks(conn, limit=10)
+        assert "vp-mission-test-2" not in _claimed_task_ids(claimed)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — dispatcher-side: forbidden_source_kinds filters at SQL time
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcherSideForbiddenSourceKinds:
+    """Even if some other path puts a vp_mission row at agent_ready=True,
+    a caller passing forbidden_source_kinds=['vp_mission'] won't see it."""
+
+    def test_forbidden_source_kinds_excludes_matching_rows(self):
+        conn = _make_conn()
+        # Hostile / legacy mirror: agent_ready=True (the bug we're guarding against)
+        _insert_task(
+            conn,
+            "vp-mission-test-3",
+            source_kind="vp_mission",
+            agent_ready=True,
+        )
+        _insert_task(conn, "internal-test-3", source_kind="internal")
+
+        # Without the filter, the legacy-mirror row WOULD be claimed (this is
+        # the exact bug Followup #3 documents).
+        claimed_unfiltered = task_hub.claim_next_dispatch_tasks(conn, limit=10)
+        assert "vp-mission-test-3" in _claimed_task_ids(claimed_unfiltered)
+
+        # Reset the dispatch state by re-inserting fresh task_ids — claimed
+        # tasks from the previous call now have status=in_progress and
+        # wouldn't appear again anyway, so create a parallel pair.
+        _insert_task(
+            conn,
+            "vp-mission-test-3b",
+            source_kind="vp_mission",
+            agent_ready=True,
+        )
+        _insert_task(conn, "internal-test-3b", source_kind="internal")
+
+        # WITH the filter, vp_mission rows are excluded.
+        claimed_filtered = task_hub.claim_next_dispatch_tasks(
+            conn,
+            limit=10,
+            forbidden_source_kinds=["vp_mission"],
+        )
+        ids = _claimed_task_ids(claimed_filtered)
+        assert "vp-mission-test-3b" not in ids
+        assert "internal-test-3b" in ids
+
+    def test_forbidden_source_kinds_supports_multiple_kinds(self):
+        conn = _make_conn()
+        _insert_task(conn, "vp-1", source_kind="vp_mission", agent_ready=True)
+        _insert_task(conn, "ext-1", source_kind="external_mirror", agent_ready=True)
+        _insert_task(conn, "ok-1", source_kind="internal", agent_ready=True)
+
+        claimed = task_hub.claim_next_dispatch_tasks(
+            conn,
+            limit=10,
+            forbidden_source_kinds=["vp_mission", "external_mirror"],
+        )
+        ids = _claimed_task_ids(claimed)
+        assert "vp-1" not in ids
+        assert "ext-1" not in ids
+        assert "ok-1" in ids
+
+    def test_forbidden_source_kinds_none_or_empty_is_no_op(self):
+        """Backwards compatibility — existing callers that don't pass the
+        param see the same behavior as before."""
+        conn = _make_conn()
+        _insert_task(conn, "any-1", source_kind="anything", agent_ready=True)
+
+        # No param at all
+        claimed = task_hub.claim_next_dispatch_tasks(conn, limit=10)
+        assert "any-1" in _claimed_task_ids(claimed)
+
+        # Re-create after the previous claim flipped status
+        _insert_task(conn, "any-1b", source_kind="anything", agent_ready=True)
+
+        # Empty list also a no-op
+        claimed_empty = task_hub.claim_next_dispatch_tasks(
+            conn,
+            limit=10,
+            forbidden_source_kinds=[],
+        )
+        assert "any-1b" in _claimed_task_ids(claimed_empty)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 plumbing — dispatch_sweep threads forbidden_source_kinds through
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSweepThreadsForbiddenSourceKinds:
+    def test_dispatch_sweep_passes_forbidden_source_kinds_through(self):
+        conn = _make_conn()
+        _insert_task(conn, "vp-sweep-1", source_kind="vp_mission", agent_ready=True)
+        _insert_task(conn, "ok-sweep-1", source_kind="internal")
+
+        claimed = dispatch_sweep(
+            conn,
+            agent_id="todo:test",
+            limit=10,
+            forbidden_source_kinds=["vp_mission"],
+        )
+        ids = _claimed_task_ids(claimed)
+        assert "vp-sweep-1" not in ids
+        assert "ok-sweep-1" in ids
+
+    def test_dispatch_sweep_without_filter_sees_all_kinds(self):
+        """Sanity: dispatch_sweep without forbidden_source_kinds is unchanged."""
+        conn = _make_conn()
+        _insert_task(conn, "any-sweep-1", source_kind="vp_mission", agent_ready=True)
+        _insert_task(conn, "ok-sweep-2", source_kind="internal")
+
+        claimed = dispatch_sweep(conn, agent_id="todo:test", limit=10)
+        ids = _claimed_task_ids(claimed)
+        assert "any-sweep-1" in ids
+        assert "ok-sweep-2" in ids
+
+
+# ---------------------------------------------------------------------------
+# Combined: producer fix + dispatcher backstop together
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedDefense:
+    def test_producer_and_dispatcher_layers_compose(self):
+        """The realistic shipped configuration: producer writes
+        agent_ready=False AND dispatcher passes forbidden_source_kinds.
+        The vp_mission row is unreachable through either layer alone."""
+        conn = _make_conn()
+        # Producer-side fix in effect: agent_ready=False
+        _insert_task(
+            conn,
+            "vp-defense-1",
+            source_kind="vp_mission",
+            agent_ready=False,
+        )
+        _insert_task(conn, "ok-defense-1", source_kind="internal")
+
+        # Even with both layers active, normal claims work
+        claimed = dispatch_sweep(
+            conn,
+            agent_id="todo:test",
+            limit=10,
+            forbidden_source_kinds=["vp_mission"],
+        )
+        ids = _claimed_task_ids(claimed)
+        assert "vp-defense-1" not in ids
+        assert "ok-defense-1" in ids


### PR DESCRIPTION
## Summary

Two-layer fix for the recurrence path that produced the 2026-05-07 rogue-branch incident:

**Layer 1 — producer-side** (`tools/vp_orchestration.py:285-303`): the Kanban mirror writes `agent_ready=False` so VP-mission rows are NOT eligible for the dispatch queue (`task_hub.py:1387` short-circuits on `agent_ready=False`). VP workers continue to claim by `mission_id` directly, unaffected.

**Layer 2 — dispatcher-side** (`task_hub.py:claim_next_dispatch_tasks`, `services/dispatch_service.py:dispatch_sweep`): new optional `forbidden_source_kinds` parameter, plumbed through. `services/todo_dispatch_service.py` passes `forbidden_source_kinds=["vp_mission"]` on Simone's sweep call. Defense-in-depth in case a future code path surfaces `vp_mission` at `agent_ready=True`.

## Why this matters

Without this fix, the rogue-branch incident is repeatable on production today:

1. A `vp_mission` gets dispatched to a VP worker that stalls or is unhealthy.
2. `task_hub.reopen_stale_delegations:4331-4376` flips the mirror row to `OPEN` after the stale window. The reopen path does NOT touch `agent_ready`.
3. `daemon_simone_todo`'s next dispatch sweep claims the row (no source_kind gate).
4. `services/agent_router.py:48-55` stamps `agent_id=simone`.
5. Simone executes the mission body under her identity prompt — including code-mutation work she's not designed to do safely.

This was the exact chain that produced commit `57c6d4e6` on `codie/docstring-cleanup-task-hub` and the CSI cron `SyntaxError` crash at 08:00 CDT on 2026-05-07.

## Test plan

- [x] 8 new unit tests in `tests/unit/test_dispatch_source_kind_isolation.py`, all passing
- [x] `tests/unit/test_dispatch_service.py` — 13 existing tests still pass (no regression)
- [x] `tests/unit/test_task_hub_lifecycle.py` + `test_task_hub_missions.py` — 26 existing tests still pass
- [x] `ruff check` clean on all changed files
- [x] `py_compile` clean on all changed files
- [ ] CI green via `pr-validate.yml`
- [ ] Operator review + merge

## References

- Postmortem: [`docs/operations/2026-05-07_codie_rogue_branch_recovery.md`](docs/operations/2026-05-07_codie_rogue_branch_recovery.md)
- Followup spec: [`docs/operations/2026-05-07_open_followups.md`](docs/operations/2026-05-07_open_followups.md) (Followup #3)
- Investigation results: [`docs/operations/2026-05-07_loose_ends_investigation_plan.md`](docs/operations/2026-05-07_loose_ends_investigation_plan.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)