### PR TITLE
docs(claude): wire 'Awesome Screenshots' Drive folder into session bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,31 @@ When executing on the VPS (`uaonvps`), agents have direct, native filesystem acc
 - **Capability Implication**: **Never** build custom "file fetcher" tools or syncing scripts to move files from the desktop to the VPS for agent tasks. Instead, simply refer to the absolute `/home/kjdragan/...` path directly. Standard OS operations (`cat`, Python `open()`, etc.) will seamlessly resolve over the SSHFS mount.
 - **Architectural Tenet**: This demonstrates the core design philosophy of "expanding system capabilities at the OS level" rather than building complex, brittle agent workarounds.
 
+## Screenshot Access (Google Drive Bridge)
+
+Claude Code sandbox sessions (the web/IDE chat ones, not VPS-running agents) cannot reach the SSHFS bridge above — those sessions run in isolated containers without `/home/kjdragan/`. To give every session a uniform way to resolve "the latest screenshot," screenshots are auto-uploaded to a dedicated Google Drive folder.
+
+**Canonical folder:** `Awesome Screenshots` (Kevin's Drive root)
+- Folder ID: `1PM22v6FKY7Z8ukJA83LF3Ru_xGw7_S9I`
+- URL: https://drive.google.com/drive/folders/1PM22v6FKY7Z8ukJA83LF3Ru_xGw7_S9I
+
+**When the operator says "look at my latest screenshot" / "the latest saved screenshot" / similar:**
+
+1. Search the canonical folder, sorted by most recent:
+   ```
+   mcp__33c2a029-2ddb-4320-9fba-2d9695495b50__search_files
+     query: "parentId = '1PM22v6FKY7Z8ukJA83LF3Ru_xGw7_S9I' and (mimeType contains 'image/' or mimeType = 'image/png' or mimeType = 'image/jpeg')"
+     pageSize: 5
+     orderBy: "modifiedTime desc"  (note: orderBy may not be honored — the API defaults to 'recency' which is similar; sort the response client-side by modifiedTime if needed)
+   ```
+2. Take the first result (highest `modifiedTime`).
+3. Read it via `mcp__33c2a029-2ddb-4320-9fba-2d9695495b50__read_file_content { fileId: <id> }` — that returns a natural-language description of the image (which is what we need to "see" what's in it). For raw binary, use `download_file_content` instead.
+
+**Operator-side setup (one-time, on the desktop):**
+The Awesome Screenshot Chrome extension has a built-in Google Drive integration. Enable it in the extension settings, authorize the same Google account that owns this Drive, and set the upload destination to the `Awesome Screenshots` folder above. From then on, every screenshot the operator captures auto-uploads to the canonical folder and any agent session can resolve it via the search above.
+
+**Fallback if the bridge is broken** (e.g., extension auth lapsed, folder renamed, file not appearing): the operator can still drag the screenshot directly into the Claude Code chat as an attachment — that always works.
+
 ## Key Commands
 - Install deps: `uv sync`
 - Run app: `uv run python -m src.universal_agent.main`


### PR DESCRIPTION
## Summary

Wires a Google Drive folder into CLAUDE.md as the canonical "latest screenshot" source, so any Claude Code sandbox session can resolve operator phrases like "look at the latest screenshot" without depending on the desktop SSHFS bridge (which doesn't reach sandbox containers).

## What changed

- New section in `CLAUDE.md` — **"Screenshot Access (Google Drive Bridge)"** — added directly after the existing SSHFS section so they're read together as complementary file-resolution mechanisms
- Records the folder ID `1PM22v6FKY7Z8ukJA83LF3Ru_xGw7_S9I` (created in Kevin's Drive root via the Drive MCP at 2026-05-10T16:50:45Z)
- Documents the exact `mcp__33c2a029-2ddb-4320-9fba-2d9695495b50__search_files` query future sessions run
- Notes the one-time operator setup (enable Awesome Screenshot Chrome extension's Google Drive integration, point it at the canonical folder)
- Documents the always-works fallback (drag PNG into chat)

## Why

Multiple sessions in the past have hit "operator says look at the screenshot → agent has no way to reach the desktop → operator has to drag the file in or describe the screenshot in words." This codifies the bridge so it's a one-line lookup forever.

Companion to the existing SSHFS section: SSHFS handles VPS-running agents (Simone/Cody/Atlas); Drive handles Claude Code sandbox sessions where SSHFS isn't reachable.

## Test plan

- [x] Folder created (verified via Drive MCP response: id, mimeType: vnd.google-apps.folder, owner: kevinjdragan@gmail.com)
- [ ] Operator-side: enable Awesome Screenshot's Google Drive integration, point it at the new folder
- [ ] First time operator says "look at the latest screenshot" after the extension is configured: verify the search query returns the new file and `read_file_content` extracts the visual description

https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_