### PR TITLE
ci: automate PR-to-production flow (pr-auto-merge + auto-promote-to-prod)

### DIFF
--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -4,6 +4,17 @@ description: Run the commit changes through to production and deploy CI/CD
 
 # Ship Workflow
 
+> **As of 2026-05-11, `/ship` is now an OPTIONAL manual fallback.** The standard path is fully automated end-to-end:
+>
+> 1. Agent opens PR (`claude/*` → `feature/latest2`)
+> 2. [`pr-validate.yml`](../../.github/workflows/pr-validate.yml) runs (compile + ruff + pytest)
+> 3. [`pr-auto-merge.yml`](../../.github/workflows/pr-auto-merge.yml) enables GitHub auto-merge on the PR
+> 4. CI passes → GitHub squash-merges into `feature/latest2`
+> 5. [`auto-promote-to-prod.yml`](../../.github/workflows/auto-promote-to-prod.yml) fires on the push → ff-promotes `feature/latest2` → `develop` → `main`
+> 6. [`deploy.yml`](../../.github/workflows/deploy.yml) fires on the `main` push → production
+>
+> No `/ship` needed for that flow. **Type `/ship` only when you want to deploy work that isn't going through a PR** — e.g., a hot-fix you committed locally, or any direct push to `feature/latest2` that needs to reach production immediately. The hygiene checks below still apply when you do.
+
 This workflow automates the canonical deployment path for the Universal Agent repository. It commits all pending changes on your current branch, merges them into `develop`, fast-forwards `main` with `develop`, and pushes to GitHub to trigger the automated CI/CD deployment workflow.
 
 > **Where can `/ship` run?** Anywhere with the right git remote and a working `gh` CLI session: your desktop, a VPS dev-tree at `/home/ua/dev/universal_agent` (provisioned per Phase D), Antigravity Remote-SSH'd into the VPS, or a sandbox-Claude with the repo cloned. The workflow is **checkout-agnostic** — it operates on `origin` only, so any clone tracking the same GitHub remote can promote feature/latest2 to production. See [`docs/WORKFLOW.md`](../../docs/WORKFLOW.md) for daily-flow context.

--- a/.github/workflows/auto-promote-to-prod.yml
+++ b/.github/workflows/auto-promote-to-prod.yml
@@ -1,0 +1,126 @@
+name: Auto-Promote to Production
+
+# Fires on push to feature/latest2 (typically from PR Auto-Merge fully
+# completing). Performs the same fast-forward promotion that /ship does:
+#
+#   feature/latest2 -> develop (merge commit) -> main (ff-only) -> push
+#
+# The push to main triggers the existing deploy.yml workflow, which
+# deploys to production.
+#
+# This is the second half of the "PR -> production" automation. With
+# pr-auto-merge.yml + this workflow, the flow becomes:
+#
+#   1. Agent opens PR (claude/* -> feature/latest2)
+#   2. pr-validate.yml runs (compile + ruff + pytest)
+#   3. pr-auto-merge.yml enables GitHub auto-merge on the PR
+#   4. CI passes -> GitHub squash-merges -> push to feature/latest2
+#   5. THIS workflow fires -> ff-promotes to develop and main
+#   6. deploy.yml fires from the main push -> production
+#
+# Manual fallback: /ship still exists for direct-push or hot-fix paths,
+# but in normal operation no operator action is required between PR
+# open and production deploy.
+
+on:
+  push:
+    branches: [feature/latest2]
+
+permissions:
+  contents: write
+
+concurrency:
+  # Never cancel an in-flight promotion; queue subsequent pushes so each
+  # PR gets its own deploy. Two PRs landing back-to-back will produce
+  # two sequential deploys, not a clobbered one.
+  group: auto-promote-to-prod
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote feature/latest2 -> develop -> main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        # Same as pr-validate.yml: opt into pipefail so `cmd | tail -N`
+        # doesn't silently swallow non-zero exit codes from cmd.
+        shell: bash -euo pipefail {0}
+
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git for bot
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Skip if push was made by this workflow itself
+        id: loop_guard
+        run: |
+          # Defensive: this workflow only writes to develop and main, not
+          # feature/latest2, so a self-trigger loop should be impossible.
+          # But if some future change pushes to feature/latest2 from this
+          # job, abort cleanly instead of looping. Pusher login for the
+          # GITHUB_TOKEN identity is "github-actions[bot]".
+          PUSHER='${{ github.event.pusher.name }}'
+          if [ "$PUSHER" = "github-actions[bot]" ]; then
+            echo "Push originated from this bot identity. Aborting to avoid loop."
+            echo "skip=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=0" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Promote feature/latest2 -> develop
+        if: steps.loop_guard.outputs.skip == '0'
+        run: |
+          git fetch origin develop main feature/latest2
+          git checkout develop
+          git pull --ff-only origin develop
+          # Merge commit (matches /ship's pattern at .claude/commands/ship.md:137).
+          # We use a merge commit (not ff-only) into develop so develop's
+          # history shows discrete deployment events.
+          git merge feature/latest2 \
+            -m "Merge branch 'feature/latest2' into develop for deployment [auto]"
+          git push origin develop
+          echo "develop advanced to $(git rev-parse --short HEAD)"
+
+      - name: Promote develop -> main (ff-only)
+        if: steps.loop_guard.outputs.skip == '0'
+        run: |
+          git fetch origin main
+          PRE_MAIN=$(git rev-parse origin/main)
+          git checkout main
+          git pull --ff-only origin main
+          git merge develop --ff-only
+          TARGET_SHA=$(git rev-parse main)
+
+          if [ "$PRE_MAIN" = "$TARGET_SHA" ]; then
+            echo "main already at ${TARGET_SHA:0:8} - nothing new to deploy."
+            exit 0
+          fi
+
+          git push origin main
+
+          # Silent-no-op detection (per ship.md:166-180 lesson from 2026-05-08).
+          # `git push` can exit 0 with "Everything up-to-date" when the
+          # local ff-merge above was a silent no-op (stale local state
+          # or branch protection silently rejecting the push). Without
+          # this check, the promotion reports success and the deploy
+          # never triggers.
+          git fetch origin main --quiet
+          POST_MAIN=$(git rev-parse origin/main)
+          if [ "$POST_MAIN" != "$TARGET_SHA" ]; then
+            echo "FATAL: push to main reported success but origin/main is at ${POST_MAIN:0:8}, expected ${TARGET_SHA:0:8}."
+            echo "       The deploy workflow will NOT trigger."
+            echo "       Most likely cause: branch protection on main rejected the push."
+            echo "       Check repo Settings -> Branches -> main -> 'Allow GitHub Actions to bypass'."
+            exit 1
+          fi
+          echo "origin/main advanced: ${PRE_MAIN:0:8} -> ${POST_MAIN:0:8}"
+          echo "deploy.yml will fire - watch at https://github.com/${{ github.repository }}/actions"

--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -1,0 +1,56 @@
+name: PR Auto-Merge
+
+# Auto-enable GitHub auto-merge on PRs that:
+#   - Target feature/latest2
+#   - Are from a claude/* head branch (i.e., from an AI coder)
+#   - Are not draft
+#
+# Once auto-merge is enabled, GitHub squash-merges the PR as soon as
+# pr-validate.yml passes and any required reviews are satisfied.
+#
+# This is half of the "PR -> production" automation. The other half is
+# auto-promote-to-prod.yml, which fires on push to feature/latest2 and
+# advances develop+main, triggering deploy.yml.
+#
+# Manual fallback: if a PR doesn't match the head-branch pattern below,
+# the operator merges it manually. /ship is also still available for
+# direct-push paths.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+    branches: [feature/latest2]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-automerge:
+    name: Enable auto-merge (squash)
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'claude/') &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enable auto-merge via gh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR_NUM="${{ github.event.pull_request.number }}"
+          # Best-effort enable. If auto-merge is already enabled or the
+          # PR is already mergeable+merged, gh exits non-zero with a
+          # message; we treat that as a soft success so a re-run on a
+          # late "synchronize" event doesn't fail the workflow.
+          if gh pr merge "$PR_NUM" \
+                --auto --squash --delete-branch \
+                --repo "${{ github.repository }}"; then
+            echo "Auto-merge enabled on PR #${PR_NUM} (squash, delete branch)."
+          else
+            echo "Note: auto-merge could not be (re-)enabled on PR #${PR_NUM}."
+            echo "      This is usually because the PR is already merged, already"
+            echo "      auto-merging, or auto-merge is disabled at the repo level."
+            echo "      Check repo Settings -> General -> 'Allow auto-merge'."
+          fi

--- a/docs/deployment/ai_coder_instructions.md
+++ b/docs/deployment/ai_coder_instructions.md
@@ -132,7 +132,7 @@ Never `git push --force` to `feature/latest2`, `develop`, or `main`.
 | Tier | Who | What goes through `/ship` directly | What MUST go through PR |
 |---|---|---|---|
 | **1 — Human-supervised conversational coding** | Kevin + Claude Code (you, this conversation), Antigravity, Codex when Kevin is in the loop | Routine fix-and-iterate, doc edits, docstring tweaks, conversational debug commits | CICD changes, deploy-pipeline edits, durable-state schema changes, autonomous-mission code |
-| **2 — Autonomous missions** (CODIE proactive cleanup, Cody scaffold-builder, demo-builder, scheduled VP coder, anything cron- or heartbeat-driven that mutates source) | Bots running unattended on the VPS | **Nothing.** Tier 2 NEVER pushes directly to `feature/latest2`. | **Everything.** Worktree → patch → syntax-check → unit tests → push to `<bot-name>/<task-id>` branch → open PR → CI passes → human merges. |
+| **2 — Autonomous missions** (CODIE proactive cleanup, Cody scaffold-builder, demo-builder, scheduled VP coder, anything cron- or heartbeat-driven that mutates source) | Bots running unattended on the VPS | **Nothing.** Tier 2 NEVER pushes directly to `feature/latest2`. | **Everything.** Worktree → patch → syntax-check → unit tests → push to `<bot-name>/<task-id>` branch → open PR → CI passes → [`pr-auto-merge.yml`](../../.github/workflows/pr-auto-merge.yml) auto-merges → [`auto-promote-to-prod.yml`](../../.github/workflows/auto-promote-to-prod.yml) deploys (no human merge needed for `claude/*` head branches). |
 | **3 — GitHub branch protection** | The safety net | N/A | Enforces tier 1 vs. tier 2 at the push level — see [`ci_cd_pipeline.md`](ci_cd_pipeline.md). |
 
 ### When in doubt: PR
@@ -231,6 +231,8 @@ Tier 1 PRs go through the same workflow — there's no exemption. The autonomous
 [`/ship`](../../.claude/commands/ship.md) (post-2026-05-07 update) runs the same `compile()` check on every changed `.py` file before it commits — so even if you forget to run a local check, `/ship` will catch a syntax error before pushing it to `develop`. It also refuses to ship a working tree that contains `.py.bak` / `.swp` / `.orig` artifacts.
 
 This means today's class of bug (broken docstring → SyntaxError → import storm) is now caught at three independent gates: agent's own pre-commit step, `pr-validate.yml` on PR, `/ship` at deploy time. Any one of them would have prevented the 2026-05-07 incident.
+
+> **As of 2026-05-11:** the standard `claude/*` PR flow is fully automated end-to-end via [`pr-auto-merge.yml`](../../.github/workflows/pr-auto-merge.yml) + [`auto-promote-to-prod.yml`](../../.github/workflows/auto-promote-to-prod.yml). PR open → CI passes → auto-merge → auto-promote → deploy fires, with no operator action required. `/ship` is now an **optional manual fallback** for direct-push or hot-fix paths that bypass the PR flow. The hygiene checks above still apply when it's invoked.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the manual `/ship` step in the standard agent-driven path with two new GitHub Actions workflows. End-to-end flow becomes:

1. Agent opens PR (`claude/*` → `feature/latest2`)
2. `pr-validate.yml` runs (compile + ruff + pytest)
3. `pr-auto-merge.yml` enables GitHub auto-merge on the PR
4. CI passes → GitHub squash-merges into `feature/latest2`
5. `auto-promote-to-prod.yml` fires on the push → ff-promotes `feature/latest2` → `develop` → `main`
6. `deploy.yml` fires from the `main` push → production

**No operator action required between PR open and production deploy.**

## Workflows

### `pr-auto-merge.yml`
- Triggers on `pull_request_target: [opened, reopened, synchronize, ready_for_review]` for PRs targeting `feature/latest2` from a `claude/*` head branch (drafts excluded).
- Calls `gh pr merge --auto --squash --delete-branch`.
- GitHub then merges as soon as `pr-validate.yml` passes (and any required reviews are satisfied per branch protection).

### `auto-promote-to-prod.yml`
- Triggers on push to `feature/latest2`.
- Ports `/ship`'s promotion logic into CI:
  - ff-pull `develop`, merge `feature/latest2` with merge commit, push.
  - ff-pull `main`, ff-merge `develop`, push.
  - **Silent-no-op detection** (per `ship.md:166-180` lesson from 2026-05-08): re-fetch `origin/main` and confirm it actually advanced; abort with a loud message if branch protection silently rejected the push.
  - **Loop guard:** skip if pusher is `github-actions[bot]`. Defensive — the workflow only writes to `develop`/`main`, not `feature/latest2`, so a self-trigger should be impossible.
  - **Concurrency group** `auto-promote-to-prod` with `cancel-in-progress=false` so two PRs landing back-to-back produce two sequential deploys.

## Doc updates

* `.claude/commands/ship.md` — banner at the top noting that `/ship` is now an optional manual fallback for the direct-push / hot-fix path. Hygiene checks still apply when invoked.
* `docs/deployment/ai_coder_instructions.md` — tier-2 row in the matrix updated from "human merges" to the new auto-merge+auto-promote chain. Added a banner at the end of the "/ship at deploy time" section explaining the new automated flow.

## One-time prerequisites (operator side; nothing to commit)

> ⚠️ **Confirm these BEFORE merging this PR.** If any are missing, the new workflows will fail loudly (which is the right outcome) but the next agent PR won't deploy automatically until they're fixed.

1. **Repo Settings → General → "Allow auto-merge"** must be on. Likely already enabled since auto-merge has been used before.
2. **Branch protection on `feature/latest2`** must list `Validate PR` (the `pr-validate.yml` job) as a required status check. Otherwise auto-merge fires immediately on PR open without waiting for CI. To check: Settings → Branches → `feature/latest2` → "Require status checks to pass before merging" → confirm `Validate PR` is in the list.
3. **Branch protection on `main`** must allow GitHub Actions to bypass (or the `GITHUB_TOKEN` must otherwise be permitted to push to protected branches). Otherwise `auto-promote-to-prod`'s push to `main` will fail. The workflow's silent-no-op detection will catch this and fail loudly rather than silently skip the deploy.

## Verification gates

- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files → parse cleanly.
- No `.py` files touched, so `py_compile` / `ruff` / `pytest` are no-ops.

## Phase reference

This is infrastructure work, not a Hermes-adaptation phase. Out of band but unblocks the rest of the Hermes phases (B.2, C, D, E, F) by removing the manual squash-and-merge step from each PR.

After this lands and is verified on the next Hermes PR (B.2), `/ship` becomes optional in normal operation.

https://claude.ai/code/session_012EAUwBoWPBNkKoxPrqLDbL

---
_Generated by [Claude Code](https://claude.ai/code/session_012EAUwBoWPBNkKoxPrqLDbL)_