### PR TITLE
fix(cody): scrub entire ANTHROPIC_* namespace from demo subprocess env

### DIFF
--- a/src/universal_agent/services/cody_implementation.py
+++ b/src/universal_agent/services/cody_implementation.py
@@ -44,15 +44,25 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-# Env vars that MUST be unset before invoking `claude` from a demo workspace.
-# Their presence in the parent shell would override the project-local
-# settings.json and silently route the request to the ZAI proxy.
-LEAKY_ANTHROPIC_ENV_VARS = (
-    "ANTHROPIC_AUTH_TOKEN",
-    "ANTHROPIC_BASE_URL",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL",
-    "ANTHROPIC_DEFAULT_SONNET_MODEL",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL",
+# Any env var starting with ANTHROPIC_ MUST be unset before invoking `claude`
+# from a demo workspace. The original list was the 5 ZAI routing vars
+# (BASE_URL/AUTH_TOKEN/three model names), but UA Python services that spawn
+# Cody (and therefore become the parent shell of the demo subprocess) also
+# carry ANTHROPIC_API_KEY in their env from Infisical. If that key reaches
+# the demo's `claude` subprocess, Claude Code treats it as an "external API
+# key" overriding OAuth and yields `Invalid API key · Fix external API key`
+# when the staged key isn't for the same Anthropic Max account. Same root
+# cause as the 2026-05-08 interactive launcher fix; same prefix-based
+# resolution. Canonical reference:
+# docs/06_Deployment_And_Environments/10_Interactive_Coding_Environment.md.
+LEAKY_ANTHROPIC_ENV_PREFIX = "ANTHROPIC_"
+
+# Backwards-compat alias kept for any external caller that imported the old
+# constant. New code should reference LEAKY_ANTHROPIC_ENV_PREFIX. The tuple
+# is now derived dynamically from the prefix at module init so it correctly
+# describes the *current* env's leaky vars rather than a stale 5-key list.
+LEAKY_ANTHROPIC_ENV_VARS: tuple[str, ...] = tuple(
+    sorted(k for k in os.environ if k.startswith(LEAKY_ANTHROPIC_ENV_PREFIX))
 )
 
 
@@ -257,11 +267,17 @@ def list_sources(workspace_dir: Path) -> list[Path]:
 
 
 def _scrubbed_env() -> dict[str, str]:
-    """Return os.environ minus the leaky Anthropic vars."""
-    env = dict(os.environ)
-    for var in LEAKY_ANTHROPIC_ENV_VARS:
-        env.pop(var, None)
-    return env
+    """Return os.environ minus every ANTHROPIC_* var.
+
+    Removes the entire ANTHROPIC_* namespace, not a fixed list, so any new
+    Anthropic env var added to Infisical (e.g. ANTHROPIC_VERTEX_PROJECT_ID
+    in the future) is automatically scrubbed without needing a code change
+    here. Same pattern as `scripts/_claude_launcher.py`'s strip helper.
+    """
+    return {
+        k: v for k, v in os.environ.items()
+        if not k.startswith(LEAKY_ANTHROPIC_ENV_PREFIX)
+    }
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_cody_implementation.py
+++ b/tests/unit/test_cody_implementation.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 import os
-import subprocess as sp
-from datetime import datetime, timezone
 from pathlib import Path
+import subprocess as sp
 
 import pytest
 
 from universal_agent.services.cody_implementation import (
+    LEAKY_ANTHROPIC_ENV_PREFIX,
     LEAKY_ANTHROPIC_ENV_VARS,
     BriefingBundle,
     DemoManifest,
@@ -29,7 +30,6 @@ from universal_agent.services.cody_implementation import (
     write_manifest,
     write_run_output,
 )
-
 
 # ── WorkspaceArtifacts shape ────────────────────────────────────────────────
 
@@ -193,9 +193,18 @@ def test_run_in_workspace_executes_and_captures_stdout(tmp_path: Path):
 
 
 def test_run_in_workspace_scrubs_leaky_anthropic_env(tmp_path: Path, monkeypatch):
-    """ANTHROPIC_AUTH_TOKEN must NOT leak into the subprocess by default."""
+    """No ANTHROPIC_* var should leak into the subprocess by default.
+
+    Covers the routing vars (BASE_URL/AUTH_TOKEN), the 2026-05-08-discovered
+    ANTHROPIC_API_KEY (which Claude Code treats as an external API key
+    overriding OAuth), and any future-added Anthropic env var (Vertex,
+    Bedrock, etc.) — the scrub is prefix-based so new vars are caught
+    automatically.
+    """
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "should_not_leak")
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://wrong.example/")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "should_not_leak_either")
+    monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "future-anthropic-var")
     ws = tmp_path / "ws"
     ws.mkdir()
     result = run_in_workspace(
@@ -205,12 +214,16 @@ def test_run_in_workspace_scrubs_leaky_anthropic_env(tmp_path: Path, monkeypatch
             "-c",
             "import os; "
             "print('TOKEN=' + os.environ.get('ANTHROPIC_AUTH_TOKEN', 'unset'));"
-            "print('URL=' + os.environ.get('ANTHROPIC_BASE_URL', 'unset'))",
+            "print('URL=' + os.environ.get('ANTHROPIC_BASE_URL', 'unset'));"
+            "print('KEY=' + os.environ.get('ANTHROPIC_API_KEY', 'unset'));"
+            "print('VTX=' + os.environ.get('ANTHROPIC_VERTEX_PROJECT_ID', 'unset'))",
         ],
         timeout=15,
     )
     assert "TOKEN=unset" in result.stdout
     assert "URL=unset" in result.stdout
+    assert "KEY=unset" in result.stdout
+    assert "VTX=unset" in result.stdout
     assert result.env_scrubbed is True
 
 
@@ -257,10 +270,24 @@ def test_run_in_workspace_respects_timeout(tmp_path: Path):
     assert "timeout" in result.stderr
 
 
-def test_leaky_env_var_list_includes_critical_items():
-    """Catch a future regression that drops one of the must-scrub vars."""
-    for v in ("ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"):
-        assert v in LEAKY_ANTHROPIC_ENV_VARS
+def test_leaky_env_prefix_is_anthropic_namespace():
+    """Scrub target is the entire ANTHROPIC_* namespace, not a fixed list.
+
+    This is the regression guard for the 2026-05-08 finding that the
+    original 5-key list omitted ANTHROPIC_API_KEY (and any other Anthropic
+    env var Infisical might hold). The launcher had the same blind spot
+    and was fixed first; this test enforces that Cody's scrub stays in
+    sync with that lesson.
+    """
+    assert LEAKY_ANTHROPIC_ENV_PREFIX == "ANTHROPIC_"
+
+
+def test_leaky_env_var_list_is_derived_from_prefix(monkeypatch):
+    """LEAKY_ANTHROPIC_ENV_VARS is a backward-compat snapshot of the
+    current env's ANTHROPIC_* keys at import time, not a hardcoded list.
+    Anything that was an ANTHROPIC_* key when the module loaded is in it."""
+    for v in LEAKY_ANTHROPIC_ENV_VARS:
+        assert v.startswith(LEAKY_ANTHROPIC_ENV_PREFIX)
 
 
 # ── detect_endpoint_from_text ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Same root cause and same fix shape as the 2026-05-08 interactive-launcher fix (PR #170), now applied to the Cody-specific code path that spawns `claude` from inside a demo workspace.
- When Cody picks up a `cody_demo_task` and invokes `run_in_workspace(scrub_env=True)`, `_scrubbed_env()` was stripping only 5 hardcoded ZAI routing vars. UA Python services that parent Cody have `ANTHROPIC_API_KEY` in their `os.environ` from Infisical because direct-SDK code paths (`refinement_agent`, `gateway_server` vision endpoint, `proactive_signals`) consume it. That key was leaking into the demo's spawned `claude`, which Claude Code interprets as an "external API key" overriding OAuth — yielding `Invalid API key · Fix external API key` when the staged key isn't for the same Anthropic Max account the demo's vanilla project-local `.claude/settings.json` is OAuthed against.
- **Fix:** switch from the fixed 5-tuple to a prefix-based scrub. `LEAKY_ANTHROPIC_ENV_PREFIX = "ANTHROPIC_"`. `_scrubbed_env()` now filters every key starting with that prefix, so any future Anthropic env var (Vertex, Bedrock, etc.) is automatically scrubbed without a code change here.
- **Backward-compat:** `LEAKY_ANTHROPIC_ENV_VARS` kept as a derived tuple of the current env's `ANTHROPIC_*` keys at module import time. Any external caller still gets a working tuple instead of an `ImportError`.

## Test plan
- [x] `tests/unit/test_cody_implementation.py::test_run_in_workspace_scrubs_leaky_anthropic_env` — extended to cover `ANTHROPIC_API_KEY` (the var that triggered the bug) and `ANTHROPIC_VERTEX_PROJECT_ID` (sentinel for future-added Anthropic vars caught by the prefix scrub).
- [x] `test_leaky_env_var_list_includes_critical_items` replaced with two tests: one asserts the prefix is `"ANTHROPIC_"`; the other verifies every entry in the backward-compat tuple matches the prefix.
- [x] All 33 tests in `test_cody_implementation.py` pass.
- [x] `ruff check` clean (one auto-fix for import ordering applied).
- [x] `py_compile` passes on the modified service module.
- [ ] CI gate `pr-validate.yml` (py_compile + ruff + `tests/unit` + artifact tripwire).

## Followup tracking
- Branch `claude/investigate-cicd-vps-setup-J9ps1` carries an additional doc-cleanup commit (`613c4af8`) that should be PR'd separately. That doc work flagged this Cody finding in `Documentation_Status.md`; this PR resolves it.

https://claude.ai/code/session_01PtaAa7ZGJG2D8xRg7348PC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtaAa7ZGJG2D8xRg7348PC)_