### PR TITLE
feat(dispatch): wire release_stale_assignments into dispatch_sweep (Hermes Phase A.2)

### DIFF
--- a/src/universal_agent/services/dispatch_service.py
+++ b/src/universal_agent/services/dispatch_service.py
@@ -34,9 +34,16 @@ def _stale_sweep_enabled() -> bool:
 
 
 def _stale_after_seconds() -> int:
+    """Resolve the per-sweep stale-cutoff in seconds.
+
+    Env: ``UA_DISPATCH_STALE_AFTER_SECONDS`` (default 1800 = 30 minutes).
+    Floored at 60s — anything tighter than a minute risks releasing
+    assignments mid-tick during normal heartbeat cadence. Falls back to
+    1800 on parse errors (e.g., operator typo).
+    """
     raw = (os.getenv("UA_DISPATCH_STALE_AFTER_SECONDS") or "1800").strip()
     try:
-        return max(60, int(raw))  # 60s floor — anything tighter is dangerous
+        return max(60, int(raw))
     except ValueError:
         return 1800
 

--- a/src/universal_agent/services/dispatch_service.py
+++ b/src/universal_agent/services/dispatch_service.py
@@ -13,12 +13,90 @@ Simone is the primary orchestrator and decides delegation via batch triage.
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 from universal_agent import task_hub
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Stale-assignment release (Hermes-adaptation Phase A.2)
+# ---------------------------------------------------------------------------
+
+
+def _stale_sweep_enabled() -> bool:
+    """Phase A.2 feature gate. Defaults to ON; operator can disable via env."""
+    raw = (os.getenv("UA_DISPATCH_STALE_SWEEP_ENABLED") or "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _stale_after_seconds() -> int:
+    raw = (os.getenv("UA_DISPATCH_STALE_AFTER_SECONDS") or "1800").strip()
+    try:
+        return max(60, int(raw))  # 60s floor — anything tighter is dangerous
+    except ValueError:
+        return 1800
+
+
+def _release_stale_for_sweep(
+    conn: sqlite3.Connection,
+    *,
+    provider_session_id: Optional[str],
+    additional_running_sessions: Optional[Iterable[str]] = None,
+    agent_id_prefix: Any = ("heartbeat:", "todo:"),
+) -> None:
+    """Top-of-sweep stale-assignment release. Hermes-adaptation Phase A.2.
+
+    Mirrors Hermes' ``release_stale_claims`` call at the top of each
+    ``dispatch_once`` tick (``kanban_db.py:3658``). Mode of operation:
+
+    * Reads ``UA_DISPATCH_STALE_SWEEP_ENABLED`` (default on) and
+      ``UA_DISPATCH_STALE_AFTER_SECONDS`` (default 1800).
+    * Builds an exclude set from ``provider_session_id`` (the current caller)
+      plus any ``additional_running_sessions`` caller provides. This protects
+      live sessions from accidental release when a heartbeat tick takes
+      longer than the stale-cutoff.
+    * Calls ``task_hub.release_stale_assignments`` with the exclude set.
+    * Logs the outcome for ops visibility; never raises into the caller.
+
+    Best-effort — failures here must not block the actual claim that follows.
+    """
+    if not _stale_sweep_enabled():
+        return
+    excluded: set[str] = set()
+    if provider_session_id:
+        text = str(provider_session_id).strip()
+        if text:
+            excluded.add(text)
+    if additional_running_sessions:
+        try:
+            for v in additional_running_sessions:
+                t = str(v).strip()
+                if t:
+                    excluded.add(t)
+        except TypeError:
+            pass
+    try:
+        result = task_hub.release_stale_assignments(
+            conn,
+            agent_id_prefix=agent_id_prefix,
+            stale_after_seconds=_stale_after_seconds(),
+            exclude_session_ids=excluded if excluded else None,
+        )
+    except Exception as exc:  # noqa: BLE001 — never block the sweep
+        log.warning("dispatch_sweep: stale-release pass failed: %s", exc)
+        return
+    if result.get("stale_detected") or result.get("skipped_live"):
+        log.info(
+            "dispatch_sweep stale-release: detected=%s finalized=%s reopened=%s skipped_live=%s",
+            result.get("stale_detected", 0),
+            result.get("finalized", 0),
+            result.get("reopened", 0),
+            result.get("skipped_live", 0),
+        )
 
 
 class DispatchError(Exception):
@@ -197,6 +275,7 @@ def dispatch_sweep(
     provider_session_id: Optional[str] = None,
     workspace_dir: Optional[str] = None,
     forbidden_source_kinds: Optional[list[str]] = None,
+    additional_running_sessions: Optional[Iterable[str]] = None,
 ) -> list[dict[str, Any]]:
     """Generic sweep dispatch — wraps claim_next_dispatch_tasks.
 
@@ -208,7 +287,23 @@ def dispatch_sweep(
     runtime. Notably, ``daemon_simone_todo`` should pass
     ``forbidden_source_kinds=["vp_mission"]`` so it won't claim VP-mirror
     rows that should be executed by VP workers (Followup #3 backstop).
+
+    ``additional_running_sessions`` (Hermes-adaptation Phase A.2): optional
+    iterable of ``provider_session_id`` values for sessions known to be live.
+    These are excluded from the stale-assignment release pass that runs at
+    the top of every sweep. The calling session (``provider_session_id``) is
+    auto-excluded. Pass ``heartbeat_service.busy_sessions``-style sets when
+    available so a long-running tick doesn't accidentally release peers.
     """
+    # Top-of-sweep stale-release pass (Phase A.2 wiring). Gated by env, runs
+    # before the claim so any reopened tasks are eligible in the very next
+    # queue rebuild this sweep performs.
+    _release_stale_for_sweep(
+        conn,
+        provider_session_id=provider_session_id,
+        additional_running_sessions=additional_running_sessions,
+    )
+
     claimed = task_hub.claim_next_dispatch_tasks(
         conn,
         limit=limit,

--- a/src/universal_agent/task_hub.py
+++ b/src/universal_agent/task_hub.py
@@ -3262,7 +3262,18 @@ def release_stale_assignments(
     agent_id_prefix: Any = "heartbeat:",
     stale_after_seconds: int = 1800,
     limit: int = 500,
+    exclude_session_ids: Optional[Any] = None,
 ) -> dict[str, int]:
+    """Release seized/running assignments older than ``stale_after_seconds``.
+
+    ``exclude_session_ids`` (Hermes-adaptation Phase A.2): an optional
+    iterable of ``provider_session_id`` values to skip even when their
+    assignments are age-eligible. Used by ``dispatch_sweep`` to protect the
+    *calling* session (and any other known-live sessions) from accidental
+    release when this function is called inline from a heartbeat tick. The
+    default (``None`` / empty) preserves backward-compat behavior for manual
+    operator triggers and ops scripts.
+    """
     ensure_schema(conn)
     stale_after_seconds = max(1, int(stale_after_seconds))
     raw_prefixes = agent_id_prefix
@@ -3273,11 +3284,25 @@ def release_stale_assignments(
     if not prefixes:
         prefixes = ["heartbeat:"]
 
+    # Normalize the exclude set. Accept any iterable; coerce to non-empty strings.
+    excluded: set[str] = set()
+    if exclude_session_ids is not None:
+        try:
+            for v in exclude_session_ids:
+                text = str(v).strip()
+                if text:
+                    excluded.add(text)
+        except TypeError:
+            # Single string accidentally passed without wrapping — treat as one item.
+            text = str(exclude_session_ids).strip()
+            if text:
+                excluded.add(text)
+
     clauses = " OR ".join("agent_id LIKE ?" for _ in prefixes)
     params = tuple(f"{prefix}%" for prefix in prefixes) + (max(1, int(limit)),)
     rows = conn.execute(
         f"""
-        SELECT assignment_id, started_at
+        SELECT assignment_id, started_at, provider_session_id
         FROM task_hub_assignments
         WHERE state IN ('seized', 'running')
           AND ({clauses})
@@ -3289,17 +3314,24 @@ def release_stale_assignments(
 
     now_dt = datetime.now(timezone.utc)
     stale_ids: list[str] = []
+    skipped_live = 0
     for row in rows:
         assignment_id = str(row["assignment_id"] or "").strip()
         started_at = _parse_iso(row["started_at"])
         if not assignment_id or started_at is None:
             continue
         age_seconds = (now_dt - started_at).total_seconds()
-        if age_seconds >= stale_after_seconds:
-            stale_ids.append(assignment_id)
+        if age_seconds < stale_after_seconds:
+            continue
+        # Skip assignments whose session is in the caller-supplied live set.
+        session_id = str(row["provider_session_id"] or "").strip()
+        if session_id and session_id in excluded:
+            skipped_live += 1
+            continue
+        stale_ids.append(assignment_id)
 
     if not stale_ids:
-        return {"stale_detected": 0, "finalized": 0, "reopened": 0}
+        return {"stale_detected": 0, "finalized": 0, "reopened": 0, "skipped_live": skipped_live}
 
     result = finalize_assignments(
         conn,
@@ -3312,6 +3344,7 @@ def release_stale_assignments(
         "stale_detected": len(stale_ids),
         "finalized": int(result.get("finalized") or 0),
         "reopened": int(result.get("reopened") or 0),
+        "skipped_live": skipped_live,
     }
 
 

--- a/tests/unit/test_dispatch_sweep_stale_release.py
+++ b/tests/unit/test_dispatch_sweep_stale_release.py
@@ -1,0 +1,441 @@
+"""Phase A.2 — stale-assignment release wired into ``dispatch_sweep``.
+
+Verifies the wiring added in
+``docs/reports/hermes-adaptation-phased-plan-2026-05-10.md`` Phase A.2:
+
+* ``release_stale_assignments`` gains an ``exclude_session_ids`` parameter.
+* ``dispatch_sweep`` calls it before each claim with the caller's
+  ``provider_session_id`` (plus any ``additional_running_sessions``) as the
+  exclude set, gated by ``UA_DISPATCH_STALE_SWEEP_ENABLED`` (default on) and
+  ``UA_DISPATCH_STALE_AFTER_SECONDS`` (default 1800, 60s floor).
+
+Mirrors Hermes' ``release_stale_claims`` call at the top of each
+``dispatch_once`` tick (``kanban_db.py:3658``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import sqlite3
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services import dispatch_service
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    task_hub.ensure_schema(conn)
+    return conn
+
+
+def _insert_stale_assignment(
+    conn: sqlite3.Connection,
+    *,
+    assignment_id: str,
+    task_id: str,
+    agent_id: str,
+    provider_session_id: str = "",
+    age_seconds: int = 7200,
+) -> None:
+    """Helper: insert an assignment whose ``started_at`` is ``age_seconds`` in the past."""
+    started_at = (datetime.now(timezone.utc) - timedelta(seconds=age_seconds)).isoformat()
+    conn.execute(
+        """
+        INSERT INTO task_hub_assignments (
+            assignment_id, task_id, agent_id, provider_session_id, state, started_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (assignment_id, task_id, agent_id, provider_session_id, "seized", started_at),
+    )
+    # Also flip the task to in_progress so finalize_assignments has something to reopen.
+    conn.execute(
+        "UPDATE task_hub_items SET status=?, seizure_state=? WHERE task_id=?",
+        (task_hub.TASK_STATUS_IN_PROGRESS, "seized", task_id),
+    )
+    conn.commit()
+
+
+# ── release_stale_assignments exclude_session_ids param ─────────────────────
+
+
+def test_exclude_session_ids_skips_matching_assignment() -> None:
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:live-session",
+                "source_kind": "internal",
+                "title": "Live session, age-eligible assignment",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-live",
+            task_id="task:live-session",
+            agent_id="heartbeat:session-live",
+            provider_session_id="session-live",
+            age_seconds=3600,
+        )
+
+        result = task_hub.release_stale_assignments(
+            conn,
+            agent_id_prefix="heartbeat:",
+            stale_after_seconds=1800,
+            exclude_session_ids={"session-live"},
+        )
+        assert result["stale_detected"] == 0
+        assert result["finalized"] == 0
+        assert result["skipped_live"] == 1
+        # Assignment must remain seized — not released.
+        row = conn.execute(
+            "SELECT state FROM task_hub_assignments WHERE assignment_id = ?",
+            ("asg-live",),
+        ).fetchone()
+        assert row is not None
+        assert row["state"] == "seized"
+    finally:
+        conn.close()
+
+
+def test_exclude_session_ids_none_preserves_default_behavior() -> None:
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:no-exclude",
+                "source_kind": "internal",
+                "title": "Stale assignment, no exclude",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-no-exclude",
+            task_id="task:no-exclude",
+            agent_id="heartbeat:session-x",
+            provider_session_id="session-x",
+            age_seconds=3600,
+        )
+
+        result = task_hub.release_stale_assignments(
+            conn,
+            agent_id_prefix="heartbeat:",
+            stale_after_seconds=1800,
+        )
+        assert result["stale_detected"] == 1
+        assert result["finalized"] == 1
+        assert result["skipped_live"] == 0
+    finally:
+        conn.close()
+
+
+def test_exclude_session_ids_does_not_protect_unmatched_sessions() -> None:
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:other-session",
+                "source_kind": "internal",
+                "title": "Stale assignment with a non-matching session",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-other",
+            task_id="task:other-session",
+            agent_id="heartbeat:session-other",
+            provider_session_id="session-other",
+            age_seconds=3600,
+        )
+
+        result = task_hub.release_stale_assignments(
+            conn,
+            agent_id_prefix="heartbeat:",
+            stale_after_seconds=1800,
+            exclude_session_ids={"session-different"},  # doesn't match
+        )
+        assert result["stale_detected"] == 1
+        assert result["finalized"] == 1
+        assert result["skipped_live"] == 0
+    finally:
+        conn.close()
+
+
+def test_exclude_session_ids_accepts_list_and_tuple() -> None:
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:list-input",
+                "source_kind": "internal",
+                "title": "Stale assignment",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-list",
+            task_id="task:list-input",
+            agent_id="heartbeat:session-list",
+            provider_session_id="session-list",
+            age_seconds=3600,
+        )
+
+        # Tuple input
+        result = task_hub.release_stale_assignments(
+            conn,
+            agent_id_prefix="heartbeat:",
+            stale_after_seconds=1800,
+            exclude_session_ids=("session-list",),
+        )
+        assert result["skipped_live"] == 1
+        assert result["stale_detected"] == 0
+    finally:
+        conn.close()
+
+
+# ── dispatch_sweep wiring ───────────────────────────────────────────────────
+
+
+def test_dispatch_sweep_releases_stale_assignment_with_default_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UA_DISPATCH_STALE_SWEEP_ENABLED", raising=False)
+    monkeypatch.delenv("UA_DISPATCH_STALE_AFTER_SECONDS", raising=False)
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:dispatch-sweep-stale",
+                "source_kind": "internal",
+                "title": "Stale before sweep",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+                "labels": ["agent-ready"],
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-stale-sweep",
+            task_id="task:dispatch-sweep-stale",
+            agent_id="heartbeat:dead-session",
+            provider_session_id="dead-session",
+            age_seconds=3600,  # > 1800 default
+        )
+
+        # Caller's session is fresh and different from the dead one.
+        claimed = dispatch_service.dispatch_sweep(
+            conn,
+            agent_id="heartbeat:fresh-session",
+            limit=1,
+            provider_session_id="fresh-session",
+        )
+
+        # The stale assignment should have been finalized BEFORE the claim ran,
+        # which reopens the task to OPEN. The sweep then re-claims it under
+        # the fresh session.
+        assert len(claimed) == 1
+        assert str(claimed[0].get("task_id")) == "task:dispatch-sweep-stale"
+
+        # Original stale assignment row should now be in terminal state.
+        row = conn.execute(
+            "SELECT state FROM task_hub_assignments WHERE assignment_id = ?",
+            ("asg-stale-sweep",),
+        ).fetchone()
+        assert row is not None
+        assert row["state"] != "seized"
+        assert row["state"] != "running"
+    finally:
+        conn.close()
+
+
+def test_dispatch_sweep_excludes_caller_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A heartbeat tick that's been busy longer than the stale-cutoff must NOT
+    release its own currently-active assignment when calling dispatch_sweep."""
+    monkeypatch.delenv("UA_DISPATCH_STALE_SWEEP_ENABLED", raising=False)
+    monkeypatch.delenv("UA_DISPATCH_STALE_AFTER_SECONDS", raising=False)
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:long-running-self",
+                "source_kind": "internal",
+                "title": "Caller's own busy task",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-self-busy",
+            task_id="task:long-running-self",
+            agent_id="heartbeat:self-busy-session",
+            provider_session_id="self-busy-session",
+            age_seconds=3600,
+        )
+
+        # Dispatch under THE SAME session_id — must not release self.
+        # We don't care about the claim result here (the task is in_progress).
+        dispatch_service.dispatch_sweep(
+            conn,
+            agent_id="heartbeat:self-busy-session",
+            limit=1,
+            provider_session_id="self-busy-session",
+        )
+
+        # The assignment must still be seized — self-exclusion worked.
+        row = conn.execute(
+            "SELECT state FROM task_hub_assignments WHERE assignment_id = ?",
+            ("asg-self-busy",),
+        ).fetchone()
+        assert row is not None
+        assert row["state"] == "seized"
+    finally:
+        conn.close()
+
+
+def test_dispatch_sweep_disabled_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When UA_DISPATCH_STALE_SWEEP_ENABLED=0, no stale-release happens."""
+    monkeypatch.setenv("UA_DISPATCH_STALE_SWEEP_ENABLED", "0")
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:disabled-env",
+                "source_kind": "internal",
+                "title": "Stale but sweep disabled",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-disabled-env",
+            task_id="task:disabled-env",
+            agent_id="heartbeat:somebody-else",
+            provider_session_id="somebody-else",
+            age_seconds=3600,
+        )
+
+        dispatch_service.dispatch_sweep(
+            conn,
+            agent_id="heartbeat:current",
+            limit=1,
+            provider_session_id="current-session",
+        )
+
+        # Stale assignment should NOT have been released.
+        row = conn.execute(
+            "SELECT state FROM task_hub_assignments WHERE assignment_id = ?",
+            ("asg-disabled-env",),
+        ).fetchone()
+        assert row is not None
+        assert row["state"] == "seized"
+    finally:
+        conn.close()
+
+
+def test_dispatch_sweep_additional_running_sessions_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caller-supplied additional_running_sessions are protected on top of
+    the auto-excluded current session."""
+    monkeypatch.delenv("UA_DISPATCH_STALE_SWEEP_ENABLED", raising=False)
+    monkeypatch.delenv("UA_DISPATCH_STALE_AFTER_SECONDS", raising=False)
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task:peer-busy",
+                "source_kind": "internal",
+                "title": "Peer session busy",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "agent_ready": True,
+            },
+        )
+        _insert_stale_assignment(
+            conn,
+            assignment_id="asg-peer",
+            task_id="task:peer-busy",
+            agent_id="heartbeat:peer-session",
+            provider_session_id="peer-session",
+            age_seconds=3600,
+        )
+
+        dispatch_service.dispatch_sweep(
+            conn,
+            agent_id="heartbeat:current",
+            limit=1,
+            provider_session_id="current-session",
+            additional_running_sessions={"peer-session"},
+        )
+
+        row = conn.execute(
+            "SELECT state FROM task_hub_assignments WHERE assignment_id = ?",
+            ("asg-peer",),
+        ).fetchone()
+        assert row is not None
+        assert row["state"] == "seized"
+    finally:
+        conn.close()
+
+
+# ── env-var parsing ─────────────────────────────────────────────────────────
+
+
+def test_stale_after_seconds_env_var_respects_floor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The 60s floor in dispatch_service prevents the operator from
+    configuring a dangerously tight stale-cutoff."""
+    from universal_agent.services.dispatch_service import _stale_after_seconds
+
+    monkeypatch.setenv("UA_DISPATCH_STALE_AFTER_SECONDS", "5")
+    assert _stale_after_seconds() == 60  # clamped up to floor
+
+    monkeypatch.setenv("UA_DISPATCH_STALE_AFTER_SECONDS", "7200")
+    assert _stale_after_seconds() == 7200
+
+    monkeypatch.setenv("UA_DISPATCH_STALE_AFTER_SECONDS", "garbage")
+    assert _stale_after_seconds() == 1800  # fall back to default
+
+    monkeypatch.delenv("UA_DISPATCH_STALE_AFTER_SECONDS", raising=False)
+    assert _stale_after_seconds() == 1800
+
+
+def test_stale_sweep_enabled_env_var_parses_truthy_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from universal_agent.services.dispatch_service import _stale_sweep_enabled
+
+    monkeypatch.delenv("UA_DISPATCH_STALE_SWEEP_ENABLED", raising=False)
+    assert _stale_sweep_enabled() is True  # default on
+
+    for value, expected in (
+        ("1", True),
+        ("true", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("no", False),
+        ("off", False),
+        ("FALSE", False),  # case-insensitive
+    ):
+        monkeypatch.setenv("UA_DISPATCH_STALE_SWEEP_ENABLED", value)
+        assert _stale_sweep_enabled() is expected, f"value={value!r}"


### PR DESCRIPTION
## Summary

Second implementation phase of the [Hermes Adaptation Phased Plan](docs/reports/hermes-adaptation-phased-plan-2026-05-10.md) — closes the long-standing wiring gap where `release_stale_assignments` existed in code but was only called by manual operator triggers and gateway-startup reconciliation. Now runs at the top of every `dispatch_sweep`, mirroring Hermes' `release_stale_claims` call at the top of `dispatch_once` (`kanban_db.py:3658`). Implements Recommendation #4 from the [comparison report](docs/reports/hermes-kanban-tenacity-comparison-2026-05-10.md) §5.

**Independent of [#193](https://github.com/Kjdragan/universal_agent/pull/193)** — both PRs are off `feature/latest2` and can be reviewed/merged in either order. Touches the same `task_hub.py` file but in non-overlapping regions (A.1 is in upsert_item + finalize_assignments; A.2 is in release_stale_assignments). Mild merge-conflict risk if both merge same-day; trivial to resolve.

## What changed

**1. `task_hub.release_stale_assignments` — new `exclude_session_ids` parameter**

Optional iterable of `provider_session_id` values to skip even when their assignments are age-eligible. Used by `dispatch_sweep` to protect the *calling* session (and any other known-live sessions) from accidental release when this function is called inline from a heartbeat tick. Default `None` preserves backward-compat for manual operator triggers and ops scripts.

Return dict gains a new `skipped_live: int` counter for observability.

**2. `services.dispatch_service.dispatch_sweep` — top-of-sweep stale-release pass**

```python
dispatch_sweep(
    conn,
    agent_id="heartbeat:fresh-session",
    provider_session_id="fresh-session",
    additional_running_sessions={"peer-1", "peer-2"},  # NEW (optional)
)
```

Before each claim, `dispatch_sweep` now calls `release_stale_assignments` with an exclude set built from:
- The current caller's `provider_session_id` (auto-excluded — protects self)
- The new optional `additional_running_sessions` arg (caller-supplied, e.g., `heartbeat_service.busy_sessions`)

Behavior is best-effort: failures during the stale-release pass are logged but never block the actual claim that follows.

**Gating env vars:**
- `UA_DISPATCH_STALE_SWEEP_ENABLED` — default `"1"` (on). Operator can disable if misbehaving.
- `UA_DISPATCH_STALE_AFTER_SECONDS` — default `1800`. 60s floor prevents dangerously tight cutoffs.

**3. Out-of-scope (intentionally):**

The dashboard-click entry points (`dispatch_immediate`, `dispatch_on_approval`, `dispatch_scheduled_due`) are NOT changed. They respond to user input and don't need to scan for stale assignments inline.

**4. Backwards compatibility:**

Existing caller `todo_dispatch_service.dispatch_sweep(...)` (`todo_dispatch_service.py:736`) gets the auto-self-exclusion behavior for free without parameter changes. Its existing `provider_session_id=session.session_id` argument is now also used as the exclude key — protecting the ToDo session from accidentally releasing its own claim.

## Files changed

- `src/universal_agent/task_hub.py` (+38 / -3)
  - `release_stale_assignments` gains `exclude_session_ids` param; SELECT extended to read `provider_session_id`; skip logic + `skipped_live` counter; backward-compatible default
- `src/universal_agent/services/dispatch_service.py` (+96 / -2)
  - New private helpers: `_stale_sweep_enabled()`, `_stale_after_seconds()`, `_release_stale_for_sweep()`
  - `dispatch_sweep` calls the stale-release pass before the claim; new `additional_running_sessions` optional parameter
- `tests/unit/test_dispatch_sweep_stale_release.py` (+399, new file)

## Test plan

- [x] `python -m py_compile src/universal_agent/task_hub.py src/universal_agent/services/dispatch_service.py tests/unit/test_dispatch_sweep_stale_release.py` — OK
- [x] `uv run ruff check` on the same files — All checks passed
- [x] `uv run pytest tests/unit/test_dispatch_sweep_stale_release.py` — 10/10 passed
- [x] `uv run pytest tests/unit/test_dispatch_service.py tests/unit/test_dispatch_vp_mission_helper.py tests/unit/test_dispatch_source_kind_isolation.py` — 25/25 passed (regression check on dispatch ecosystem)
- [x] `uv run pytest tests/unit/test_task_hub_lifecycle.py` — 21/21 passed (regression check on the file this PR touches most)
- [x] `uv run pytest tests/unit/` — **2578 passed, 13 skipped, 3 deselected, 0 regressions** in 188s

## Test coverage (10 new tests)

**`release_stale_assignments` exclude_session_ids parameter:**
- Skips matching assignment, returns `skipped_live=1`
- Default (`None`) preserves prior release-all behavior
- Doesn't protect sessions not in the exclude set
- Accepts list/tuple inputs (not just sets)

**`dispatch_sweep` wiring:**
- Default config releases stale assignment and re-claims its task fresh
- The caller's own `provider_session_id` is auto-excluded (a long-running self-tick doesn't release its own assignment)
- `UA_DISPATCH_STALE_SWEEP_ENABLED=0` disables the pass entirely
- `additional_running_sessions` exclude set is honored

**Env-var parsing:**
- `UA_DISPATCH_STALE_AFTER_SECONDS` respects 60s floor; falls back to 1800 on garbage
- `UA_DISPATCH_STALE_SWEEP_ENABLED` parses `1/true/yes/on` and `0/false/no/off` case-insensitively

## Operator verification post-merge

- Watch gateway logs for `dispatch_sweep stale-release: detected=N finalized=N reopened=N skipped_live=N` lines. These appear only when there's something to act on — silence means no stale work.
- To verify the exclude-set logic on production, transiently set `UA_DISPATCH_STALE_AFTER_SECONDS=120` (must be ≥60), watch a 3-minute Simone tick, confirm self-exclusion (no release event for Simone's current assignment).
- To disable in an emergency: `UA_DISPATCH_STALE_SWEEP_ENABLED=0` then restart gateway.

## Reference docs

- [Phased Plan, Phase A.2](docs/reports/hermes-adaptation-phased-plan-2026-05-10.md)
- [Comparison Report §5 Recommendation #4](docs/reports/hermes-kanban-tenacity-comparison-2026-05-10.md)

https://claude.ai/code/session_012EAUwBoWPBNkKoxPrqLDbL

---
_Generated by [Claude Code](https://claude.ai/code/session_012EAUwBoWPBNkKoxPrqLDbL)_