### PR TITLE
docs(claude): clarify VPS interactive user is `ua`, not `kjdragan`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ The Universal Agent infrastructure includes a seamless, transparent file resolut
 
 When executing on the VPS (`uaonvps`), agents have direct, native filesystem access to the local desktop environment at the exact same path.
 
+- **The VPS user**: interactive Claude Code on the VPS runs as system user `ua` (not `kjdragan`). Reach the VPS with `ssh ua@uaonvps`. The `/home/kjdragan/...` paths below are an SSHFS mount point — `ua` can read those paths via the mount; there's no `kjdragan` user account on the VPS itself. Global `~/.claude/CLAUDE.md` for VPS interactive sessions therefore lives at `/home/ua/.claude/CLAUDE.md`.
 - **The Path Guarantee**: The local desktop path `/home/kjdragan/...` is mounted onto the VPS at `/home/kjdragan/...`.
 - **Capability Implication**: **Never** build custom "file fetcher" tools or syncing scripts to move files from the desktop to the VPS for agent tasks. Instead, simply refer to the absolute `/home/kjdragan/...` path directly. Standard OS operations (`cat`, Python `open()`, etc.) will seamlessly resolve over the SSHFS mount.
 - **Architectural Tenet**: This demonstrates the core design philosophy of "expanding system capabilities at the OS level" rather than building complex, brittle agent workarounds.


### PR DESCRIPTION
## Summary

One-line clarification in CLAUDE.md's SSHFS section that the VPS interactive user is `ua`, not `kjdragan`. Prevents the same guess-the-user mistake I just made (suggested `kjdragan@uaonvps` for a Tier 2 paste; right answer is `ua@uaonvps`, which other docs already say).

## Diff

Adds one bullet at the top of the SSHFS section:

```markdown
- **The VPS user**: interactive Claude Code on the VPS runs as system user `ua` (not `kjdragan`). Reach the VPS with `ssh ua@uaonvps`. The `/home/kjdragan/...` paths below are an SSHFS mount point — `ua` can read those paths via the mount; there's no `kjdragan` user account on the VPS itself. Global `~/.claude/CLAUDE.md` for VPS interactive sessions therefore lives at `/home/ua/.claude/CLAUDE.md`.
```

The mount-point paths section (`/home/kjdragan/...`) stays unchanged — it's correct as-is. The added bullet just disambiguates that the path name doesn't imply a `kjdragan` user account.

https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_