### PR TITLE
fix(csi): six follow-ups from Phase E persistence self-review

### DIFF
--- a/src/universal_agent/services/csi_intelligence_persistence.py
+++ b/src/universal_agent/services/csi_intelligence_persistence.py
@@ -279,14 +279,33 @@ def _resolve_effective_op(
         return (ACTION_CREATE, canonical_name, "")
 
     if intended in {"extend", "revise"}:
-        # Honor the LLM's existing_slug if present and the page exists
-        # under that name, else fall back to canonical_name.
-        candidate_name = action.existing_slug or canonical_name
-        if memex_page_exists(vault_path, memex_kind, candidate_name):
-            actual_op = ACTION_EXTEND if intended == "extend" else ACTION_REVISE
-            return (actual_op, candidate_name, "")
-        # The LLM intended to extend/revise something that doesn't exist —
-        # treat as a fresh CREATE with the canonical name.
+        actual_op = ACTION_EXTEND if intended == "extend" else ACTION_REVISE
+
+        # First try: honor the LLM's existing_slug if it actually exists.
+        if action.existing_slug and memex_page_exists(
+            vault_path, memex_kind, action.existing_slug
+        ):
+            return (actual_op, action.existing_slug, "")
+
+        # Second try: maybe the LLM gave a wrong existing_slug but the
+        # canonical name already has a page. Don't create a duplicate —
+        # extend the canonical-name page instead. (Phase D Step 1
+        # surfaced this as a real-world failure mode: LLM emits
+        # ``existing_slug="multi"`` for a "Claude Managed Agents" extend,
+        # which doesn't exist, but the canonical "Claude Managed Agents"
+        # page does. Preserve the operator's intent — EXTEND wins over
+        # CREATE when any reasonable target exists.)
+        if memex_page_exists(vault_path, memex_kind, canonical_name):
+            note = ""
+            if action.existing_slug and action.existing_slug != canonical_name:
+                note = (
+                    f"redirected {intended.upper()} from existing_slug="
+                    f"{action.existing_slug!r} (missing) to canonical "
+                    f"name {canonical_name!r} (exists)"
+                )
+            return (actual_op, canonical_name, note)
+
+        # No matching page exists under either slug — fall back to CREATE.
         return (
             ACTION_CREATE,
             canonical_name,
@@ -344,9 +363,79 @@ def _append_relations_log(
     return written
 
 
+def _append_posts_log(
+    vault_path: Path,
+    delta: VaultDelta,
+    *,
+    packet_id: str,
+    handle: str,
+) -> bool:
+    """Append a per-post analysis record to ``posts.jsonl`` at vault root.
+
+    Captures the LLM's post-level metadata (``post_summary``, ``post_tags``)
+    that isn't tied to any specific entity page. Without this, posts whose
+    delta has no relations would lose ``post_summary`` entirely — see
+    Phase E followup #2.
+
+    Returns True if a record was written.
+    """
+    has_summary = bool((delta.post_summary or "").strip())
+    has_tags = bool(delta.post_tags)
+    if not (has_summary or has_tags):
+        return False
+
+    import json  # local import — only needed when post-level metadata is present
+
+    primary_post_id = ""
+    for va in delta.vault_actions:
+        if va.source_post_ids:
+            primary_post_id = va.source_post_ids[0]
+            break
+
+    log_path = vault_path / "posts.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "packet_id": packet_id,
+        "handle": handle,
+        "primary_post_id": primary_post_id,
+        "post_summary": delta.post_summary,
+        "post_tags": list(delta.post_tags),
+        "vault_action_count": len(delta.vault_actions),
+        "relation_count": len(delta.relations),
+    }
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False))
+        fh.write("\n")
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+# Confidence ordering for the optional min_confidence filter.
+_CONFIDENCE_RANK = {"low": 1, "medium": 2, "high": 3}
+
+
+def _packet_id_to_section_label(packet_id: str, primary_post_id: str) -> str:
+    """Render a short, human-readable section header for an EXTEND.
+
+    Packet IDs are typically of the form ``YYYY-MM-DD/HHMMSS__handle`` —
+    using the raw form as a markdown header is verbose and ugly. Extract
+    just the date prefix when present, otherwise fall back to the raw
+    packet_id, primary_post_id, or "Update".
+    """
+    pid = (packet_id or "").strip()
+    if pid:
+        # Match YYYY-MM-DD prefix (10 chars), keep just that for the header.
+        m = re.match(r"^(\d{4}-\d{2}-\d{2})", pid)
+        if m:
+            return f"Update {m.group(1)}"
+        return f"Update {pid}"
+    if primary_post_id:
+        return f"Update from post {primary_post_id}"
+    return "Update"
 
 
 def apply_vault_delta_to_vault(
@@ -355,19 +444,25 @@ def apply_vault_delta_to_vault(
     vault_path: Path,
     packet_id: str = "",
     handle: str = "",
+    min_confidence: str | None = None,
 ) -> dict[str, Any]:
     """Persist a ``VaultDelta`` to a Memex vault.
 
     For each ``VaultAction`` in ``delta.vault_actions``:
       1. Canonicalize the entity name (light surface-form normalization).
-      2. Resolve the effective op based on current vault state
+      2. Optionally drop low-confidence actions per ``min_confidence``.
+      3. Resolve the effective op based on current vault state
          (auto-downgrade CREATE→EXTEND when page already exists;
-         auto-upgrade EXTEND/REVISE→CREATE when target page is missing).
-      3. Build the markdown body content from structured fields.
-      4. Call ``memex_apply_action`` (which dispatches to the appropriate
+         auto-upgrade EXTEND/REVISE→CREATE when target page is missing;
+         redirect EXTEND/REVISE to canonical name when the LLM's
+         ``existing_slug`` is wrong but a canonical-name page exists).
+      4. Build the markdown body content from structured fields.
+      5. Call ``memex_apply_action`` (which dispatches to the appropriate
          create/extend/revise primitive and appends to ``log.md``).
 
-    Then append every ``VaultRelation`` to ``relations.jsonl``.
+    Then append every ``VaultRelation`` to ``relations.jsonl``, plus a
+    per-post metadata record to ``posts.jsonl`` (so ``post_summary`` /
+    ``post_tags`` are recoverable even when no relations exist).
 
     Args:
         delta: The structured analysis emitted by ``analyze_action``.
@@ -377,6 +472,11 @@ def apply_vault_delta_to_vault(
             for tracing which CSI poll surfaced the entity.
         handle: Optional X handle (e.g. ``"ClaudeDevs"``) used to build
             full ``https://x.com/<handle>/status/<id>`` URLs.
+        min_confidence: Optional confidence threshold. When set to
+            ``"high"``, ``"medium"``, or ``"low"``, VaultActions with a
+            confidence rank below this threshold are skipped (counted in
+            ``skipped_low_confidence``). Default ``None`` persists all
+            actions regardless of confidence.
 
     Returns:
         Dict summary of what happened, suitable for logging:
@@ -385,8 +485,10 @@ def apply_vault_delta_to_vault(
 
            {
              "applied": [
-                {"op": "CREATE", "name": "Claude Code", "kind": "product",
-                 "page_rel_path": "entities/claude-code.md", "log_note": ""},
+                {"op": "CREATE", "name": "Claude Code",
+                 "llm_kind": "product", "memex_kind": "entity",
+                 "page_rel_path": "entities/claude-code.md",
+                 "snapshot_path": None, "log_note": ""},
                 ...
              ],
              "errors": [
@@ -394,7 +496,9 @@ def apply_vault_delta_to_vault(
              ],
              "counts": {"create": 3, "extend": 1, "revise": 0},
              "relations_written": 4,
+             "post_log_written": True,
              "skipped_empty": 0,
+             "skipped_low_confidence": 0,
            }
 
     Never raises on a single VaultAction error — collects per-action
@@ -405,11 +509,35 @@ def apply_vault_delta_to_vault(
     errors: list[dict[str, Any]] = []
     counts: dict[str, int] = {"create": 0, "extend": 0, "revise": 0}
     skipped_empty = 0
+    skipped_low_confidence = 0
+
+    threshold_rank: int | None = None
+    if min_confidence:
+        normalized = min_confidence.strip().lower()
+        if normalized in _CONFIDENCE_RANK:
+            threshold_rank = _CONFIDENCE_RANK[normalized]
+        else:
+            logger.warning(
+                "csi_persistence: ignoring unknown min_confidence=%r "
+                "(expected high/medium/low)",
+                min_confidence,
+            )
 
     for idx, va in enumerate(delta.vault_actions):
         if not va.name.strip():
             skipped_empty += 1
             continue
+
+        if threshold_rank is not None:
+            action_rank = _CONFIDENCE_RANK.get(va.confidence, 2)
+            if action_rank < threshold_rank:
+                skipped_low_confidence += 1
+                logger.info(
+                    "csi_persistence: skipping VaultAction[%d] "
+                    "(name=%r confidence=%r below threshold %r)",
+                    idx, va.name, va.confidence, min_confidence,
+                )
+                continue
 
         try:
             effective_op, effective_name, log_note = _resolve_effective_op(
@@ -425,7 +553,10 @@ def apply_vault_delta_to_vault(
 
             # Tags surfaced into page frontmatter for downstream filtering /
             # capability-library indexing. Includes the kind, the source
-            # provenance bucket, and the LLM's confidence rating.
+            # provenance bucket, the LLM's confidence rating, the packet
+            # ID for time-window filtering, and one ``alias:<x>`` tag per
+            # alias so downstream consumers can canonicalize without
+            # re-parsing the body.
             tags = [
                 f"kind:{va.kind}",
                 "source:csi-claude-code",
@@ -433,6 +564,10 @@ def apply_vault_delta_to_vault(
             ]
             if packet_id:
                 tags.append(f"packet:{packet_id}")
+            for alias in va.aliases or []:
+                cleaned = (alias or "").strip()
+                if cleaned:
+                    tags.append(f"alias:{cleaned}")
 
             primary_post_id = (va.source_post_ids or [""])[0]
             primary_doc_url = (va.source_doc_urls or [""])[0]
@@ -441,7 +576,9 @@ def apply_vault_delta_to_vault(
 
             section_label = ""
             if effective_op == ACTION_EXTEND:
-                section_label = packet_id or primary_post_id or "Update"
+                section_label = _packet_id_to_section_label(
+                    packet_id, primary_post_id
+                )
 
             reason = ""
             if effective_op == ACTION_REVISE:
@@ -503,13 +640,18 @@ def apply_vault_delta_to_vault(
             )
 
     relations_written = _append_relations_log(vault_path, delta, packet_id=packet_id)
+    post_log_written = _append_posts_log(
+        vault_path, delta, packet_id=packet_id, handle=handle
+    )
 
     return {
         "applied": applied,
         "errors": errors,
         "counts": counts,
         "relations_written": relations_written,
+        "post_log_written": post_log_written,
         "skipped_empty": skipped_empty,
+        "skipped_low_confidence": skipped_low_confidence,
     }
 
 

--- a/tests/unit/test_csi_intelligence_persistence.py
+++ b/tests/unit/test_csi_intelligence_persistence.py
@@ -561,3 +561,378 @@ class TestTagsAndProvenance:
         assert "source:csi-claude-code" in page
         assert "confidence:high" in page
         assert "packet:2026-05-06/210011" in page
+
+    def test_aliases_emitted_as_alias_tags(self, vault: Path):
+        """Followup #3 — aliases land in frontmatter as ``alias:<x>`` tags so
+        downstream consumers can canonicalize without re-parsing the body."""
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create",
+                    kind="product",
+                    name="Claude Opus 4.7",
+                    aliases=["Opus 4.7", "claude-opus-4-7", "opus47"],
+                    summary="Anthropic's flagship model.",
+                    confidence="high",
+                )
+            ],
+        )
+        apply_vault_delta_to_vault(delta, vault_path=vault)
+        page = _read_page(vault, "entities", "claude-opus-4-7")
+        assert "alias:Opus 4.7" in page
+        assert "alias:claude-opus-4-7" in page
+        assert "alias:opus47" in page
+
+
+# ---------------------------------------------------------------------------
+# Followup #2 — posts.jsonl persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPostsLog:
+    def test_post_summary_persisted_when_no_relations(self, vault: Path):
+        """The earlier impl dropped post_summary when relations were empty.
+        Followup #2 fix: write it to ``posts.jsonl`` so it's recoverable."""
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create",
+                    kind="product",
+                    name="Lone Entity",
+                    summary="One entity, no relations.",
+                    source_post_ids=["2050000000000000001"],
+                    confidence="medium",
+                )
+            ],
+            relations=[],  # no relations
+            post_summary="A standalone entity announcement.",
+            post_tags=["release_announcement"],
+        )
+        result = apply_vault_delta_to_vault(
+            delta, vault_path=vault, packet_id="2026-05-08/foo", handle="ClaudeDevs"
+        )
+        assert result["post_log_written"] is True
+
+        log_path = vault / "posts.jsonl"
+        assert log_path.is_file()
+        line = log_path.read_text(encoding="utf-8").strip()
+        record = json.loads(line)
+        assert record["packet_id"] == "2026-05-08/foo"
+        assert record["handle"] == "ClaudeDevs"
+        assert record["primary_post_id"] == "2050000000000000001"
+        assert record["post_summary"] == "A standalone entity announcement."
+        assert record["post_tags"] == ["release_announcement"]
+        assert record["vault_action_count"] == 1
+        assert record["relation_count"] == 0
+
+    def test_no_posts_log_when_summary_and_tags_empty(self, vault: Path):
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="X",
+                    summary="X.", confidence="low",
+                )
+            ],
+            post_summary="",
+            post_tags=[],
+        )
+        result = apply_vault_delta_to_vault(delta, vault_path=vault)
+        assert result["post_log_written"] is False
+        assert not (vault / "posts.jsonl").exists()
+
+    def test_posts_log_appends_idempotently_across_calls(self, vault: Path):
+        delta = VaultDelta(
+            vault_actions=[],
+            post_summary="Just a post-level summary.",
+            post_tags=["commentary"],
+        )
+        apply_vault_delta_to_vault(delta, vault_path=vault, packet_id="p1")
+        apply_vault_delta_to_vault(delta, vault_path=vault, packet_id="p2")
+        lines = (vault / "posts.jsonl").read_text().strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0])["packet_id"] == "p1"
+        assert json.loads(lines[1])["packet_id"] == "p2"
+
+
+# ---------------------------------------------------------------------------
+# Followup #4 — confidence-threshold gating
+# ---------------------------------------------------------------------------
+
+
+class TestConfidenceGating:
+    def test_min_confidence_high_drops_medium_and_low(self, vault: Path):
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="High Confidence Thing",
+                    summary="Should be persisted.", confidence="high",
+                ),
+                VaultAction(
+                    op="create", kind="product", name="Medium Confidence Thing",
+                    summary="Should be skipped at min=high.", confidence="medium",
+                ),
+                VaultAction(
+                    op="create", kind="product", name="Low Confidence Thing",
+                    summary="Should be skipped at min=high.", confidence="low",
+                ),
+            ],
+        )
+        result = apply_vault_delta_to_vault(
+            delta, vault_path=vault, min_confidence="high"
+        )
+        assert result["counts"]["create"] == 1
+        assert result["skipped_low_confidence"] == 2
+        assert (vault / "entities" / "high-confidence-thing.md").exists()
+        assert not (vault / "entities" / "medium-confidence-thing.md").exists()
+        assert not (vault / "entities" / "low-confidence-thing.md").exists()
+
+    def test_min_confidence_medium_keeps_medium_and_high(self, vault: Path):
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="High",
+                    summary=".", confidence="high",
+                ),
+                VaultAction(
+                    op="create", kind="product", name="Medium",
+                    summary=".", confidence="medium",
+                ),
+                VaultAction(
+                    op="create", kind="product", name="Low",
+                    summary=".", confidence="low",
+                ),
+            ],
+        )
+        result = apply_vault_delta_to_vault(
+            delta, vault_path=vault, min_confidence="medium"
+        )
+        assert result["counts"]["create"] == 2
+        assert result["skipped_low_confidence"] == 1
+
+    def test_no_min_confidence_persists_all(self, vault: Path):
+        """Default behavior — backward compat."""
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="LowConfThing",
+                    summary=".", confidence="low",
+                ),
+            ],
+        )
+        result = apply_vault_delta_to_vault(delta, vault_path=vault)
+        assert result["counts"]["create"] == 1
+        assert result["skipped_low_confidence"] == 0
+
+    def test_unknown_min_confidence_ignored_with_warning(self, vault: Path):
+        """Defensive: unknown threshold values fall through as no-op."""
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="Whatever",
+                    summary=".", confidence="medium",
+                ),
+            ],
+        )
+        result = apply_vault_delta_to_vault(
+            delta, vault_path=vault, min_confidence="bogus"
+        )
+        assert result["counts"]["create"] == 1
+        assert result["skipped_low_confidence"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Followup #5 — section_label cleanup for EXTEND
+# ---------------------------------------------------------------------------
+
+
+class TestExtendSectionLabel:
+    def test_extend_section_uses_date_prefix_when_packet_id_is_dated(self, vault: Path):
+        # Seed the page first
+        seed = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="Claude Code",
+                    summary="seed.", confidence="medium",
+                )
+            ],
+        )
+        apply_vault_delta_to_vault(seed, vault_path=vault)
+
+        # Now extend with a typical CSI-style packet_id
+        ext = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="extend", kind="product", name="Claude Code",
+                    existing_slug="claude-code",
+                    summary="A new fact.", confidence="high",
+                )
+            ],
+        )
+        apply_vault_delta_to_vault(
+            ext, vault_path=vault, packet_id="2026-05-08/210011__ClaudeDevs"
+        )
+        page = _read_page(vault, "entities", "claude-code")
+        # The H2 section header (from memex_extend_page + our section_label)
+        # should be clean and date-prefixed, NOT the full verbose packet_id.
+        # The packet_id can still appear elsewhere (frontmatter packet: tag,
+        # body provenance footer) — that's intentional. Just the header
+        # needs to be readable.
+        h2_lines = [line for line in page.splitlines() if line.startswith("## ")]
+        assert h2_lines, "expected at least one H2 section in the extended page"
+        extend_header = h2_lines[-1]  # most recently appended section
+        assert "2026-05-08" in extend_header
+        assert "210011__ClaudeDevs" not in extend_header
+
+    def test_extend_falls_back_to_post_id_when_no_packet(self, vault: Path):
+        seed = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="Thing",
+                    summary="seed.", confidence="medium",
+                )
+            ],
+        )
+        apply_vault_delta_to_vault(seed, vault_path=vault)
+
+        ext = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="extend", kind="product", name="Thing",
+                    existing_slug="thing",
+                    summary="An update.",
+                    source_post_ids=["2050000000000099999"],
+                    confidence="medium",
+                )
+            ],
+        )
+        apply_vault_delta_to_vault(ext, vault_path=vault, packet_id="")
+        page = _read_page(vault, "entities", "thing")
+        assert "Update from post 2050000000000099999" in page
+
+
+# ---------------------------------------------------------------------------
+# Followup #6 — existing_slug is wrong but canonical_name has a page
+# ---------------------------------------------------------------------------
+
+
+class TestExistingSlugRedirect:
+    def test_extend_with_wrong_existing_slug_redirects_to_canonical(self, vault: Path):
+        """LLM emits ``existing_slug='managed'`` (wrong — that page doesn't
+        exist) for an entity whose canonical name 'Claude Managed Agents'
+        already has a page. We should EXTEND the canonical-name page,
+        NOT CREATE a duplicate ``managed.md``."""
+
+        # Seed: page exists under the canonical slug
+        seed = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="Claude Managed Agents",
+                    summary="seed.", confidence="medium",
+                )
+            ],
+        )
+        apply_vault_delta_to_vault(seed, vault_path=vault)
+        assert (vault / "entities" / "claude-managed-agents.md").exists()
+
+        # Now LLM emits an EXTEND with the WRONG existing_slug
+        ext = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="extend",
+                    kind="product",
+                    name="Claude Managed Agents",
+                    existing_slug="managed",  # wrong — managed.md doesn't exist
+                    summary="New capability.",
+                    confidence="high",
+                )
+            ],
+        )
+        result = apply_vault_delta_to_vault(ext, vault_path=vault)
+
+        # Should EXTEND the canonical-name page, not CREATE a duplicate
+        assert result["counts"]["extend"] == 1
+        assert result["counts"]["create"] == 0
+        applied = result["applied"][0]
+        assert applied["op"] == "EXTEND"
+        assert applied["page_rel_path"] == "entities/claude-managed-agents.md"
+        assert "redirected" in applied["log_note"]
+        assert "managed" in applied["log_note"]
+        assert "claude-managed-agents" in applied["log_note"].lower() or \
+               "Claude Managed Agents" in applied["log_note"]
+
+        # No spurious managed.md page was created
+        assert not (vault / "entities" / "managed.md").exists()
+
+        # The canonical page got the new content
+        page = _read_page(vault, "entities", "claude-managed-agents")
+        assert "New capability." in page
+
+    def test_revise_with_wrong_existing_slug_redirects_to_canonical(self, vault: Path):
+        """Same fix applies to REVISE."""
+        seed = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="Claude Code",
+                    summary="seed.", confidence="medium",
+                )
+            ],
+        )
+        apply_vault_delta_to_vault(seed, vault_path=vault)
+
+        rev = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="revise",
+                    kind="product",
+                    name="Claude Code",
+                    existing_slug="code",  # wrong — code.md doesn't exist
+                    summary="Reframed description.",
+                    confidence="high",
+                )
+            ],
+        )
+        result = apply_vault_delta_to_vault(rev, vault_path=vault)
+        assert result["counts"]["revise"] == 1
+        assert result["counts"]["create"] == 0
+        applied = result["applied"][0]
+        assert applied["op"] == "REVISE"
+        assert applied["page_rel_path"] == "entities/claude-code.md"
+        assert applied["snapshot_path"] is not None  # _history/ snapshot written
+        assert "redirected" in applied["log_note"]
+
+
+# ---------------------------------------------------------------------------
+# Followup #1 — docstring example sanity (verify return-dict shape)
+# ---------------------------------------------------------------------------
+
+
+class TestReturnDictShape:
+    def test_return_dict_has_documented_fields(self, vault: Path):
+        """Sanity check that the dict shape matches the docstring example."""
+        delta = VaultDelta(
+            vault_actions=[
+                VaultAction(
+                    op="create", kind="product", name="DocstringSanity",
+                    summary=".", confidence="medium",
+                )
+            ],
+        )
+        result = apply_vault_delta_to_vault(delta, vault_path=vault)
+
+        # All documented top-level keys
+        for key in {
+            "applied",
+            "errors",
+            "counts",
+            "relations_written",
+            "post_log_written",
+            "skipped_empty",
+            "skipped_low_confidence",
+        }:
+            assert key in result, f"missing top-level key: {key!r}"
+
+        # Each applied entry has the documented shape (incl. llm_kind / memex_kind)
+        applied = result["applied"][0]
+        for key in {"op", "name", "llm_kind", "memex_kind", "page_rel_path",
+                    "snapshot_path", "log_note"}:
+            assert key in applied, f"missing applied[*] key: {key!r}"


### PR DESCRIPTION
## Summary

Six minor improvements I flagged during the PR #159 self-review. All additive — no API breakage. The existing 21 tests still pass; this PR adds 13 more.

| # | Item | What changes |
|---|---|---|
| 1 | Docstring drift | Update example return-dict in `apply_vault_delta_to_vault` docstring to reflect the actual emitted fields (`llm_kind`, `memex_kind`, `post_log_written`, `skipped_low_confidence`). |
| 2 | `post_summary` / `post_tags` were dropped when `relations` was empty | New `_append_posts_log` writes per-call records to `<vault>/posts.jsonl`. Skipped when both summary and tags are empty. |
| 3 | Aliases body-only | Aliases now also surface as `alias:<x>` frontmatter tags so downstream consumers can canonicalize without re-parsing the body. |
| 4 | No confidence gating | Optional `min_confidence` parameter (`"high"`/`"medium"`/`"low"`/`None`). Default `None` preserves backward-compat. Skipped actions counted in new `skipped_low_confidence` dict field. |
| 5 | Verbose `section_label` | EXTEND section header now extracts just `YYYY-MM-DD` prefix when present (e.g. `"Update 2026-05-08"` instead of `"Update 2026-05-08/210011__ClaudeDevs"`). Frontmatter `packet:` tag + body provenance footer still carry the full packet_id. |
| 6 | EXTEND with wrong `existing_slug` upgraded to CREATE (duplicates) | Now redirects to canonical name when canonical_name has a page. Phase D Step 1 surfaced this as a real-world failure mode. Only falls back to CREATE when neither existing_slug nor canonical_name has a page. |

## Test plan

- [x] All 21 existing tests still pass (no regression)
- [x] 13 new tests across 5 new test classes (`TestPostsLog`, `TestConfidenceGating`, `TestExtendSectionLabel`, `TestExistingSlugRedirect`, `TestReturnDictShape`) plus one in `TestTagsAndProvenance`
- [x] `ruff check` clean
- [x] `py_compile` clean
- [ ] CI green via `pr-validate.yml`
- [ ] Operator review + merge

## What this unblocks

Nothing strictly — Phase F can proceed against PR #159's persistence helper as-is. These fixes just make the persistence layer more robust and audit-friendly when the new pass starts running on real packets in production.

## References

- Predecessor PR: #159 (Phase E persistence helper)
- Architecture: [`docs/proactive_signals/knowledge_extraction_redesign_context_2026-05-07.md`](docs/proactive_signals/knowledge_extraction_redesign_context_2026-05-07.md)
- Phase plan: [`docs/proactive_signals/csi_intelligence_pass_implementation_plan_2026-05-07.md`](docs/proactive_signals/csi_intelligence_pass_implementation_plan_2026-05-07.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)