### PR TITLE
fix(cicd): route Dependabot through develop + sync local main on deploy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,68 @@
+# Dependabot configuration — routes dependency-update PRs through develop
+# instead of merging directly to main.
+#
+# Why target-branch: develop?
+#
+# Without this config, Dependabot defaults to opening PRs against the repo's
+# default branch (main). When those PRs merge to main directly, they bypass
+# the canonical feature/latest2 → develop → main fast-forward chain that
+# /ship relies on. Subsequent /ship runs then fail with "Diverging branches
+# can't be fast-forwarded" because main has commits develop doesn't.
+#
+# That's exactly what happened on 2026-05-07: PR #152 (a python-multipart
+# bump) merged directly to main via the GitHub UI, breaking /ship for the
+# next session and requiring a manual merge-commit recovery on main.
+#
+# By routing Dependabot PRs to develop, dep updates flow through the same
+# review path as feature work: develop → main fast-forward stays clean.
+#
+# References:
+#   - docs/operations/2026-05-07_open_followups.md (Followup #2 background)
+#   - .claude/commands/ship.md (the workflow whose --ff-only this protects)
+
+version: 2
+updates:
+
+  # Python dependencies (uv / pyproject.toml)
+  # Dependabot's pip ecosystem reads pyproject.toml directly. It does not
+  # natively understand uv.lock; users merging Dependabot's PRs must run
+  # `uv sync` (or `uv lock --upgrade-package <name>`) to refresh the lock
+  # before deployment. The dependencies install via uv on the production
+  # VPS in deploy.yml, so the lockfile must be regenerated locally.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00"
+      timezone: "America/Chicago"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    # Group security updates separately so they can be expedited if needed
+    groups:
+      python-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # GitHub Actions workflow dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "12:00"
+      timezone: "America/Chicago"
+    target-branch: "develop"
+    labels:
+      - "dependencies"
+      - "ci-cd"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,7 +112,14 @@ jobs:
             fi
             git fetch origin main
             git reset --hard origin/main
-            
+            # Sync the local 'main' branch pointer to origin/main too. Without
+            # this, repeated deploys advance HEAD and the working tree but
+            # leave the local main branch ref stuck at its old SHA. Anyone
+            # later running 'git checkout main' on the production tree (e.g.
+            # operator during incident recovery) lands on stale code.
+            # See Followup #2 in docs/operations/2026-05-07_open_followups.md.
+            git update-ref refs/heads/main "$(git rev-parse origin/main)"
+
             echo "--> Transferring ownership to service user before dependency sync..."
             # || true: tolerate ENOENT from transient SQLite WAL/SHM files
             # that may vanish mid-scan while the running service writes to DB.


### PR DESCRIPTION
## Summary

Two CI/CD plumbing fixes that together close the recurrence path of the 2026-05-07 /ship divergence incident:

1. **`.github/dependabot.yml`** (new file) — routes all Dependabot dep-update PRs to `develop` instead of `main`, so they flow through the canonical `feature/latest2 → develop → main` chain.
2. **`.github/workflows/deploy.yml`** — adds `git update-ref refs/heads/main` after the production `reset --hard`, so the local `main` branch pointer on the production VPS tracks HEAD (Followup #2 from the postmortem).

## What this prevents

On 2026-05-07 PR #152 (a python-multipart Dependabot bump) merged directly to `main` via the GitHub UI. That created a divergence — main had a commit develop didn't. The next `/ship` failed at the `git merge develop --ff-only` step because the histories no longer fast-forwarded. Recovery required a manual merge commit on main.

With this PR landed:

- Future Dependabot PRs target `develop`. They flow through the same review path as feature work. `develop → main` fast-forward stays clean.
- Production deploys keep the local `main` ref aligned with `origin/main`. Operators reading the production tree's git state during incident recovery see the right SHA on the right branch label.

## Test plan

- [x] `python3 -m yaml.safe_load` clean on both files
- [x] Dependabot config schema sanity check: version=2, both `pip` + `github-actions` entries target `develop`, directory `/`
- [x] Existing `deploy.yml` git ops (lock-handling, infisical bootstrap, systemd reloads) untouched — only the local-pointer line is added
- [ ] CI green via `pr-validate.yml`
- [ ] Operator review + merge

## Verifying after merge

After this PR merges to main and the deploy workflow runs:

```bash
ssh ua@uaonvps
cd /opt/universal_agent
test "$(git rev-parse HEAD)" = "$(git rev-parse main)"  # should match
test "$(git rev-parse main)" = "$(git rev-parse origin/main)"  # should match
```

For Dependabot routing: the next time Dependabot opens a PR, it should target `develop` rather than `main`. This will be visible in the PR's "base" branch in the GitHub UI.

## References

- Postmortem: [`docs/operations/2026-05-07_codie_rogue_branch_recovery.md`](docs/operations/2026-05-07_codie_rogue_branch_recovery.md)
- Followups: [`docs/operations/2026-05-07_open_followups.md`](docs/operations/2026-05-07_open_followups.md) (Followup #2)
- /ship workflow: [`.claude/commands/ship.md`](.claude/commands/ship.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)