### PR TITLE
chore(memory): session memory snapshot 2026-05-10

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -9,6 +9,7 @@ Persistent context for the agent.
 ## [RECENT_CONTEXT]
 Recent context snapshots (most recent first):
 
+- 2026-05-10T02:37:46.413955+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 909466s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:45:16.135377+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 701116s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:40:06.982338+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 715207s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:39:58.294306+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 700798s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
@@ -18,5 +19,4 @@ Recent context snapshots (most recent first):
 - 2026-05-07T16:34:27.217951+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 714867s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:34:17.183555+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 700457s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:31:30.793702+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 714691s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-05-07T16:17:19.357999+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 713839s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 

--- a/memory/2026-05-10.md
+++ b/memory/2026-05-10.md
@@ -1,0 +1,9 @@
+## 2026-05-10T02:37:46.413955+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 909466s This type of proactive work was productive.
+
+Proactive task completed successfully: Digest proactive task
+Source: proactive_codie | Duration: 909466s
+This type of proactive work was productive.
+

--- a/memory/index.json
+++ b/memory/index.json
@@ -738,5 +738,20 @@
     "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 701116s This type of proactive work was productive.",
     "file_path": "/home/user/universal_agent/memory/2026-05-07.md",
     "content_hash": "f038dcff986a04b63ac2262250e038aa7a6fe37d9018b8d630accd09a941a4cd"
+  },
+  {
+    "entry_id": "d8c52df3-454b-4cb1-b7db-8c09a605b8ca",
+    "timestamp": "2026-05-10T02:37:46.413955+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 909466s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 909466s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-10.md",
+    "content_hash": "620cdb2181620feecbd01957f6798e2fe6380f40f7ddd707871735482368dd1e"
   }
 ]


### PR DESCRIPTION
## Summary

Routine harness session-memory snapshot from the 2026-05-10 develop-removal session. The harness's proactive_codie task system writes structured outcome entries to `MEMORY.md` and `memory/index.json` automatically; the same kind of commit lives in the repo's history (last in `a9d72b04`).

**What's in the diff:** one new memory entry recording successful completion of "Digest proactive task Source: proactive_codie" at 2026-05-10T02:37:46Z.

**Why a separate PR (not folded into PR #181):** the develop-removal PR was already open and CI-validated when the harness wrote this snapshot. Folding it in would have required a CI re-run on a 750-line PR for a 25-line auto-generated chore. Cleaner to keep it isolated.

## Test plan

- [x] No code change → no test impact
- [ ] `pr-validate.yml` will run on this PR (no Python files changed, so py_compile + ruff + pytest pass trivially)
- [ ] `deploy.yml` will be suppressed by `paths-ignore` (the new `memory/**`-adjacent paths fall under `state/**`-style ignored patterns; if not, the post-merge deploy is a no-op restart since no code changed)

https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_