### PR TITLE
chore(tests): add unit tests for json_utils and safe_slug

### DIFF
--- a/tests/unit/test_json_utils.py
+++ b/tests/unit/test_json_utils.py
@@ -1,0 +1,110 @@
+"""Unit tests for utils/json_utils.py — 5-layer JSON extraction."""
+
+from pydantic import BaseModel
+import pytest
+
+from universal_agent.utils.json_utils import extract_json_payload
+
+# ── Pydantic model fixtures ──────────────────────────────────────────────
+
+
+class SampleModel(BaseModel):
+    name: str
+    count: int
+
+
+# ── Layer 0/1: standard JSON ─────────────────────────────────────────────
+
+
+class TestStandardParse:
+    def test_valid_dict(self):
+        result = extract_json_payload('{"a": 1}')
+        assert result == {"a": 1}
+
+    def test_valid_list(self):
+        result = extract_json_payload("[1, 2, 3]")
+        assert result == [1, 2, 3]
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            extract_json_payload("")
+
+    def test_none_raises(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            extract_json_payload(None)
+
+    def test_non_string_raises(self):
+        with pytest.raises(ValueError, match="non-empty string"):
+            extract_json_payload(42)
+
+
+# ── Layer 0: Python literal normalization ─────────────────────────────────
+
+
+class TestPythonLiteralNormalization:
+    def test_true_false_none(self):
+        result = extract_json_payload('{"ok": True, "fail": False, "val": None}')
+        assert result == {"ok": True, "fail": False, "val": None}
+
+    def test_mixed_python_literals(self):
+        result = extract_json_payload('{"a": True, "b": None, "c": False}')
+        assert result["a"] is True
+        assert result["b"] is None
+        assert result["c"] is False
+
+
+# ── Layer 2: json_repair recovery ────────────────────────────────────────
+
+
+class TestJsonRepair:
+    def test_trailing_comma(self):
+        result = extract_json_payload('{"a": 1,}')
+        assert result == {"a": 1}
+
+    def test_unquoted_keys(self):
+        result = extract_json_payload('{a: 1, b: "hello"}')
+        assert result == {"a": 1, "b": "hello"}
+
+
+# ── Layer 3: regex extraction from surrounding text ──────────────────────
+
+
+class TestRegexExtraction:
+    def test_json_wrapped_in_markdown(self):
+        text = 'Here is the result:\n```json\n{"key": "value"}\n```\nDone.'
+        result = extract_json_payload(text)
+        assert result == {"key": "value"}
+
+    def test_json_in_conversational_text(self):
+        text = 'The answer is {"status": "ok", "data": [1, 2]} as discussed.'
+        result = extract_json_payload(text)
+        assert result["status"] == "ok"
+
+    def test_no_json_raises(self):
+        with pytest.raises(ValueError, match="Failed to extract"):
+            extract_json_payload("This is just plain text with no JSON at all.")
+
+
+# ── Layer 5: Pydantic validation ─────────────────────────────────────────
+
+
+class TestPydanticValidation:
+    def test_valid_model(self):
+        result = extract_json_payload('{"name": "test", "count": 5}', model=SampleModel)
+        assert isinstance(result, SampleModel)
+        assert result.name == "test"
+        assert result.count == 5
+
+    def test_model_validation_fails_returns_dict(self):
+        """When require_model=False (default), return raw dict on validation failure."""
+        result = extract_json_payload('{"name": "test"}', model=SampleModel)
+        assert isinstance(result, dict)
+        assert result == {"name": "test"}
+
+    def test_require_model_raises_on_bad_schema(self):
+        with pytest.raises(ValueError, match="did not match required schema"):
+            extract_json_payload('{"name": "test"}', model=SampleModel, require_model=True)
+
+    def test_no_model_returns_dict(self):
+        result = extract_json_payload('{"anything": "goes"}')
+        assert isinstance(result, dict)

--- a/tests/unit/test_safe_slug.py
+++ b/tests/unit/test_safe_slug.py
@@ -1,0 +1,58 @@
+"""Unit tests for utils/session_workspace.py — safe_slug helper."""
+
+import pytest
+
+from universal_agent.utils.session_workspace import safe_slug
+
+
+class TestSafeSlug:
+    def test_simple_text(self):
+        assert safe_slug("hello world") == "hello_world"
+
+    def test_empty_returns_fallback(self):
+        assert safe_slug("") == "run"
+
+    def test_none_returns_fallback(self):
+        assert safe_slug(None) == "run"
+
+    def test_whitespace_only_returns_fallback(self):
+        assert safe_slug("   ") == "run"
+
+    def test_special_characters_replaced_with_underscore(self):
+        # Each run of non-alphanumeric chars becomes a single _
+        assert safe_slug("foo!@#$%bar") == "foo_bar"
+
+    def test_leading_trailing_dots_stripped(self):
+        assert safe_slug("...test...") == "test"
+
+    def test_leading_trailing_hyphens_stripped(self):
+        assert safe_slug("--test--") == "test"
+
+    def test_custom_fallback(self):
+        assert safe_slug("", fallback="default") == "default"
+
+    def test_max_len_truncates(self):
+        long_text = "a" * 200
+        result = safe_slug(long_text, max_len=50)
+        assert len(result) == 50
+
+    def test_dots_and_hyphens_preserved(self):
+        assert safe_slug("my-file_v2.0") == "my-file_v2.0"
+
+    def test_all_special_chars_returns_fallback(self):
+        assert safe_slug("!@#$%^&*()") == "run"
+
+    def test_mixed_content_collapses_runs(self):
+        # Comma+space collapses to single _
+        assert safe_slug("Hello, World! 2024") == "Hello_World_2024"
+
+    def test_tabs_and_newlines(self):
+        assert safe_slug("hello\tworld\nfoo") == "hello_world_foo"
+
+    def test_max_len_default_80(self):
+        long_text = "a" * 200
+        result = safe_slug(long_text)
+        assert len(result) == 80
+
+    def test_unicode_preserved(self):
+        assert safe_slug("café") == "caf"


### PR DESCRIPTION
## Summary

Adds 31 lightweight unit tests covering two previously untested utility helper modules:

- **`utils/json_utils.py`** — `extract_json_payload()` 5-layer extraction pipeline
- **`utils/session_workspace.py`** — `safe_slug()` path-sanitization helper

## Changed Files

| File | Change |
|---|---|
| `tests/unit/test_json_utils.py` | NEW — 16 tests |
| `tests/unit/test_safe_slug.py` | NEW — 15 tests |

No production code was modified.

## Tests Run

```
uv run pytest tests/unit/test_json_utils.py tests/unit/test_safe_slug.py -v
# 31 passed in 0.15s
```

Full suite: 315 passed (1 pre-existing failure in `test_claude_code_intel`, unrelated).

Lint: `uv run ruff check` — clean.

## Red-Green Evidence

Two `test_safe_slug` tests initially failed because my expectations for consecutive-special-character collapsing were wrong (the regex `_SAFE_SLUG_RE.sub("_", ...)` replaces each run of non-alphanumerics with a single `_`, not character-by-character). Fixed the test expectations to match actual behavior — no production code changes needed.

## Why These Modules

`extract_json_payload` is the system's JSON extraction workhorse with a complex 5-layer pipeline (standard parse, Python literal normalization, json_repair, regex extraction, Pydantic validation). It had zero test coverage despite being called from multiple research and intelligence services. `safe_slug` is used for workspace path construction everywhere — also untested.

## Risks

None. Test-only change, no production code modified.

## Rollback

`git revert` the merge commit.

## Scope Complexity

Low. Pure function testing only, no mocking, no external dependencies, no subsystem changes.

---

🤖 Generated by **Codie** (vp.coder.primary) — proactive cleanup task.