### PR TITLE
fix(hackernews): detect iframe-blocking headers; stop auto-swapping to blank iframe

### DIFF
--- a/src/universal_agent/services/hackernews_article_reader.py
+++ b/src/universal_agent/services/hackernews_article_reader.py
@@ -70,11 +70,12 @@ def fetch_article(url: str, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> dict[str
             "error": "invalid_url",
             "host": "",
             "source_url": url,
+            "iframe_blocked_by_headers": False,
         }
     host = parsed.netloc.removeprefix("www.")
 
     try:
-        html_text = _fetch_html(url, timeout_s=timeout_s)
+        html_text, response_headers = _fetch_html(url, timeout_s=timeout_s)
     except Exception as exc:  # noqa: BLE001 — surface clean error payload
         logger.info("HN reader: fetch failed for %s: %s", url, exc)
         return {
@@ -82,6 +83,12 @@ def fetch_article(url: str, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> dict[str
             "error": f"fetch_failed: {type(exc).__name__}: {exc}",
             "host": host,
             "source_url": url,
+            # We don't know the headers (fetch failed) — but in the operator
+            # UX, "fetch failed" already means "iframe also probably won't
+            # work" because most fetch failures are 4xx/5xx that the iframe
+            # would also surface. Mark as blocked so the UI doesn't auto-swap
+            # to a likely-blank iframe.
+            "iframe_blocked_by_headers": True,
         }
 
     if not html_text:
@@ -90,6 +97,7 @@ def fetch_article(url: str, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> dict[str
             "error": "empty_response",
             "host": host,
             "source_url": url,
+            "iframe_blocked_by_headers": _is_iframe_blocked(response_headers),
         }
 
     soup = BeautifulSoup(html_text, "html.parser")
@@ -109,14 +117,30 @@ def fetch_article(url: str, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> dict[str
         "content_length": len(content_md),
         "fetched_at": datetime.now(timezone.utc).isoformat(),
         "source_url": url,
+        # If the upstream sets X-Frame-Options or a restrictive
+        # Content-Security-Policy frame-ancestors directive, the operator's
+        # browser will refuse to embed the URL in our preview iframe. The
+        # frontend uses this flag to decide whether to auto-swap to
+        # "Original" (iframe) when reader extraction returns empty/error
+        # content, or to instead show the friendly "Open in new tab"
+        # error panel. Catches the twitter.com / x.com / github.com case
+        # where bs4 returns a noscript stub (empty content_md) and the
+        # iframe would also blank out from XFO/CSP — without this flag
+        # we'd silently swap to a blank iframe.
+        "iframe_blocked_by_headers": _is_iframe_blocked(response_headers),
     }
 
 
 # ─── HTTP fetch ────────────────────────────────────────────────────────
 
 
-def _fetch_html(url: str, *, timeout_s: float) -> str:
-    """GET the URL with a browser-like UA; honor MAX_BYTES; return decoded text."""
+def _fetch_html(url: str, *, timeout_s: float) -> tuple[str, dict[str, str]]:
+    """GET the URL with a browser-like UA; honor MAX_BYTES.
+
+    Returns (decoded_html, response_headers_dict). The headers are returned
+    separately so the caller can inspect anti-embedding signals like
+    X-Frame-Options and Content-Security-Policy without re-fetching.
+    """
     headers = {
         "User-Agent": USER_AGENT,
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
@@ -138,10 +162,59 @@ def _fetch_html(url: str, *, timeout_s: float) -> str:
     if len(raw) > MAX_BYTES:
         raw = raw[:MAX_BYTES]
     encoding = resp.encoding or "utf-8"
+    # Lower-case header keys for case-insensitive lookup downstream
+    headers_dict = {k.lower(): v for k, v in resp.headers.items()}
     try:
-        return raw.decode(encoding, errors="replace")
+        return raw.decode(encoding, errors="replace"), headers_dict
     except LookupError:
-        return raw.decode("utf-8", errors="replace")
+        return raw.decode("utf-8", errors="replace"), headers_dict
+
+
+def _is_iframe_blocked(headers: dict[str, str]) -> bool:
+    """Return True if the upstream server sends headers that block iframe embedding.
+
+    We look at two headers:
+
+    * ``X-Frame-Options`` (deprecated but widely used): values ``DENY``,
+      ``SAMEORIGIN``, or ``ALLOW-FROM <uri>`` all block embedding from
+      our origin (we're never same-origin with HN-linked sites and the
+      ALLOW-FROM URI is never us).
+
+    * ``Content-Security-Policy`` ``frame-ancestors`` directive: values
+      ``'none'``, ``'self'``, or any host list that doesn't include
+      our dashboard domain block embedding. We treat ANY frame-ancestors
+      directive as blocking unless it explicitly allows ``*`` or our
+      production hostname.
+
+    False negatives (we say not-blocked but iframe still blanks) are
+    acceptable — the user can still click "Open in new tab". False
+    positives (we say blocked but iframe would have worked) are also
+    acceptable — they just see the friendly error panel instead of a
+    rendered iframe. The cost-of-error tradeoff favors over-blocking.
+    """
+    xfo = (headers.get("x-frame-options") or "").strip().lower()
+    if xfo:
+        # Any X-Frame-Options value blocks us in practice.
+        return True
+
+    csp = (headers.get("content-security-policy") or "").lower()
+    if "frame-ancestors" not in csp:
+        return False
+
+    # Find the frame-ancestors directive value.
+    for directive in csp.split(";"):
+        d = directive.strip()
+        if d.startswith("frame-ancestors"):
+            value = d[len("frame-ancestors"):].strip()
+            if not value:
+                return True
+            # Permissive forms: '*' or our production hostname.
+            if "*" in value.split() or "app.clearspringcg.com" in value:
+                return False
+            # 'none', 'self', or any specific host list that doesn't
+            # include us blocks embedding.
+            return True
+    return False
 
 
 # ─── metadata extraction ───────────────────────────────────────────────

--- a/tests/unit/test_hackernews_article_reader.py
+++ b/tests/unit/test_hackernews_article_reader.py
@@ -199,3 +199,168 @@ def test_strict_max_bytes_truncates_huge_response(monkeypatch: pytest.MonkeyPatc
 
     out = reader.fetch_article("https://example.com/")
     assert out["ok"] is True  # truncated but still parsed
+
+
+# ─── iframe-blocked detection (frontend auto-fallback signal) ───────────
+
+
+def _html_response_with_headers(html: str, extra_headers: dict[str, str]) -> httpx.Response:
+    headers = {"content-type": "text/html; charset=utf-8"}
+    headers.update(extra_headers)
+    return httpx.Response(200, headers=headers, text=html)
+
+
+def test_iframe_blocked_when_xfo_deny(monkeypatch: pytest.MonkeyPatch) -> None:
+    """X-Frame-Options: DENY means the iframe will blank — flag must be True."""
+    html = "<html><body><article><p>content here</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(html, {"x-frame-options": "DENY"}),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["ok"] is True
+    assert out["iframe_blocked_by_headers"] is True
+
+
+def test_iframe_blocked_when_xfo_sameorigin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """X-Frame-Options: SAMEORIGIN blocks us (we're never same-origin with linked sites)."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(html, {"x-frame-options": "SAMEORIGIN"}),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is True
+
+
+def test_iframe_blocked_when_csp_frame_ancestors_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CSP frame-ancestors 'none' blocks all embedding."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(
+            html,
+            {"content-security-policy": "default-src 'self'; frame-ancestors 'none'"},
+        ),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is True
+
+
+def test_iframe_blocked_when_csp_frame_ancestors_self(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CSP frame-ancestors 'self' blocks us (we're never same-origin)."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(
+            html,
+            {"content-security-policy": "frame-ancestors 'self'"},
+        ),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is True
+
+
+def test_iframe_blocked_when_csp_lists_other_hosts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """frame-ancestors with a host list that doesn't include us blocks us."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(
+            html,
+            {"content-security-policy": "frame-ancestors *.theverge.com vox.com"},
+        ),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is True
+
+
+def test_iframe_NOT_blocked_when_csp_wildcard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """frame-ancestors * means anyone can embed — NOT blocked."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(
+            html,
+            {"content-security-policy": "frame-ancestors *"},
+        ),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is False
+
+
+def test_iframe_NOT_blocked_when_csp_includes_our_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If frame-ancestors explicitly allows our prod host, NOT blocked."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(
+            html,
+            {"content-security-policy": "frame-ancestors app.clearspringcg.com"},
+        ),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is False
+
+
+def test_iframe_NOT_blocked_when_no_xfo_or_csp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No anti-embed headers → iframe should work → NOT blocked."""
+    html = "<html><body><article><p>plain content, no XFO</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(html, {}),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is False
+
+
+def test_iframe_blocked_when_csp_has_other_directives_but_no_frame_ancestors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CSP without frame-ancestors doesn't block embedding."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        lambda req: _html_response_with_headers(
+            html,
+            {"content-security-policy": "default-src 'self'; script-src 'self'"},
+        ),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is False
+
+
+def test_iframe_blocked_marker_set_to_true_on_fetch_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On fetch failure (5xx, timeout) we conservatively mark iframe_blocked=True.
+
+    Rationale: most fetch failures from our backend (DNS, 5xx, Akamai 403,
+    timeouts) suggest the iframe load from the user's browser will also
+    fail. Better to show the friendly error panel than auto-swap to a
+    likely-blank iframe.
+    """
+    _patch_transport(monkeypatch, lambda req: httpx.Response(500, text="server error"))
+    out = reader.fetch_article("https://example.com/")
+    assert out["ok"] is False
+    assert out["iframe_blocked_by_headers"] is True
+
+
+def test_invalid_url_iframe_blocked_marker_is_false() -> None:
+    """An invalid URL never goes to fetch — iframe_blocked stays False (and it
+    doesn't matter; the frontend won't try to iframe an invalid URL anyway)."""
+    out = reader.fetch_article("not-a-url")
+    assert out["ok"] is False
+    assert out["iframe_blocked_by_headers"] is False
+
+
+def test_xfo_header_check_is_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Real-world servers send X-Frame-Options in mixed case (e.g. 'X-Frame-Options: deny')."""
+    html = "<html><body><article><p>content</p></article></body></html>"
+    _patch_transport(
+        monkeypatch,
+        # Lower-case header from server (httpx normalizes case but real responses vary)
+        lambda req: _html_response_with_headers(html, {"X-Frame-Options": "deny"}),
+    )
+    out = reader.fetch_article("https://example.com/")
+    assert out["iframe_blocked_by_headers"] is True

--- a/web-ui/app/dashboard/hackernews/page.tsx
+++ b/web-ui/app/dashboard/hackernews/page.tsx
@@ -1061,6 +1061,13 @@ type ArticleData = {
   source_url?: string;
   fetched_at?: string;
   error?: string;
+  // True when the upstream URL's response carries X-Frame-Options or a
+  // restrictive CSP frame-ancestors directive that will cause our preview
+  // iframe to render blank. Used to decide whether to auto-fall-back to
+  // Original (iframe) when reader extraction yields empty content, or to
+  // instead show the friendly "Open in new tab" error panel. See
+  // services/hackernews_article_reader.py:_is_iframe_blocked.
+  iframe_blocked_by_headers?: boolean;
 };
 
 type ReaderStatus = "loading" | "ready" | "error";
@@ -1105,19 +1112,36 @@ function PreviewOverlay({
       .then((data: ArticleData) => {
         if (cancelled) return;
         setArticle(data);
-        if (data.ok && (data.content_md ?? "").trim().length > 0) {
+        const hasReadableContent =
+          data.ok && (data.content_md ?? "").trim().length > 0;
+        if (hasReadableContent) {
           setReaderStatus("ready");
         } else {
-          // Reader couldn't extract anything useful — fall through to iframe.
+          // Reader couldn't extract anything useful. Decide whether to
+          // auto-swap to Original (iframe) — but ONLY if iframe is likely
+          // to actually render. For sites that send X-Frame-Options or a
+          // restrictive CSP frame-ancestors (twitter.com, x.com,
+          // github.com, etc.), the iframe will blank out too and silently
+          // swapping just shows a different blank screen. In that case
+          // keep the user in Reader mode and let the ReaderError panel
+          // surface the "Open in new tab" CTA. See
+          // services/hackernews_article_reader.py for the upstream
+          // iframe_blocked_by_headers detection.
           setReaderStatus("error");
-          setMode("original");
+          if (!data.iframe_blocked_by_headers) {
+            setMode("original");
+          }
         }
       })
       .catch((err) => {
         if (cancelled) return;
         console.warn("HN reader fetch failed:", err);
         setReaderStatus("error");
-        setMode("original");
+        // Same logic as above — if our backend even crashed, we don't
+        // know whether the iframe will work, but the typical "fetch
+        // failed" cases (DNS, timeouts, 5xx) suggest the iframe will
+        // also be unable to load. Don't auto-swap; show the error panel.
+        // The user can still manually toggle to Original via the pill.
       });
     return () => {
       cancelled = true;
@@ -1377,6 +1401,10 @@ function ReaderError({
   sourceUrl: string;
 }) {
   const reason = article?.error || "couldn’t extract reader content";
+  // If we know the upstream blocks iframes too, the "Switch to Original"
+  // suggestion would just hand the user another blank screen. In that
+  // case lead with "open in a new tab" as the primary affordance.
+  const iframeBlocked = article?.iframe_blocked_by_headers === true;
   return (
     <div
       style={{
@@ -1394,20 +1422,52 @@ function ReaderError({
       }}
     >
       <AlertTriangle size={20} color={T.warn} />
-      <div style={{ color: T.t1 }}>Reader-mode extraction failed</div>
-      <div style={{ color: T.t3, fontSize: 11 }}>{reason}</div>
-      <div style={{ color: T.t3, fontSize: 11 }}>
-        Switch to <b style={{ color: T.t1 }}>Original</b> above, or{" "}
-        <a
-          href={sourceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: T.hn, textDecoration: "none" }}
-        >
-          open in a new tab
-        </a>
-        .
+      <div style={{ color: T.t1 }}>
+        {iframeBlocked
+          ? "This site can’t be previewed inline"
+          : "Reader-mode extraction failed"}
       </div>
+      <div style={{ color: T.t3, fontSize: 11, maxWidth: 480 }}>
+        {iframeBlocked ? (
+          <>
+            <b style={{ color: T.t1 }}>{article?.host || "The site"}</b> blocks
+            both reader extraction and iframe embedding (it sends
+            X-Frame-Options or a restrictive CSP). Most modern SaaS sites
+            (twitter, github, x.com, ...) do this.
+          </>
+        ) : (
+          <>{reason}</>
+        )}
+      </div>
+      <a
+        href={sourceUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          marginTop: 4,
+          padding: "6px 14px",
+          borderRadius: 6,
+          border: `1px solid ${T.hnDim}`,
+          background: "rgba(255,102,0,0.08)",
+          color: T.hn,
+          textDecoration: "none",
+          fontFamily: T.fontMono,
+          fontSize: 12,
+          fontWeight: 600,
+        }}
+      >
+        <ExternalLink size={12} />
+        Open in a new tab
+      </a>
+      {!iframeBlocked && (
+        <div style={{ color: T.t3, fontSize: 10.5 }}>
+          (or switch to <b style={{ color: T.t2 }}>Original</b> above to try
+          the iframe view)
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Operator hit blank screens on HN preview overlay despite PR #180's reader-mode landing in production (verified prod runs `22f8567b`, backend extracts content from github.com / chrismorgan.info correctly).

Browser-test diagnostic by general-purpose sub-agent (full curl + playwright pass) found the residual blank is a **new, narrower failure mode introduced by the auto-fallback path**:

| Site | bs4 fetch result | Old frontend reaction | Why it blanks |
|---|---|---|---|
| twitter.com / x.com | `<noscript>JavaScript not available</noscript>` → `ok:true, content_md:""` | `setMode("original")` → iframe | twitter sends `X-Frame-Options: deny` → blank iframe |
| war.gov / Akamai-protected | HTTP 403 → `ok:false` | `setMode("original")` → iframe | upstream serves "Access Denied" → blank-ish iframe |
| github.com (manual click of "Original") | reader extracts cleanly but user toggled | iframe loads | github sends `frame-ancestors 'none'` → blank iframe |

The auto-fallback was supposed to hand the user a working iframe when reader couldn't extract — but for any site that ALSO blocks iframe embedding, it just hands them a different blank screen.

## What changed

**Backend** (`services/hackernews_article_reader.py`)
- `_fetch_html` now returns `(html_text, headers_dict)` — no extra HTTP request, just plumbs the response headers we already have.
- New `_is_iframe_blocked(headers)` helper:
  - `X-Frame-Options`: ANY value blocks (DENY, SAMEORIGIN, ALLOW-FROM `<uri>` — none of those allow our origin in practice)
  - `Content-Security-Policy`: any `frame-ancestors` directive that doesn't explicitly include `*` or `app.clearspringcg.com` blocks
- `fetch_article` payload now includes `iframe_blocked_by_headers: bool` on every code path. On fetch failure (5xx, timeout, Akamai 403) it's conservatively set `True` since the iframe load from the user's browser is also likely to fail.

**Frontend** (`web-ui/app/dashboard/hackernews/page.tsx`)
- `ArticleData` type gains `iframe_blocked_by_headers?: boolean`
- `.then` handler only auto-`setMode("original")` when reader has no usable content **AND** `iframe_blocked_by_headers` is false. When iframe is known-blocked, user stays in Reader mode and the existing `ReaderError` panel surfaces.
- `ReaderError` component adapts copy + CTA to the blocked vs not-blocked case:
  - blocked → "This site can't be previewed inline" + "<host> blocks both reader extraction and iframe embedding (most modern SaaS sites do this)" + prominent **Open in a new tab** pill
  - not-blocked → "Reader-mode extraction failed" + reason + "switch to Original above to try the iframe view" + the same Open-in-new-tab pill

## Test plan

- [x] 12 new unit tests covering `_is_iframe_blocked` (XFO DENY/SAMEORIGIN, CSP `'none'`/`'self'`/host-list/wildcard/our-host, no headers, fetch-failure, case insensitivity). 25 reader tests pass total.
- [x] `ruff check --select E9,F --ignore E402,F401,F541,F811,F841` on changed `.py` files → clean
- [x] `tsc --noEmit -p web-ui` → clean
- [x] Real-network smoke: github.com → `ok:true, content_length:8109, iframe_blocked:true` (correct — GitHub sends `frame-ancestors 'none'` even for readable pages). HN itself sends `X-Frame-Options:DENY` too.
- [ ] **Post-merge:** click a twitter URL on production HN tab — should render a friendly "This site can't be previewed inline" panel instead of blank iframe
- [ ] **Post-merge:** click a github.com URL — Reader mode should still render the README; clicking Original should still show blank (intentional)
- [ ] **Post-merge:** click a regular blog (chrismorgan.info, etc.) — Reader mode should still render the article

https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_