### PR TITLE
feat(csi): swap regex extractor for LLM intelligence pass (Phase F)

### DIFF
--- a/src/universal_agent/services/claude_code_intel_replay.py
+++ b/src/universal_agent/services/claude_code_intel_replay.py
@@ -27,18 +27,14 @@ from universal_agent.services.claude_code_intel import (
     KB_SLUG,
     LANE_SLUG,
     SOURCE_KIND_DEMO_TASK,
-    SOURCE_KIND_SCAFFOLD_REQUEST,
     SOURCE_KIND_KB_UPDATE,
+    SOURCE_KIND_SCAFFOLD_REQUEST,
     classify_post,
     queue_follow_up_tasks,
     register_packet_artifact,
 )
 from universal_agent.wiki.core import (
-    ACTION_CREATE,
-    ACTION_EXTEND,
     ensure_vault,
-    memex_apply_action,
-    memex_page_exists,
     wiki_ingest_external_source,
 )
 
@@ -278,7 +274,13 @@ def refine_actions_with_linked_sources(
         if not post_id:
             continue
         metadata_path = Path(str(entry.get("metadata_path") or ""))
-        metadata = _load_json(metadata_path) if metadata_path.exists() else {}
+        # NB: must be is_file(), not exists() — `exists()` returns True for
+        # directories too. The 2026-05-07 v2 backfill hit a packet whose
+        # metadata_path resolved to '.' (cwd), which is a directory; the
+        # subsequent _load_json(...).read_text() then raised IsADirectoryError
+        # and killed replay for that packet. Tracked in Followup #4 of
+        # docs/operations/2026-05-07_open_followups.md.
+        metadata = _load_json(metadata_path) if metadata_path.is_file() else {}
         summary_parts = [
             f"source_type={metadata.get('source_type') or ''}",
             f"domain={metadata.get('domain') or ''}",
@@ -527,163 +529,50 @@ def apply_research_grounding_pass(
     return out
 
 
-# ── Memex extraction (PR 15) ────────────────────────────────────────────────
+# ── Memex extraction — LLM-driven (Phase F replacement) ────────────────────
 #
-# After every replay, decide which entity/concept pages to CREATE or EXTEND
-# from each action. CREATE is the dominant case (~80% per design doc §4.2);
-# EXTEND fires when the page already exists. REVISE (~5%) requires LLM
-# judgment about supersedes and is intentionally NOT wired here — it can
-# layer on as a follow-up PR once we have data on how often it actually
-# matters.
+# Replaces the regex-based extractor that was producing ~50% junk entities
+# (English stopwords, t.co URL slugs, joke words from meme tweets — full
+# evidence in docs/operations/2026-05-07_codie_rogue_branch_recovery.md).
 #
-# Source-of-name precedence (deterministic, no LLM call):
-#   1. release_info.package — when the action is a release_announcement
-#      (PR 6a), the package name itself is an entity.
-#   2. CamelCase / snake_case feature terms in action.text — same heuristic
-#      research_grounding uses.
-#   3. Skipped: anything from linked source titles. Future enhancement.
-
-# Lifted from research_grounding._TERM_PATTERN so we extract the same
-# named-feature shapes consistently across the v2 pipeline.
-_MEMEX_TERM_PATTERN = re.compile(
-    r"\b([A-Z][a-zA-Z0-9_]{2,}|[a-z][a-zA-Z0-9_]+_[a-zA-Z0-9_]+)\b"
-)
-_MEMEX_TERM_STOPWORDS = frozenset(
-    {
-        "claude",
-        "anthropic",
-        "agents",
-        "agent",
-        "tool",
-        "tools",
-        "this",
-        "that",
-        "with",
-        "from",
-        "into",
-        "what",
-        "when",
-        "have",
-        "been",
-        "more",
-        "https",
-        "http",
-        "url",
-        "post",
-        "github",
-        "discord",
-        "twitter",
-        "reddit",
-        "demo",
-        "demos",
-        "build",
-        "release",
-        "released",
-        "today",
-        "support",
-        "supports",
-    }
-)
+# New design (per docs/proactive_signals/knowledge_extraction_redesign_context_2026-05-07.md):
+#   1. ``services.csi_intelligence_pass.analyze_action`` — LLM call (GLM-5.1)
+#      returning a structured ``VaultDelta`` (entities/concepts/relations
+#      with rich kinds and aliases). The LLM does the meaning judgment;
+#      code does no stopword filtering / pattern matching / ranking.
+#   2. ``services.csi_intelligence_persistence.apply_vault_delta_to_vault``
+#      — pure plumbing layer that translates the VaultDelta into
+#      ``memex_apply_action`` calls (auto-downgrade / -upgrade / -redirect
+#      based on current vault state, light name canonicalization, alias-tag
+#      emission, posts.jsonl + relations.jsonl persistence).
+#
+# Quality validation: Phase D ran 50 LLM calls across 4 diverse packets
+# with 0 junk emissions, perfect cross-packet canonical-name stability
+# for high-frequency entities (Claude Code, Opus 4.7, Claude Managed Agents).
 
 
-def _memex_candidates_for_action(action: dict[str, Any]) -> list[tuple[str, str]]:
-    """Return [(kind, name)] candidates for one action.
-
-    Conservative: returns at most a handful per action so the Memex pass
-    doesn't explode into dozens of pages per tweet.
-    """
-    candidates: list[tuple[str, str]] = []
-    seen: set[tuple[str, str]] = set()
-
-    def _add(kind: str, name: str) -> None:
-        cleaned = str(name or "").strip()
-        if not cleaned:
-            return
-        key = (kind, cleaned.lower())
-        if key in seen:
-            return
-        seen.add(key)
-        candidates.append((kind, cleaned))
-
-    # 1. Release announcements: the package itself is an entity.
-    release_info = action.get("release_info") if isinstance(action.get("release_info"), dict) else None
-    if release_info and release_info.get("package"):
-        _add("entity", str(release_info["package"]))
-
-    # 2. CamelCase / snake_case terms in the action's text. Cap to first 5.
-    text = str(action.get("text") or "")
-    if text:
-        terms_found = 0
-        for raw in _MEMEX_TERM_PATTERN.findall(text):
-            if len(raw) < 3:
-                continue
-            if raw.lower() in _MEMEX_TERM_STOPWORDS:
-                continue
-            _add("entity", raw)
-            terms_found += 1
-            if terms_found >= 5:
-                break
-
-    return candidates
+def _read_linked_source_text(entry: dict[str, Any], *, max_chars: int = 8000) -> str:
+    """Read a linked source's fetched body text. Empty string on any error."""
+    source_path = str(entry.get("source_path") or "").strip()
+    if not source_path:
+        return ""
+    try:
+        text = Path(source_path).read_text(encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return ""
+    if len(text) > max_chars:
+        return text[:max_chars] + f"\n\n[... truncated, original length {len(text)} chars]"
+    return text
 
 
-def _memex_body_for_create(
-    *,
-    handle: str,
-    action: dict[str, Any],
-    linked_for_post: list[dict[str, Any]],
-) -> str:
-    """Synthesize a minimal entity-page body from action + linked sources."""
-    title = str(action.get("post_id") or "").strip()
-    text = str(action.get("text") or "").strip()
-    classifier = action.get("classifier") if isinstance(action.get("classifier"), dict) else {}
-    reasoning = str(classifier.get("reasoning") or "").strip()
-    post_url = str(action.get("url") or "").strip()
-    parts: list[str] = ["## Discovery context", ""]
-    parts.append(f"- handle: `@{handle}`")
-    if post_url:
-        parts.append(f"- post: {post_url}")
-    if title:
-        parts.append(f"- post_id: `{title}`")
-    parts.append("")
-    if text:
-        parts.extend(["### Tweet text", "", text, ""])
-    if reasoning:
-        parts.extend(["### Classifier rationale", "", reasoning, ""])
-    if linked_for_post:
-        parts.extend(["### Linked official sources", ""])
-        for entry in linked_for_post[:6]:
-            url = str(entry.get("url") or "").strip()
-            t = str(entry.get("title") or "").strip() or url or "source"
-            if url:
-                parts.append(f"- [{t}]({url})")
-            else:
-                parts.append(f"- {t}")
-        parts.append("")
-    return "\n".join(parts).rstrip() + "\n"
-
-
-def _memex_body_for_extend(
-    *,
-    action: dict[str, Any],
-    linked_for_post: list[dict[str, Any]],
-) -> str:
-    """Body for an EXTEND — short, dated section appended to existing page."""
-    text = str(action.get("text") or "").strip()
-    parts: list[str] = []
-    if text:
-        parts.append(text)
-    if linked_for_post:
-        parts.append("")
-        parts.append("Newly linked sources:")
-        for entry in linked_for_post[:6]:
-            url = str(entry.get("url") or "").strip()
-            t = str(entry.get("title") or "").strip() or url or "source"
-            if url:
-                parts.append(f"- [{t}]({url})")
-            else:
-                parts.append(f"- {t}")
-    return "\n".join(parts).rstrip() + "\n"
+def _existing_vault_slugs(vault_path: Path) -> list[str]:
+    """List the slugs of existing entity + concept pages in this vault."""
+    slugs: list[str] = []
+    for sub in ("entities", "concepts"):
+        d = vault_path / sub
+        if d.is_dir():
+            slugs.extend(p.stem for p in d.glob("*.md"))
+    return slugs
 
 
 def apply_memex_pass(
@@ -692,81 +581,150 @@ def apply_memex_pass(
     handle: str,
     actions: list[dict[str, Any]],
     linked_source_entries: list[dict[str, Any]],
+    packet_id: str = "",
+    min_tier: int = 2,
 ) -> list[dict[str, Any]]:
-    """Walk every action; CREATE or EXTEND entity/concept pages as needed.
+    """Run the LLM-driven CSI intelligence pass over every tier-2+ action.
 
-    Returns a list of action records suitable for inclusion in the candidate
-    ledger. Never raises on per-action failure — surfaces the error in the
-    record so the downstream pipeline can keep working.
+    For each action whose tier ≥ ``min_tier``:
+      1. Gather linked-source text for the action's post (read fetched
+         markdown bodies from disk; truncated per source to keep prompt
+         sizes bounded).
+      2. Read the current vault's existing entity/concept slugs so the
+         LLM can choose CREATE-vs-EXTEND-vs-REVISE.
+      3. Call ``analyze_action`` (one GLM-5.1 call per action) →
+         ``VaultDelta``.
+      4. Persist the ``VaultDelta`` via ``apply_vault_delta_to_vault``.
+      5. Refresh the slug list with newly-created pages so the next
+         action's LLM context reflects the live vault state.
+
+    Returns a flat list of per-entity records preserving the legacy shape
+    callers expect:
+
+      ``{"action": "CREATE"|"EXTEND"|"REVISE"|"ERROR",
+         "post_id": "...", "entity_name": "...",
+         "entity_kind": "<llm kind: product/feature/concept/...>",
+         "memex_kind": "<entity|concept>",
+         "page_path": "entities/...md", "snapshot_path": "...|None",
+         "log_note": "..."}``
+
+    Never raises on per-action failure — surfaces errors as ``action="ERROR"``
+    records so the replay orchestrator can keep going.
     """
+    # Imports kept local to avoid pulling pydantic / anthropic SDK into
+    # callers that don't actually trigger memex (e.g. dry-run replays).
+    from universal_agent.services.csi_intelligence_pass import analyze_action
+    from universal_agent.services.csi_intelligence_persistence import (
+        apply_vault_delta_to_vault,
+    )
+
     results: list[dict[str, Any]] = []
 
-    # Pre-index linked sources by post_id so each action gets only its own.
-    linked_by_post: dict[str, list[dict[str, Any]]] = {}
+    # Pre-index linked-source TEXT (not entries) by post_id so each action
+    # gets only its own bodies, deduplicated by source_path.
+    linked_text_by_post: dict[str, list[str]] = {}
+    seen_paths_by_post: dict[str, set[str]] = {}
     for entry in linked_source_entries:
         if str(entry.get("fetch_status") or "") != "fetched":
             continue
         post_id = str(entry.get("post_id") or "").strip()
-        if post_id:
-            linked_by_post.setdefault(post_id, []).append(entry)
+        if not post_id:
+            continue
+        source_path = str(entry.get("source_path") or "").strip()
+        if not source_path:
+            continue
+        seen = seen_paths_by_post.setdefault(post_id, set())
+        if source_path in seen:
+            continue
+        seen.add(source_path)
+        text = _read_linked_source_text(entry)
+        if text:
+            linked_text_by_post.setdefault(post_id, []).append(text)
+
+    # Read existing slugs once; refresh from each apply_vault_delta_to_vault
+    # result so the next action's LLM context reflects in-batch additions.
+    existing_slugs: set[str] = set(_existing_vault_slugs(vault_path))
 
     for action in actions:
         post_id = str(action.get("post_id") or "").strip()
-        candidates = _memex_candidates_for_action(action)
-        if not candidates:
+        try:
+            tier_int = int(action.get("tier") or 0)
+        except (TypeError, ValueError):
+            tier_int = 0
+        if tier_int < min_tier:
             continue
-        linked_for_post = linked_by_post.get(post_id, [])
-        source_id = f"x_post_{post_id}" if post_id else "x_post"
-        source_title = f"ClaudeDevs post {post_id}" if post_id else "ClaudeDevs post"
 
-        for kind, name in candidates:
-            try:
-                if memex_page_exists(vault_path, kind, name):
-                    body = _memex_body_for_extend(
-                        action=action,
-                        linked_for_post=linked_for_post,
-                    )
-                    result = memex_apply_action(
-                        vault_path,
-                        action=ACTION_EXTEND,
-                        kind=kind,
-                        name=name,
-                        body=body,
-                        source_id=source_id,
-                        source_title=source_title,
-                        section_label=f"Update from @{handle}: post {post_id}",
-                    )
-                else:
-                    body = _memex_body_for_create(
-                        handle=handle,
-                        action=action,
-                        linked_for_post=linked_for_post,
-                    )
-                    result = memex_apply_action(
-                        vault_path,
-                        action=ACTION_CREATE,
-                        kind=kind,
-                        name=name,
-                        body=body,
-                        source_id=source_id,
-                        source_title=source_title,
-                        tags=["claude-code", "claude-devs", str(action.get("action_type") or "")],
-                    )
-                result["post_id"] = post_id
-                result["entity_name"] = name
-                result["entity_kind"] = kind
-                results.append(result)
-            except Exception as exc:
-                results.append(
-                    {
-                        "action": "ERROR",
-                        "post_id": post_id,
-                        "entity_name": name,
-                        "entity_kind": kind,
-                        "error_type": type(exc).__name__,
-                        "error": str(exc)[:300],
-                    }
-                )
+        # 3. LLM call
+        try:
+            delta = analyze_action(
+                action=action,
+                linked_sources=linked_text_by_post.get(post_id, []),
+                existing_vault_entities=sorted(existing_slugs),
+            )
+        except Exception as exc:
+            results.append(
+                {
+                    "action": "ERROR",
+                    "post_id": post_id,
+                    "stage": "analyze_action",
+                    "error_type": type(exc).__name__,
+                    "error": str(exc)[:300],
+                }
+            )
+            continue
+
+        # 4. Persistence
+        try:
+            persist = apply_vault_delta_to_vault(
+                delta,
+                vault_path=vault_path,
+                packet_id=packet_id,
+                handle=handle,
+            )
+        except Exception as exc:
+            results.append(
+                {
+                    "action": "ERROR",
+                    "post_id": post_id,
+                    "stage": "apply_vault_delta_to_vault",
+                    "error_type": type(exc).__name__,
+                    "error": str(exc)[:300],
+                }
+            )
+            continue
+
+        # 5. Convert to legacy result shape
+        for applied in persist.get("applied", []):
+            results.append(
+                {
+                    "action": applied["op"],
+                    "post_id": post_id,
+                    "entity_name": applied["name"],
+                    "entity_kind": applied["llm_kind"],
+                    "memex_kind": applied["memex_kind"],
+                    "page_path": applied["page_rel_path"],
+                    "snapshot_path": applied.get("snapshot_path"),
+                    "log_note": applied.get("log_note", ""),
+                }
+            )
+            # Track newly-created slugs so subsequent LLM calls see them
+            page_rel = str(applied.get("page_rel_path") or "")
+            if page_rel:
+                existing_slugs.add(Path(page_rel).stem)
+
+        for err in persist.get("errors", []):
+            results.append(
+                {
+                    "action": "ERROR",
+                    "post_id": post_id,
+                    "entity_name": err.get("name", ""),
+                    "entity_kind": err.get("kind", ""),
+                    "stage": "apply_vault_delta_to_vault",
+                    "error_type": (err.get("error", "") or "").split(":")[0],
+                    "error": err.get("error", ""),
+                }
+            )
+
     return results
 
 
@@ -891,11 +849,20 @@ def ingest_packet_into_external_vault(
     memex_actions: list[dict[str, Any]] = []
     if str(os.getenv("UA_CSI_MEMEX_WIRING_ENABLED") or "1").strip().lower() not in {"0", "false", "no", "off"}:
         try:
+            # Build a packet_id from the packet directory's last two segments,
+            # e.g. "2026-05-06/210011__ClaudeDevs". Used by the persistence
+            # layer for `packet:` frontmatter tags + EXTEND section labels.
+            packet_id = (
+                f"{packet_dir.parent.name}/{packet_dir.name}"
+                if packet_dir.parent.name
+                else packet_dir.name
+            )
             memex_actions = apply_memex_pass(
                 vault_path=context.path,
                 handle=handle,
                 actions=actions,
                 linked_source_entries=linked_source_entries,
+                packet_id=packet_id,
             )
         except Exception:
             # Memex failure must never block the source-page writes that
@@ -1382,7 +1349,7 @@ def _normalize_web_content(*, body: str, content_type: str, url: str, source_typ
     if source_type in {"docs_page", "vendor_docs"}:
         lines = ["# Linked Source", ""]
         if html_features["title"]:
-            lines.extend([f"## Title", "", html_features["title"], ""])
+            lines.extend(["## Title", "", html_features["title"], ""])
         if html_features["headings"]:
             lines.extend(["## Headings", ""])
             for heading in html_features["headings"][:12]:

--- a/tests/unit/test_csi_memex_wiring.py
+++ b/tests/unit/test_csi_memex_wiring.py
@@ -1,316 +1,507 @@
-"""Tests for the Memex pass wired into ClaudeDevs replay (PR 15)."""
+"""Tests for the LLM-driven Memex pass wired into ClaudeDevs replay (Phase F).
+
+Replaces the prior PR 15 regex-extractor tests. The new ``apply_memex_pass``
+runs ``services.csi_intelligence_pass.analyze_action`` (LLM call, mocked
+here) per tier-2+ action, then ``services.csi_intelligence_persistence
+.apply_vault_delta_to_vault`` (deterministic). These tests mock the LLM
+call to return fixture VaultDeltas and verify the orchestration:
+
+  - Tier filter: actions below ``min_tier`` are skipped (no LLM call).
+  - Linked sources are read from disk per ``source_path`` and passed to
+    the LLM as text.
+  - Existing vault entity slugs are read once and refreshed in-batch as
+    new pages are created (so subsequent LLM calls see live state).
+  - The packet_id is propagated to the persistence layer.
+  - Per-action LLM failures are surfaced as ``action="ERROR"`` records
+    without raising or sinking sibling actions.
+  - ``ingest_packet_into_external_vault`` honors the
+    ``UA_CSI_MEMEX_WIRING_ENABLED=0`` kill switch.
+
+The granular Phase A schema + Phase E persistence behaviors have their own
+test files (``test_csi_intelligence_pass.py`` /
+``test_csi_intelligence_persistence.py``) — this file is purely about the
+replay-level wiring.
+"""
 
 from __future__ import annotations
 
-import importlib
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
 from universal_agent.services import claude_code_intel_replay
 from universal_agent.services.claude_code_intel_replay import (
-    _memex_body_for_create,
-    _memex_body_for_extend,
-    _memex_candidates_for_action,
     apply_memex_pass,
     ingest_packet_into_external_vault,
 )
-from universal_agent.wiki.core import (
-    ACTION_CREATE,
-    ACTION_EXTEND,
-    ensure_vault,
-    memex_page_exists,
+from universal_agent.services.csi_intelligence_pass import (
+    VaultAction,
+    VaultDelta,
+    VaultRelation,
 )
+from universal_agent.wiki.core import ensure_vault
 
-
-# ── Candidate extraction ────────────────────────────────────────────────────
-
-
-def test_candidates_includes_release_info_package():
-    action = {
-        "post_id": "1",
-        "text": "we shipped something",
-        "release_info": {"package": "claude-agent-sdk", "version": "0.5.1"},
-    }
-    candidates = _memex_candidates_for_action(action)
-    assert ("entity", "claude-agent-sdk") in candidates
-
-
-def test_candidates_extracts_camelcase_terms_from_text():
-    action = {
-        "post_id": "1",
-        "text": "Try the new MemoryTool with ManagedAgents support",
-    }
-    candidates = _memex_candidates_for_action(action)
-    names = {n for _, n in candidates}
-    assert "MemoryTool" in names
-    assert "ManagedAgents" in names
-
-
-def test_candidates_filters_stopwords():
-    action = {
-        "post_id": "1",
-        "text": "Anthropic announced new Claude Tool support today",
-    }
-    candidates = _memex_candidates_for_action(action)
-    names_lower = {n.lower() for _, n in candidates}
-    # Generic words should not become entities.
-    for stop in ("anthropic", "claude", "tool", "today"):
-        assert stop not in names_lower
-
-
-def test_candidates_caps_at_5_terms():
-    action = {
-        "post_id": "1",
-        "text": "FeatureA FeatureB FeatureC FeatureD FeatureE FeatureF FeatureG FeatureH",
-    }
-    candidates = _memex_candidates_for_action(action)
-    # 5 terms from text (cap), no release_info.
-    assert len(candidates) == 5
-
-
-def test_candidates_dedupe():
-    action = {
-        "post_id": "1",
-        "text": "MemoryTool MemoryTool memorytool",  # case-insensitive dedupe
-        "release_info": {"package": "claude-agent-sdk", "version": "0.5.1"},
-    }
-    candidates = _memex_candidates_for_action(action)
-    # Only one MemoryTool entry plus the release package.
-    names = [n.lower() for _, n in candidates]
-    assert names.count("memorytool") == 1
-
-
-def test_candidates_empty_when_nothing_matches():
-    action = {"post_id": "1", "text": "just a chat with friends"}
-    assert _memex_candidates_for_action(action) == []
-
-
-# ── Body construction ───────────────────────────────────────────────────────
-
-
-def test_create_body_includes_handle_post_url_text_reasoning_sources():
-    action = {
-        "post_id": "999",
-        "text": "Skills support cross-project references",
-        "url": "https://x.com/ClaudeDevs/status/999",
-        "classifier": {"reasoning": "Reusable for agent systems"},
-    }
-    linked = [
-        {"url": "https://docs.anthropic.com/skills", "title": "Skills docs"},
-    ]
-    body = _memex_body_for_create(handle="ClaudeDevs", action=action, linked_for_post=linked)
-    assert "@ClaudeDevs" in body
-    assert "https://x.com/ClaudeDevs/status/999" in body
-    assert "post_id: `999`" in body
-    assert "Skills support cross-project references" in body
-    assert "Reusable for agent systems" in body
-    assert "Skills docs" in body
-    assert "https://docs.anthropic.com/skills" in body
-
-
-def test_extend_body_is_compact():
-    action = {"post_id": "999", "text": "small follow-up"}
-    body = _memex_body_for_extend(action=action, linked_for_post=[])
-    assert "small follow-up" in body
-    # Extend bodies don't repeat the full discovery context block.
-    assert "Discovery context" not in body
-
-
-# ── End-to-end Memex pass ────────────────────────────────────────────────────
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def vault(tmp_path: Path):
+def vault(tmp_path: Path) -> Path:
+    """A clean external vault under tmp_path."""
     ctx = ensure_vault(
         "external",
-        "memex-wiring-test",
-        title="Memex Wiring Test",
-        root_override=str(tmp_path / "vault"),
+        "csi-replay-test",
+        title="CSI replay test vault",
+        root_override=str(tmp_path),
     )
     return ctx.path
 
 
-def test_memex_pass_creates_entity_pages_from_release_info(vault: Path):
-    actions = [
-        {
-            "post_id": "100",
-            "text": "Claude Code 2.1.116 ships with Skills",
-            "url": "https://x.com/ClaudeDevs/status/100",
-            "release_info": {"package": "claude-code", "version": "2.1.116"},
-            "action_type": "release_announcement",
-        }
-    ]
-    results = apply_memex_pass(
-        vault_path=vault,
-        handle="ClaudeDevs",
-        actions=actions,
-        linked_source_entries=[],
+def _action(post_id: str, text: str, tier: int = 2, **extra) -> dict:
+    out = {
+        "post_id": post_id,
+        "text": text,
+        "tier": tier,
+        "action_type": "release_announcement",
+        "url": f"https://x.com/ClaudeDevs/status/{post_id}",
+    }
+    out.update(extra)
+    return out
+
+
+def _linked_entry(
+    post_id: str,
+    *,
+    source_path: str,
+    fetch_status: str = "fetched",
+    title: str = "Doc",
+    url: str = "https://platform.claude.com/docs",
+) -> dict:
+    return {
+        "post_id": post_id,
+        "url": url,
+        "source_path": source_path,
+        "fetch_status": fetch_status,
+        "title": title,
+    }
+
+
+def _delta(*actions: VaultAction, post_summary: str = "", relations=None) -> VaultDelta:
+    return VaultDelta(
+        vault_actions=list(actions),
+        relations=list(relations or []),
+        post_summary=post_summary,
     )
-    # claude-code (release_info) + Skills (CamelCase) = 2 entities
-    creates = [r for r in results if r.get("action") == ACTION_CREATE]
-    names = {r["entity_name"] for r in creates}
-    assert "claude-code" in names
-    assert "Skills" in names
-    assert memex_page_exists(vault, "entity", "claude-code")
-    assert memex_page_exists(vault, "entity", "Skills")
 
 
-def test_memex_pass_extends_existing_pages(vault: Path):
-    """Second action that mentions an existing entity should EXTEND, not CREATE."""
-    actions_first = [
-        {
-            "post_id": "100",
-            "text": "MemoryTool announcement",
-            "url": "https://x.com/ClaudeDevs/status/100",
-        }
-    ]
-    apply_memex_pass(
-        vault_path=vault,
-        handle="ClaudeDevs",
-        actions=actions_first,
-        linked_source_entries=[],
-    )
-    # Now a second action mentioning the same entity.
-    actions_second = [
-        {
-            "post_id": "200",
-            "text": "MemoryTool now supports typed schemas",
-            "url": "https://x.com/ClaudeDevs/status/200",
-        }
-    ]
-    results = apply_memex_pass(
-        vault_path=vault,
-        handle="ClaudeDevs",
-        actions=actions_second,
-        linked_source_entries=[],
-    )
-    extends = [r for r in results if r.get("action") == ACTION_EXTEND and r.get("entity_name") == "MemoryTool"]
-    assert len(extends) == 1
-    # The page should have content from BOTH actions.
-    page = (vault / "entities" / "memorytool.md").read_text(encoding="utf-8")
-    assert "MemoryTool announcement" in page
-    assert "MemoryTool now supports typed schemas" in page
+# ---------------------------------------------------------------------------
+# Tier filtering
+# ---------------------------------------------------------------------------
 
 
-def test_memex_pass_records_log_entries(vault: Path):
-    actions = [
-        {
-            "post_id": "100",
-            "text": "Hooks API expanded with PostToolUseFailure",
-            "url": "https://x.com/ClaudeDevs/status/100",
-        }
-    ]
-    apply_memex_pass(
-        vault_path=vault,
-        handle="ClaudeDevs",
-        actions=actions,
-        linked_source_entries=[],
-    )
-    log_text = (vault / "log.md").read_text(encoding="utf-8")
-    assert "CREATE" in log_text
-    # Log entries reference slugified page paths, e.g. entities/hooks.md.
-    assert "entities/hooks.md" in log_text or "entities/posttoolusefailure.md" in log_text
+class TestTierFilter:
+    def test_tier_1_actions_are_skipped(self, vault: Path):
+        actions = [
+            _action("100", "Tier-1 promotional. Live now.", tier=1),
+            _action("200", "Tier-2 substantive content.", tier=2),
+        ]
+        analyzed_post_ids: list[str] = []
+
+        def fake_analyze(action, **_):
+            analyzed_post_ids.append(action["post_id"])
+            return _delta(VaultAction(
+                op="create", kind="product", name=f"Entity for {action['post_id']}",
+                summary=".", confidence="medium",
+            ))
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            results = apply_memex_pass(
+                vault_path=vault,
+                handle="ClaudeDevs",
+                actions=actions,
+                linked_source_entries=[],
+            )
+
+        # Only tier-2 action got an LLM call
+        assert analyzed_post_ids == ["200"]
+        # The result list contains only the tier-2 entity record
+        post_ids_in_results = {r.get("post_id") for r in results}
+        assert post_ids_in_results == {"200"}
+
+    def test_min_tier_override(self, vault: Path):
+        actions = [
+            _action("a", "tier-2", tier=2),
+            _action("b", "tier-3", tier=3),
+        ]
+        called_with: list[dict] = []
+
+        def fake_analyze(action, **_):
+            called_with.append(action)
+            return _delta()  # empty — no vault writes
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            apply_memex_pass(
+                vault_path=vault, handle="ClaudeDevs",
+                actions=actions, linked_source_entries=[],
+                min_tier=3,
+            )
+        assert [a["post_id"] for a in called_with] == ["b"]
 
 
-def test_memex_pass_handles_per_action_failure_gracefully(vault: Path, monkeypatch):
-    """One bad action must not block the rest."""
-
-    actions = [
-        {"post_id": "100", "text": "MemoryTool is great"},
-        {"post_id": "200", "text": "Skills are awesome"},
-    ]
-
-    real_apply = claude_code_intel_replay.memex_apply_action
-    call_count = {"n": 0}
-
-    def flaky_apply(*args, **kwargs):
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            raise RuntimeError("simulated_first_call_failure")
-        return real_apply(*args, **kwargs)
-
-    monkeypatch.setattr(claude_code_intel_replay, "memex_apply_action", flaky_apply)
-
-    results = apply_memex_pass(
-        vault_path=vault,
-        handle="ClaudeDevs",
-        actions=actions,
-        linked_source_entries=[],
-    )
-    # First call errored — record in results.
-    errors = [r for r in results if r.get("action") == "ERROR"]
-    successes = [r for r in results if r.get("action") in (ACTION_CREATE, ACTION_EXTEND)]
-    assert len(errors) >= 1
-    assert len(successes) >= 1
+# ---------------------------------------------------------------------------
+# Linked-source plumbing (read from disk, dedupe, pass to LLM as text)
+# ---------------------------------------------------------------------------
 
 
-def test_ingest_packet_runs_memex_when_wiring_enabled(monkeypatch, tmp_path: Path):
-    monkeypatch.setenv("UA_CSI_MEMEX_WIRING_ENABLED", "1")
-    artifacts_root = tmp_path / "artifacts"
-    artifacts_root.mkdir()
-    packet_dir = tmp_path / "packet"
-    packet_dir.mkdir()
-    (packet_dir / "manifest.json").write_text("{}", encoding="utf-8")
+class TestLinkedSourceWiring:
+    def test_linked_sources_read_from_disk_and_passed_per_post(
+        self, vault: Path, tmp_path: Path
+    ):
+        # Create two source files for two different posts
+        src_a = tmp_path / "source_a.md"
+        src_a.write_text("Body A — Anthropic docs about prompt caching.")
+        src_b = tmp_path / "source_b.md"
+        src_b.write_text("Body B — different Anthropic doc.")
 
-    posts = [{"id": "100", "text": "MemoryTool launched"}]
-    actions = [{"post_id": "100", "text": "MemoryTool launched", "url": "https://x.com/ClaudeDevs/status/100"}]
+        actions = [
+            _action("aaa", "Post A about caching.", tier=2),
+            _action("bbb", "Post B about something else.", tier=2),
+        ]
+        linked = [
+            _linked_entry("aaa", source_path=str(src_a)),
+            _linked_entry("bbb", source_path=str(src_b)),
+            _linked_entry("aaa", source_path=str(src_b)),  # extra cross-post
+            # An entry that didn't actually fetch successfully — should be skipped
+            _linked_entry("aaa", source_path="/nonexistent/file.md", fetch_status="failed"),
+        ]
 
-    result = ingest_packet_into_external_vault(
-        packet_dir=packet_dir,
-        handle="ClaudeDevs",
-        posts=posts,
-        actions=actions,
-        linked_source_entries=[],
-        artifacts_root=artifacts_root,
-        work_product_dir=None,
-        enabled=True,
-    )
-    assert "memex_actions" in result
-    memex_actions = result["memex_actions"]
-    assert any(r.get("entity_name") == "MemoryTool" for r in memex_actions)
+        captured: dict[str, list[str]] = {}
+
+        def fake_analyze(action, *, linked_sources, **_):
+            captured[action["post_id"]] = list(linked_sources)
+            return _delta()
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            apply_memex_pass(
+                vault_path=vault, handle="ClaudeDevs",
+                actions=actions, linked_source_entries=linked,
+            )
+
+        # Post aaa got Body A first; the cross-post entry pointing at source_b
+        # also gets attached because they're indexed by post_id.
+        assert any("Body A" in t for t in captured["aaa"])
+        assert any("Body B" in t for t in captured["aaa"])
+        # Post bbb got only Body B
+        assert any("Body B" in t for t in captured["bbb"])
+        # The failed-fetch entry never made it into either list
+        assert all("/nonexistent" not in t for t in captured["aaa"])
+
+    def test_dedup_by_source_path(self, vault: Path, tmp_path: Path):
+        """Same source file referenced twice for one post should appear once."""
+        src = tmp_path / "src.md"
+        src.write_text("the body text")
+        actions = [_action("p1", "post text", tier=2)]
+        linked = [
+            _linked_entry("p1", source_path=str(src)),
+            _linked_entry("p1", source_path=str(src)),  # duplicate
+        ]
+
+        captured: list[list[str]] = []
+
+        def fake_analyze(action, *, linked_sources, **_):
+            captured.append(list(linked_sources))
+            return _delta()
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            apply_memex_pass(
+                vault_path=vault, handle="ClaudeDevs",
+                actions=actions, linked_source_entries=linked,
+            )
+        assert len(captured) == 1
+        assert len(captured[0]) == 1  # deduplicated
 
 
-def test_ingest_packet_skips_memex_when_wiring_disabled(monkeypatch, tmp_path: Path):
-    monkeypatch.setenv("UA_CSI_MEMEX_WIRING_ENABLED", "0")
-    artifacts_root = tmp_path / "artifacts"
-    artifacts_root.mkdir()
-    packet_dir = tmp_path / "packet"
-    packet_dir.mkdir()
-    (packet_dir / "manifest.json").write_text("{}", encoding="utf-8")
-
-    posts = [{"id": "100", "text": "MemoryTool launched"}]
-    actions = [{"post_id": "100", "text": "MemoryTool launched"}]
-
-    result = ingest_packet_into_external_vault(
-        packet_dir=packet_dir,
-        handle="ClaudeDevs",
-        posts=posts,
-        actions=actions,
-        linked_source_entries=[],
-        artifacts_root=artifacts_root,
-        work_product_dir=None,
-        enabled=True,
-    )
-    # memex_actions present but empty when wiring is off.
-    assert result.get("memex_actions") == []
+# ---------------------------------------------------------------------------
+# Existing-entities refresh — newly-created slugs visible to next LLM call
+# ---------------------------------------------------------------------------
 
 
-def test_ingest_packet_returns_memex_actions_field_when_disabled_via_enabled_flag(tmp_path: Path):
-    """If ingest itself is disabled (enabled=False), nothing happens at all."""
-    artifacts_root = tmp_path / "artifacts"
-    artifacts_root.mkdir()
-    packet_dir = tmp_path / "packet"
-    packet_dir.mkdir()
-    result = ingest_packet_into_external_vault(
-        packet_dir=packet_dir,
-        handle="ClaudeDevs",
-        posts=[],
-        actions=[],
-        linked_source_entries=[],
-        artifacts_root=artifacts_root,
-        work_product_dir=None,
-        enabled=False,
-    )
-    # Disabled-ingest short-circuit doesn't include memex_actions key.
-    assert result == {"vault_path": "", "pages": [], "email_evidence_ids": []}
+class TestExistingEntitiesRefresh:
+    def test_action2_sees_action1_created_slug(self, vault: Path):
+        """When action #1 creates an entity, action #2's LLM call should
+        receive that new slug in existing_vault_entities. (Otherwise the
+        LLM might emit a duplicate CREATE that the persistence layer has
+        to auto-downgrade.)"""
+        actions = [
+            _action("p1", "First post.", tier=2),
+            _action("p2", "Second post.", tier=2),
+        ]
+        seen_slugs: list[set[str]] = []
+
+        def fake_analyze(action, *, existing_vault_entities, **_):
+            seen_slugs.append(set(existing_vault_entities))
+            return _delta(VaultAction(
+                op="create", kind="product",
+                name=f"Entity {action['post_id']}",
+                summary=".", confidence="medium",
+            ))
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            apply_memex_pass(
+                vault_path=vault, handle="ClaudeDevs",
+                actions=actions, linked_source_entries=[],
+            )
+
+        # First call sees an empty vault
+        assert "entity-p1" not in seen_slugs[0]
+        # Second call sees the slug created by the first action
+        assert "entity-p1" in seen_slugs[1]
+
+
+# ---------------------------------------------------------------------------
+# Persistence integration — VaultDelta ends up as files on disk
+# ---------------------------------------------------------------------------
+
+
+class TestPersistenceIntegration:
+    def test_vault_delta_creates_entity_pages(self, vault: Path):
+        actions = [_action("100", "Multi-feature release.", tier=3)]
+
+        def fake_analyze(action, **_):
+            return _delta(
+                VaultAction(
+                    op="create", kind="product", name="Claude Managed Agents",
+                    summary="Hosted agent runtime.",
+                    source_post_ids=[action["post_id"]],
+                    confidence="high",
+                ),
+                VaultAction(
+                    op="create", kind="feature", name="Outcomes Loop",
+                    summary="Rubric-driven self-improvement.",
+                    source_post_ids=[action["post_id"]],
+                    confidence="high",
+                ),
+                relations=[
+                    VaultRelation(
+                        from_slug="outcomes-loop",
+                        to_slug="claude-managed-agents",
+                        kind="feature-of",
+                    )
+                ],
+                post_summary="Announce managed agents capabilities.",
+            )
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            results = apply_memex_pass(
+                vault_path=vault, handle="ClaudeDevs",
+                actions=actions, linked_source_entries=[],
+                packet_id="2026-05-08/test-packet",
+            )
+
+        # Files on disk
+        assert (vault / "entities" / "claude-managed-agents.md").is_file()
+        assert (vault / "entities" / "outcomes-loop.md").is_file()
+        assert (vault / "relations.jsonl").is_file()
+        assert (vault / "posts.jsonl").is_file()
+
+        # log.md tracks both creations
+        log_md = (vault / "log.md").read_text()
+        assert "entities/claude-managed-agents.md CREATE" in log_md
+        assert "entities/outcomes-loop.md CREATE" in log_md
+
+        # Result records preserve legacy shape
+        ops = [r["action"] for r in results]
+        assert ops.count("CREATE") == 2
+        names = {r["entity_name"] for r in results}
+        assert names == {"Claude Managed Agents", "Outcomes Loop"}
+        for r in results:
+            assert r["post_id"] == "100"
+            assert "page_path" in r
+            assert "memex_kind" in r
+            assert r["memex_kind"] == "entity"  # product/feature both → entity
+            assert "log_note" in r
+
+    def test_packet_id_reaches_frontmatter_tags(self, vault: Path):
+        """packet_id should propagate into the page's frontmatter as a tag."""
+        def fake_analyze(action, **_):
+            return _delta(VaultAction(
+                op="create", kind="concept", name="Some Concept",
+                summary=".", confidence="medium",
+            ))
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            apply_memex_pass(
+                vault_path=vault, handle="ClaudeDevs",
+                actions=[_action("1", "x", tier=2)],
+                linked_source_entries=[],
+                packet_id="2026-05-08/abc__bcherny",
+            )
+        page = (vault / "concepts" / "some-concept.md").read_text()
+        assert "packet:2026-05-08/abc__bcherny" in page
+
+
+# ---------------------------------------------------------------------------
+# Error handling — per-action failures don't sink the batch
+# ---------------------------------------------------------------------------
+
+
+class TestErrorIsolation:
+    def test_analyze_action_failure_surfaces_as_error_record(self, vault: Path):
+        actions = [
+            _action("ok", "First action — fine.", tier=2),
+            _action("bad", "Second action — LLM raises.", tier=2),
+            _action("ok2", "Third action — also fine.", tier=2),
+        ]
+        call_count = {"n": 0}
+
+        def fake_analyze(action, **_):
+            call_count["n"] += 1
+            if action["post_id"] == "bad":
+                raise RuntimeError("simulated LLM failure")
+            return _delta(VaultAction(
+                op="create", kind="product", name=f"Entity {action['post_id']}",
+                summary=".", confidence="medium",
+            ))
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            results = apply_memex_pass(
+                vault_path=vault, handle="ClaudeDevs",
+                actions=actions, linked_source_entries=[],
+            )
+
+        # All three actions were attempted (no early exit on the failure)
+        assert call_count["n"] == 3
+
+        ops = [r["action"] for r in results]
+        assert ops.count("ERROR") == 1
+        assert ops.count("CREATE") == 2
+
+        err = next(r for r in results if r["action"] == "ERROR")
+        assert err["post_id"] == "bad"
+        assert err["stage"] == "analyze_action"
+        assert "RuntimeError" in err["error_type"]
+        assert "simulated LLM failure" in err["error"]
+
+
+# ---------------------------------------------------------------------------
+# UA_CSI_MEMEX_WIRING_ENABLED kill switch
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    def test_disabled_via_env_var(
+        self, vault: Path, tmp_path: Path, monkeypatch
+    ):
+        # Build the minimal fixture ingest_packet_into_external_vault expects
+        packet_dir = tmp_path / "2026-05-08" / "abc__ClaudeDevs"
+        packet_dir.mkdir(parents=True)
+        (packet_dir / "manifest.json").write_text("{}")
+
+        analyze_called = {"n": 0}
+
+        def fake_analyze(action, **_):
+            analyze_called["n"] += 1
+            return _delta()
+
+        monkeypatch.setenv("UA_CSI_MEMEX_WIRING_ENABLED", "0")
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            result = ingest_packet_into_external_vault(
+                packet_dir=packet_dir,
+                handle="ClaudeDevs",
+                posts=[],
+                actions=[_action("1", "tier-2 content", tier=2)],
+                linked_source_entries=[],
+                artifacts_root=tmp_path,
+                work_product_dir=None,
+                enabled=True,
+            )
+
+        # Memex pass should be entirely skipped
+        assert analyze_called["n"] == 0
+        assert result["memex_actions"] == []
+
+    def test_enabled_by_default_runs_memex(
+        self, vault: Path, tmp_path: Path, monkeypatch
+    ):
+        packet_dir = tmp_path / "2026-05-08" / "abc__ClaudeDevs"
+        packet_dir.mkdir(parents=True)
+        (packet_dir / "manifest.json").write_text("{}")
+
+        analyze_called = {"n": 0}
+
+        def fake_analyze(action, **_):
+            analyze_called["n"] += 1
+            return _delta(VaultAction(
+                op="create", kind="product", name="Test Entity",
+                summary=".", confidence="medium",
+            ))
+
+        # No env var override — wiring defaults to enabled
+        monkeypatch.delenv("UA_CSI_MEMEX_WIRING_ENABLED", raising=False)
+
+        with mock.patch(
+            "universal_agent.services.csi_intelligence_pass.analyze_action",
+            side_effect=fake_analyze
+        ):
+            result = ingest_packet_into_external_vault(
+                packet_dir=packet_dir,
+                handle="ClaudeDevs",
+                posts=[],
+                actions=[_action("1", "content", tier=2)],
+                linked_source_entries=[],
+                artifacts_root=tmp_path,
+                work_product_dir=None,
+                enabled=True,
+            )
+        assert analyze_called["n"] == 1
+        assert len(result["memex_actions"]) == 1
+        assert result["memex_actions"][0]["action"] == "CREATE"
+
+
+# ---------------------------------------------------------------------------
+# Module-level smoke — package imports cleanly post-swap
+# ---------------------------------------------------------------------------
+
+
+def test_module_no_longer_has_deleted_regex_helpers():
+    """Ensure the deleted regex helpers don't have lingering references."""
+    for name in (
+        "_MEMEX_TERM_PATTERN",
+        "_MEMEX_TERM_STOPWORDS",
+        "_memex_candidates_for_action",
+        "_memex_body_for_create",
+        "_memex_body_for_extend",
+    ):
+        assert not hasattr(claude_code_intel_replay, name), (
+            f"{name!r} should have been deleted in Phase F but still exists"
+        )


### PR DESCRIPTION
## Summary

Phase F of the CSI extractor redesign — the actual swap. Replaces the regex-based `_memex_candidates_for_action` with a pipeline call to the new LLM-driven CSI intelligence pass (PR #158's Phase A scaffold + PR #159 / #160's Phase E + E.1 persistence helper).

After this ships, every tier-2+ action in every CSI packet replays through GLM-5.1's structured-output `analyze_action()` instead of regex token-spotting.

## Quality story (already validated in Phase D)

50 LLM calls across 4 diverse packets, validated in this session:

- **Zero junk emissions** — no t.co URL slugs, no English stopwords, no joke words from meme tweets
- **Perfect cross-packet canonical-name stability** — `Claude Code` emitted 16× across all 4 packets with identical canonical name; `Claude Managed Agents` 6× across 3 packets; `claude-api skill` 3× across 2 packets
- **Sensible kind taxonomy** — product/feature/concept/person/event preserved as frontmatter tags with confidence ratings

## What changes in `services/claude_code_intel_replay.py`

**Deleted (~150 LoC):**
- `_MEMEX_TERM_PATTERN`, `_MEMEX_TERM_STOPWORDS`
- `_memex_candidates_for_action`
- `_memex_body_for_create`, `_memex_body_for_extend`
- Stale imports (`ACTION_CREATE`, `ACTION_EXTEND`, `memex_apply_action`, `memex_page_exists`)

**Added/rewrote:**
- `_read_linked_source_text` — reads fetched body off disk for the LLM, truncates to 8K chars
- `_existing_vault_slugs` — lists current entities/concepts so the LLM can choose CREATE-vs-EXTEND-vs-REVISE
- `apply_memex_pass` — rewritten to call `analyze_action` (Phase A) then `apply_vault_delta_to_vault` (Phase E) per tier-2+ action; preserves legacy result-list shape; per-action errors collected, never raised
- `packet_id` parameter threaded through from `ingest_packet_into_external_vault` (constructs `"YYYY-MM-DD/HHMMSS__handle"` from `packet_dir`)

**Free incidental fix (line 281):**
- `refine_actions_with_linked_sources` now uses `metadata_path.is_file()` instead of `.exists()`. The 2026-05-07 v2 backfill caught a packet whose `metadata_path` resolved to `'.'` (a directory), and the subsequent `read_text()` raised `IsADirectoryError`. Tracked as Followup #4; fixed here per the Phase F implementation plan.

## Test changes

**Deleted 8 obsolete tests** for the regex helpers (`test_candidates_*`, `test_create_body_*`, `test_extend_body_*`).

**Added 11 tests** covering the new wiring, all mocking `analyze_action`:
- `TestTierFilter` — tier-1 skipped; `min_tier` override honored
- `TestLinkedSourceWiring` — linked sources read from disk per post_id; dedup by source_path
- `TestExistingEntitiesRefresh` — action #2's LLM call sees the slug created by action #1
- `TestPersistenceIntegration` — VaultDelta becomes vault files; packet_id propagates to frontmatter tags
- `TestErrorIsolation` — per-action LLM failure surfaces as `action="ERROR"` record without sinking sibling actions
- `TestKillSwitch` — `UA_CSI_MEMEX_WIRING_ENABLED=0` short-circuits the pass
- `test_module_no_longer_has_deleted_regex_helpers` — belt-and-suspenders that deleted symbols don't sneak back in

## Test plan

- [x] 11 new memex-wiring tests pass
- [x] 34 Phase E persistence tests still pass
- [x] 8 dispatch_source_kind_isolation tests still pass (Followup #3)
- [x] Existing `test_claude_code_intel_replay.py` still passes (no regression)
- [x] `test_csi_url_judge_*` tests still pass
- [x] `test_csi_research_grounding_wiring.py` still passes
- [x] **84 tests total across the affected suite, all green**
- [x] `ruff check` clean
- [x] `py_compile` clean
- [ ] CI green via `pr-validate.yml`
- [ ] Operator review + merge

## What this unblocks

Phase G — full small backfill from a clean v2 vault. Per the implementation plan: `rm -rf` the v2 vault, run `claude_code_intel_backfill_v2` against all 36 packets through the new code path, eyeball quality on 10 random sampled entities. Estimated: ~50-100 LLM calls, ~10-30 min. After Phase G passes, Phase H is the final ship.

## References

- Predecessor PRs: #158 (Phase A scaffold + VaultDelta schema), #159 (Phase E persistence helper), #160 (Phase E.1 self-review followups)
- Architecture: [`docs/proactive_signals/knowledge_extraction_redesign_context_2026-05-07.md`](docs/proactive_signals/knowledge_extraction_redesign_context_2026-05-07.md)
- Phase plan: [`docs/proactive_signals/csi_intelligence_pass_implementation_plan_2026-05-07.md`](docs/proactive_signals/csi_intelligence_pass_implementation_plan_2026-05-07.md)
- Postmortem context: [`docs/operations/2026-05-07_codie_rogue_branch_recovery.md`](docs/operations/2026-05-07_codie_rogue_branch_recovery.md) (the v2 backfill that produced the rogue-branch incident's fallout — same regex extractor we're replacing here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)