### PR TITLE
test: add unit tests for _safe_parse_iso and harness helpers

### DIFF
--- a/tests/unit/test_harness_helpers_pure.py
+++ b/tests/unit/test_harness_helpers_pure.py
@@ -1,0 +1,153 @@
+"""Unit tests for pure helper functions in urw/harness_helpers.py.
+
+Covers: compact_agent_context, build_harness_context_injection,
+create_harness_workspace. These are deterministic pure functions
+with no external I/O (except mkdir which uses tmp_path fixtures).
+"""
+
+from pathlib import Path
+
+from universal_agent.urw.harness_helpers import (
+    build_harness_context_injection,
+    compact_agent_context,
+    create_harness_workspace,
+)
+
+
+class TestCompactAgentContext:
+    def test_default_returns_hard_reset(self):
+        result = compact_agent_context(client=None)
+        assert result["keep_client"] is False
+        assert "Hard reset" in result["notes"]
+
+    def test_force_new_client_returns_hard_reset(self):
+        result = compact_agent_context(client=None, force_new_client=True)
+        assert result["keep_client"] is False
+        assert "Explicit" in result["notes"]
+
+    def test_returns_dict_with_required_keys(self):
+        result = compact_agent_context(client="fake")
+        assert "keep_client" in result
+        assert "notes" in result
+
+    def test_keep_client_always_false_in_current_strategy(self):
+        """Both paths return keep_client=False per the hard-reset default."""
+        for force in (True, False):
+            result = compact_agent_context(client=None, force_new_client=force)
+            assert result["keep_client"] is False
+
+
+class TestBuildHarnessContextInjection:
+    def test_minimal_single_phase(self):
+        result = build_harness_context_injection(
+            phase_num=1,
+            total_phases=1,
+            phase_title="Research",
+            phase_instructions="Do the research.",
+            prior_session_paths=[],
+            expected_artifacts=["report.md"],
+        )
+        assert "Phase 1 of 1" in result
+        assert "Research" in result
+        assert "report.md" in result
+
+    def test_multi_phase_shows_prior_paths(self):
+        result = build_harness_context_injection(
+            phase_num=2,
+            total_phases=3,
+            phase_title="Draft",
+            phase_instructions="Write it up.",
+            prior_session_paths=["/tmp/phase1", "/tmp/phase2_prev"],
+            expected_artifacts=[],
+        )
+        assert "Phase 2 of 3" in result
+        assert "/tmp/phase1" in result
+        assert "/tmp/phase2_prev" in result
+
+    def test_overall_goal_included(self):
+        result = build_harness_context_injection(
+            phase_num=1,
+            total_phases=2,
+            phase_title="Research",
+            phase_instructions="Search.",
+            prior_session_paths=[],
+            expected_artifacts=[],
+            overall_goal="Ship the feature.",
+        )
+        assert "Ship the feature." in result
+
+    def test_no_overall_goal_omits_line(self):
+        result = build_harness_context_injection(
+            phase_num=1,
+            total_phases=1,
+            phase_title="Test",
+            phase_instructions="Run tests.",
+            prior_session_paths=[],
+            expected_artifacts=[],
+            overall_goal=None,
+        )
+        assert "Overall Project Goal" not in result
+
+    def test_current_session_path_included(self):
+        result = build_harness_context_injection(
+            phase_num=1,
+            total_phases=1,
+            phase_title="Build",
+            phase_instructions="Code.",
+            prior_session_paths=[],
+            expected_artifacts=[],
+            current_session_path="/workspace/phase1",
+        )
+        assert "/workspace/phase1" in result
+        assert "CURRENT WORKSPACE" in result
+
+    def test_tasks_rendered(self):
+        task = type("Task", (), {
+            "name": "search",
+            "description": "Find sources",
+            "use_case": "Web search",
+            "success_criteria": ["3 sources found"],
+        })()
+        result = build_harness_context_injection(
+            phase_num=1,
+            total_phases=1,
+            phase_title="Search",
+            phase_instructions="Go.",
+            prior_session_paths=[],
+            expected_artifacts=["sources.md"],
+            tasks=[task],
+        )
+        assert "search" in result
+        assert "Find sources" in result
+        assert "Web search" in result
+        assert "3 sources found" in result
+
+    def test_empty_expected_artifacts_shows_success_message(self):
+        result = build_harness_context_injection(
+            phase_num=1,
+            total_phases=1,
+            phase_title="Think",
+            phase_instructions="Contemplate.",
+            prior_session_paths=[],
+            expected_artifacts=[],
+        )
+        assert "Complete the phase successfully" in result
+
+
+class TestCreateHarnessWorkspace:
+    def test_creates_dir_with_auto_id(self, tmp_path):
+        result = create_harness_workspace(tmp_path)
+        assert result.exists()
+        assert result.parent == tmp_path
+        assert result.name.startswith("harness_")
+
+    def test_creates_dir_with_explicit_id(self, tmp_path):
+        result = create_harness_workspace(tmp_path, harness_id="my_test")
+        assert result == tmp_path / "harness_my_test"
+        assert result.exists()
+
+    def test_idempotent_on_existing_dir(self, tmp_path):
+        first = create_harness_workspace(tmp_path, harness_id="dup")
+        second = create_harness_workspace(tmp_path, harness_id="dup")
+        assert first == second
+        assert first.exists()

--- a/tests/unit/test_mission_control_tiles_safe_parse_iso.py
+++ b/tests/unit/test_mission_control_tiles_safe_parse_iso.py
@@ -1,0 +1,66 @@
+"""Unit tests for _safe_parse_iso in mission_control_tiles.py.
+
+Covers: naive SQLite strings, ISO 8601 with Z suffix, timezone-aware
+strings, empty/None inputs, and malformed values.
+"""
+
+from datetime import datetime, timezone
+
+from universal_agent.services.mission_control_tiles import _safe_parse_iso
+
+
+class TestSafeParseIso:
+    def test_none_returns_none(self):
+        assert _safe_parse_iso(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _safe_parse_iso("") is None
+
+    def test_whitespace_returns_none(self):
+        assert _safe_parse_iso("   ") is None
+
+    def test_sqlite_naive_string_becomes_utc(self):
+        """SQLite datetime('now') produces naive 'YYYY-MM-DD HH:MM:SS'."""
+        result = _safe_parse_iso("2026-05-10 14:30:00")
+        assert result is not None
+        assert result == datetime(2026, 5, 10, 14, 30, 0, tzinfo=timezone.utc)
+
+    def test_iso_with_z_suffix(self):
+        result = _safe_parse_iso("2026-05-10T14:30:00Z")
+        assert result is not None
+        assert result.tzinfo is not None
+        assert result.year == 2026
+
+    def test_iso_with_utc_offset(self):
+        result = _safe_parse_iso("2026-05-10T14:30:00+00:00")
+        assert result is not None
+        assert result.tzinfo is not None
+
+    def test_iso_with_negative_offset(self):
+        result = _safe_parse_iso("2026-05-10T09:30:00-05:00")
+        assert result is not None
+        assert result.tzinfo is not None
+        assert result.utcoffset().total_seconds() == -5 * 3600
+
+    def test_naive_string_gets_utc_tzinfo(self):
+        result = _safe_parse_iso("2026-01-01 00:00:00")
+        assert result is not None
+        assert result.tzinfo == timezone.utc
+
+    def test_malformed_string_returns_none(self):
+        assert _safe_parse_iso("not-a-date") is None
+
+    def test_partial_date_returns_none(self):
+        assert _safe_parse_iso("2026-05") is None
+
+    def test_microseconds_preserved(self):
+        result = _safe_parse_iso("2026-05-10T14:30:00.123456+00:00")
+        assert result is not None
+        assert result.microsecond == 123456
+
+    def test_roundtrip_consistency(self):
+        """A UTC ISO string round-trips cleanly."""
+        original = "2026-05-10T14:30:00+00:00"
+        parsed = _safe_parse_iso(original)
+        assert parsed is not None
+        assert parsed.isoformat() == original


### PR DESCRIPTION
## Summary

Adds 26 focused unit tests covering two under-tested pure helper areas:

- **`_safe_parse_iso`** (`mission_control_tiles.py`) — 12 tests for the ISO timestamp parser used by multiple Mission Control tile `compute_state()` methods. Covers naive SQLite strings, ISO 8601 with Z/offset suffixes, None/empty/malformed inputs, microsecond preservation, and roundtrip consistency. Previously had zero direct tests.

- **`harness_helpers.py` pure functions** — 14 tests for:
  - `compact_agent_context`: both `force_new_client` paths, required dict keys, hard-reset strategy invariant
  - `build_harness_context_injection`: phase numbering, prior session paths, overall goal inclusion/omission, current session path, task rendering, empty artifacts fallback
  - `create_harness_workspace`: auto-generated ID, explicit ID, idempotency on existing dir

## Changed Files

| File | Change |
|------|--------|
| `tests/unit/test_mission_control_tiles_safe_parse_iso.py` | New — 12 tests |
| `tests/unit/test_harness_helpers_pure.py` | New — 14 tests |

## Tests Run

All 26 new tests pass. Ruff lint clean. Full unit suite has one pre-existing unrelated failure in `test_claude_code_intel.py`.

## Red-Green Evidence

Mechanical-only test addition for pure functions — no behavioral code changes, so red-green TDD is not applicable. Tests exercise existing untested code paths and all pass against current implementation.

## Risks

None. Pure test additions with no production code changes.

## Rollback

Single commit revert. No migration, no config, no deployment impact.

## Scope

Low complexity. Two new test files, no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
