### PR TITLE
chore(deploy): add memory/** to paths-ignore + cleanup followup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,12 @@ on:
       # so a deploy on these commits would just restart the gateway for
       # zero behavior change.
       - 'artifacts/**'
+      # Harness-managed session memory snapshots (memory/index.json,
+      # memory/<date>.md). Auto-written during agent sessions and
+      # periodically committed (e.g. PR #182). Production gateway never
+      # reads these — they're operator-tier state — so a deploy that
+      # only touches memory/ would restart the gateway for nothing.
+      - 'memory/**'
   workflow_dispatch:
 
 jobs:

--- a/tests/unit/test_deploy_prod_workflow_guard.py
+++ b/tests/unit/test_deploy_prod_workflow_guard.py
@@ -83,8 +83,17 @@ def test_deploy_workflow_paths_ignore_suppresses_docs_only_deploys() -> None:
     content = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
 
     assert "paths-ignore:" in content
-    # Keep these exact globs in sync with .github/workflows/deploy.yml's on.push trigger
-    for glob in ("- 'docs/**'", "- '**.md'", "- 'reports/**'", "- 'state/**'", "- 'artifacts/**'"):
+    # Keep these exact globs in sync with .github/workflows/deploy.yml's on.push trigger.
+    # `memory/**` was added 2026-05-10 follow-up after PR #182 merge triggered a
+    # no-op gateway restart for harness session-memory updates.
+    for glob in (
+        "- 'docs/**'",
+        "- '**.md'",
+        "- 'reports/**'",
+        "- 'state/**'",
+        "- 'artifacts/**'",
+        "- 'memory/**'",
+    ):
         assert glob in content, f"paths-ignore missing required glob: {glob}"
 
 


### PR DESCRIPTION
## Summary

Two cleanup items from the post-2026-05-10 ship-flow simplification:

### 1. Add `memory/**` to `deploy.yml` paths-ignore (the actual code change)

PR #182's merge (harness session-memory snapshot) triggered a full production deploy because `memory/index.json` wasn't covered by the existing paths-ignore globs (only `memory/<date>.md` matched the `**.md` glob). Production gateway never reads `memory/*` — it's operator-tier state — so the deploy was a wasted ~3 minutes of service-restart noise.

Adding `'memory/**'` so future memory snapshot merges land on main without restarting services.

Guard test in `test_deploy_prod_workflow_guard.py` updated to pin the new glob (so a future paths-ignore edit can't silently drop it).

### 2. Stale `chore/configure-main-branch-protection` branch on origin (operator action needed)

The failed branch-protection workflow branch from earlier this session is still on origin. The branch's only workflow file triggers on push to *itself*, so it can't auto-trigger again — it's inert. But the branch + the failed run in the Actions history are visible cosmetic clutter.

I tried `git push origin --delete chore/configure-main-branch-protection` from this sandbox three times across two proxy sessions; the local proxy returns HTTP 403 every time (and the github MCP doesn't expose a `delete_branch` tool). **Two-second UI fix on your end:**
1. https://github.com/Kjdragan/universal_agent/branches → click the trash icon next to `chore/configure-main-branch-protection`
2. (Optional) https://github.com/Kjdragan/universal_agent/actions/workflows/configure-main-branch-protection.yml → no follow-up needed; the workflow file is on a branch you just deleted, so it can't run again.

## Test plan

- [x] `pytest tests/unit/test_deploy_prod_workflow_guard.py -v` → 6 passed (incl. updated paths-ignore guard with `memory/**` assertion)
- [ ] PR-Validate CI passes
- [ ] **Verify the no-op deploy suppression actually works:** wait for the next nightly-doc-drift / openclaw-release-sync auto-merged PR; confirm via `gh run list --workflow=deploy.yml -L 1` that the merge does NOT trigger a Deploy run
- [ ] Manual: delete the stale branch via UI per step 2 above

https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_