### PR TITLE
feat(local-dev): Phase C.2 — gate remaining services that ticked in dev

### DIFF
--- a/docs/06_Deployment_And_Environments/12_Local_Dev_Environment.md
+++ b/docs/06_Deployment_And_Environments/12_Local_Dev_Environment.md
@@ -215,18 +215,23 @@ just dev   # Ctrl-C the previous session first
 
 Available flags (one per loop):
 
-| Loop | Env var |
-|---|---|
-| Autonomous heartbeat | `UA_HEARTBEAT_AUTONOMOUS_ENABLED` |
-| Idle dispatch loop | `UA_IDLE_POLL_ENABLED` |
-| Dispatch stale sweep | `UA_DISPATCH_STALE_SWEEP_ENABLED` |
-| Daemon sessions | `UA_DAEMON_SESSIONS_ENABLED` |
-| VP event bridge | `UA_VP_EVENT_BRIDGE_ENABLED` |
-| VP stale reconciler | `UA_VP_STALE_RECONCILE_ENABLED` |
-| Cron registration (all crons) | `UA_CRON_REGISTRATION_ENABLED` |
-| AgentMail polling | `UA_AGENTMAIL_ENABLED` |
-| AgentMail WS | `UA_AGENTMAIL_WS_ENABLED` |
-| Autonomous daily briefing | `UA_AUTONOMOUS_DAILY_BRIEFING_ENABLED` |
+| Loop | Env var | Notes |
+|---|---|---|
+| Heartbeat (entire service) | `UA_HEARTBEAT_ENABLED` | Master gate. When OFF, the `HeartbeatService` itself is not instantiated and no scheduler loop ticks — zero Claude Agent SDK invocations from heartbeat. |
+| Heartbeat (autonomous tick subset, only relevant if service is on) | `UA_HEARTBEAT_AUTONOMOUS_ENABLED` | |
+| Cron service (entire service) | `UA_CRON_ENABLED` | Master gate. When OFF, the `CronService` itself is not instantiated. |
+| Cron job registration (only relevant if cron service is on) | `UA_CRON_REGISTRATION_ENABLED` | When OFF, the cron service ticks but no schedules are registered. |
+| Idle dispatch loop | `UA_IDLE_POLL_ENABLED` | |
+| Dispatch stale sweep | `UA_DISPATCH_STALE_SWEEP_ENABLED` | |
+| Daemon sessions | `UA_DAEMON_SESSIONS_ENABLED` | |
+| VP event bridge | `UA_VP_EVENT_BRIDGE_ENABLED` | |
+| VP stale reconciler | `UA_VP_STALE_RECONCILE_ENABLED` | |
+| AgentMail service (entire service) | `UA_AGENTMAIL_SERVICE_ENABLED` | Master gate. When OFF, no inbox polling, no WebSocket, no outbound email. |
+| AgentMail polling-specific (legacy, only if service is on) | `UA_AGENTMAIL_ENABLED` | |
+| AgentMail WS-specific (legacy, only if service is on) | `UA_AGENTMAIL_WS_ENABLED` | |
+| Notification dispatcher (real emails) | `UA_NOTIFICATION_DISPATCHER_ENABLED` | Defaults OFF in dev — prevents accidental gmail blast from queued backlog. |
+| YouTube playlist watcher | `UA_YOUTUBE_PLAYLIST_WATCHER_ENABLED` | |
+| Autonomous daily briefing | `UA_AUTONOMOUS_DAILY_BRIEFING_ENABLED` | |
 
 **Pattern B: Single-iteration CLI invocations (deferred — coming in a follow-up PR).**
 
@@ -358,11 +363,20 @@ rm -f ~/.local/share/universal_agent/dev.db
 
 Items the doc claims that **may not yet be true** in the codebase. Each one is a small, testable task.
 
-**Closed in PR following the contract:**
+**Closed in PR #200 (initial implementation, 2026-05-11):**
 
 - [x] **`justfile` at repo root with `dev` recipe.** Runs gateway + api + web-ui in parallel with prefixed output and clean Ctrl-C teardown. Recipes: `dev`, `dev-gateway`, `dev-webui`, `bootstrap`, `dev-kill`, `test`, `lint`, `format`, `preship`.
-- [x] **Verify every autonomous loop has a clean OFF flag.** Audit completed; new `src/universal_agent/loop_control.py` is the centralized control plane. In `UA_RUNTIME_STAGE=development` every loop defaults OFF; explicit `UA_<NAME>_ENABLED` always wins. Refactored: heartbeat_service, idle_dispatch_loop, dispatch_service (stale sweep), daemon_sessions, gateway_server (vp_event_bridge, vp_stale_reconcile, cron_registration master). Already-OFF-by-default: AgentMail, daily briefing, dashboard SSE, activity digest. Standalone CLI process: worker.py (only runs when manually invoked).
+- [x] **Initial loop-off audit + master switch.** New `src/universal_agent/loop_control.py` is the centralized control plane. In `UA_RUNTIME_STAGE=development` every loop defaults OFF; explicit `UA_<NAME>_ENABLED` always wins. Initial refactor wave: idle_dispatch_loop, dispatch_service (stale sweep), daemon_sessions, gateway_server (vp_event_bridge, vp_stale_reconcile, cron_registration master), heartbeat_service (autonomous-tick subset).
 - [x] **`docs/README.md` and `docs/Documentation_Status.md` reference this doc** + the companion briefing doc.
+
+**Closed in Phase C.2 follow-up (2026-05-11, after first end-to-end dev verification revealed gaps):**
+
+- [x] **Heartbeat SERVICE master gate** (not just the autonomous-tick subset). `feature_flags.heartbeat_enabled()` now defaults OFF in dev. Without this, `HeartbeatService` itself instantiated and the scheduler loop ticked, firing real Claude Agent SDK runs.
+- [x] **Cron service master gate.** `feature_flags.cron_enabled()` now defaults OFF in dev — the `CronService` itself doesn't instantiate (independent of `UA_CRON_REGISTRATION_ENABLED` which only controls registration once the service is up).
+- [x] **AgentMail service master gate.** `should_run_loop("agentmail_service")` — when OFF, no inbox polling, no WebSocket, no outbound email. Prevents dev from racing with prod on the same `oddcity216@agentmail.to` inbox or sending real emails to operator's gmail.
+- [x] **Notification dispatcher master gate.** `_notification_dispatcher_enabled()` now uses `should_run_loop` — defaults OFF in dev. Prevents accidental email blast from queued notification backlog when dev boots.
+- [x] **YouTube playlist watcher master gate.** `should_run_loop("youtube_playlist_watcher")` — no Google API quota burn from dev.
+- [x] **`bootstrap_local_hq_dev.sh` prints a "loops silenced" banner** at the end of bootstrap so operators see what's off and how to opt back in.
 
 **Deferred to follow-up PRs (not blockers for the contract):**
 

--- a/scripts/bootstrap_local_hq_dev.sh
+++ b/scripts/bootstrap_local_hq_dev.sh
@@ -184,7 +184,29 @@ cat <<EOF
 
 HQ dev bootstrap complete.
 
-Run commands:
+Recommended: start the full stack with:
+  cd "$APP_ROOT" && just dev
+
+  (Or run the three services manually — Gateway/API/Web UI commands below.)
+
+Autonomous loops silenced in dev (UA_RUNTIME_STAGE=development):
+  • Heartbeat (no Claude Agent SDK runs, no quota burn)
+  • Cron service (registered crons don't fire; cron service itself doesn't tick)
+  • Cron job registration (no schedules registered at startup)
+  • Idle dispatch loop
+  • Dispatch stale-task sweep
+  • Daemon sessions
+  • VP event bridge / VP stale reconciler
+  • AgentMail service (no inbox polling, no WebSocket, no outbound email)
+  • Notification dispatcher (no real emails to operator)
+  • YouTube playlist watcher (no Google API quota burn)
+
+To opt a specific loop back on for testing, set its UA_<NAME>_ENABLED=1 in .env
+and restart. Examples:
+  UA_HEARTBEAT_ENABLED=1            # turn heartbeat on for one dev session
+  UA_AGENTMAIL_SERVICE_ENABLED=1    # use real AgentMail inbox in dev (careful)
+
+Manual run commands (skip if using 'just dev'):
   Gateway:
     cd "$APP_ROOT" && set -a && source .env && set +a && PYTHONPATH=src "$PY_BIN" -m universal_agent.gateway_server
 

--- a/src/universal_agent/feature_flags.py
+++ b/src/universal_agent/feature_flags.py
@@ -30,12 +30,26 @@ def _read_env_bool(name: str) -> bool | None:
 
 
 def heartbeat_enabled(default: bool = True) -> bool:
-    """Return True when heartbeat is enabled (default: ON)."""
+    """Return True when heartbeat is enabled (default: ON in prod, OFF in dev).
+
+    Resolution order:
+      1. ``UA_DISABLE_HEARTBEAT=1`` → False (legacy explicit kill-switch wins).
+      2. ``UA_ENABLE_HEARTBEAT=1`` → True (legacy explicit on-switch wins).
+      3. ``UA_HEARTBEAT_ENABLED`` (modern flag) handled by ``should_run_loop``.
+      4. Else: OFF in ``UA_RUNTIME_STAGE=development``, ``default`` otherwise.
+
+    Centralizes the dev-default-OFF behavior added in PR #200's
+    ``loop_control.should_run_loop`` so the heartbeat doesn't tick on a
+    fresh dev box.
+    """
+    # Lazy import to avoid circular-import surface at module-load time.
+    from universal_agent.loop_control import should_run_loop
+
     if _is_truthy(os.getenv("UA_DISABLE_HEARTBEAT")):
         return False
     if _is_truthy(os.getenv("UA_ENABLE_HEARTBEAT")):
         return True
-    return default
+    return should_run_loop("heartbeat", prod_default=default)
 
 
 def memory_index_enabled(default: bool = True) -> bool:
@@ -44,12 +58,21 @@ def memory_index_enabled(default: bool = True) -> bool:
 
 
 def cron_enabled(default: bool = True) -> bool:
-    """Return True when cron is enabled (default: ON)."""
+    """Return True when cron service is enabled (default: ON in prod, OFF in dev).
+
+    Same resolution shape as ``heartbeat_enabled``. Note: PR #200's
+    ``UA_CRON_REGISTRATION_ENABLED`` master gate independently controls
+    whether the registered cron jobs actually fire. This flag controls
+    whether the ``CronService`` itself is instantiated and its scheduler
+    loop ticks.
+    """
+    from universal_agent.loop_control import should_run_loop
+
     if _is_truthy(os.getenv("UA_DISABLE_CRON")):
         return False
     if _is_truthy(os.getenv("UA_ENABLE_CRON")):
         return True
-    return default
+    return should_run_loop("cron", prod_default=default)
 
 
 def task_hub_missions_enabled(default: bool = False) -> bool:

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -14325,17 +14325,25 @@ async def lifespan(app: FastAPI):
             subpath=subpath, payload=payload, headers={"x-ua-source": "yt_playlist_watcher"}
         )
 
-    _yt_playlist_watcher = YouTubePlaylistWatcher(
-        dispatch_fn=_yt_watcher_dispatch_fn,
-        notification_sink=_hook_notification_sink,
-    )
-    _spawn_background_task(
-        _run_after_deployment_window(
-            "youtube_playlist_watcher",
-            _startup_start_youtube_playlist_watcher,
-        ),
-        task_name="youtube_playlist_watcher_startup",
-    )
+    if should_run_loop("youtube_playlist_watcher", prod_default=True):
+        _yt_playlist_watcher = YouTubePlaylistWatcher(
+            dispatch_fn=_yt_watcher_dispatch_fn,
+            notification_sink=_hook_notification_sink,
+        )
+        _spawn_background_task(
+            _run_after_deployment_window(
+                "youtube_playlist_watcher",
+                _startup_start_youtube_playlist_watcher,
+            ),
+            task_name="youtube_playlist_watcher_startup",
+        )
+    else:
+        logger.info(
+            "⏸️ YouTube playlist watcher disabled "
+            "(UA_YOUTUBE_PLAYLIST_WATCHER_ENABLED=0 or "
+            "UA_RUNTIME_STAGE=development). No 60s polling, no Google API "
+            "quota burn."
+        )
 
     # --- gws Workspace Event Listener (Phase 5 — Gmail polling) ---
     async def _gws_event_dispatch_fn(subpath: str, payload: dict) -> tuple[bool, str]:
@@ -14520,17 +14528,25 @@ async def lifespan(app: FastAPI):
                 parts.append(str(sid))
         return ", ".join(parts[:3]) or "background tasks"
 
-    _agentmail_service = AgentMailService(
-        dispatch_fn=_agentmail_dispatch_fn,
-        dispatch_with_admission_fn=_agentmail_dispatch_with_admission_fn,
-        notification_sink=_hook_notification_sink,
-        trusted_ingress_fn=_maybe_trigger_heartbeat_from_agentmail_action,
-        priority_dispatch_fn=_priority_dispatch_for_email,
-    )
-    _spawn_background_task(
-        _run_after_deployment_window("agentmail_service", _startup_start_agentmail_service),
-        task_name="agentmail_service_startup",
-    )
+    if should_run_loop("agentmail_service", prod_default=True):
+        _agentmail_service = AgentMailService(
+            dispatch_fn=_agentmail_dispatch_fn,
+            dispatch_with_admission_fn=_agentmail_dispatch_with_admission_fn,
+            notification_sink=_hook_notification_sink,
+            trusted_ingress_fn=_maybe_trigger_heartbeat_from_agentmail_action,
+            priority_dispatch_fn=_priority_dispatch_for_email,
+        )
+        _spawn_background_task(
+            _run_after_deployment_window("agentmail_service", _startup_start_agentmail_service),
+            task_name="agentmail_service_startup",
+        )
+    else:
+        logger.info(
+            "⏸️ AgentMail service disabled (UA_AGENTMAIL_SERVICE_ENABLED=0 or "
+            "UA_RUNTIME_STAGE=development). No inbox polling, no WebSocket, "
+            "no outbound email. Set UA_AGENTMAIL_SERVICE_ENABLED=1 in .env to "
+            "test against a real inbox."
+        )
 
     _spawn_background_task(
         _run_after_deployment_window(
@@ -18346,12 +18362,16 @@ def _ensure_proactive_artifact_digest_cron_job() -> Optional[dict[str, Any]]:
 def _notification_dispatcher_enabled() -> bool:
     """Master switch for the out-of-band email/Telegram delivery loop.
 
-    Defaults ON — the user explicitly wants high-severity proactive
-    alerts delivered via email/Telegram so they don't have to keep the
-    dashboard open.  Set `UA_NOTIFICATION_DISPATCHER_ENABLED=0` to
-    disable (e.g. during incident remediation to avoid alert storms).
+    Defaults ON in production — the user explicitly wants high-severity
+    proactive alerts delivered via email/Telegram so they don't have to
+    keep the dashboard open. Defaults OFF in ``UA_RUNTIME_STAGE=development``
+    so a local dev run can't accidentally fire real emails to operator
+    while flushing a backlog of queued notifications. Set
+    ``UA_NOTIFICATION_DISPATCHER_ENABLED=0`` to disable in prod (e.g.
+    during incident remediation to avoid alert storms); set =1 in dev
+    to opt back in for testing.
     """
-    return os.getenv("UA_NOTIFICATION_DISPATCHER_ENABLED", "1").strip().lower() in {"1", "true", "yes", "on"}
+    return should_run_loop("notification_dispatcher", prod_default=True)
 
 
 def _list_undelivered_high_severity_notifications(limit: int = 50) -> list[dict[str, Any]]:

--- a/tests/unit/test_feature_flags_defaults.py
+++ b/tests/unit/test_feature_flags_defaults.py
@@ -46,3 +46,74 @@ def test_task_hub_missions_enable_and_disable(monkeypatch):
 
     monkeypatch.setenv("UA_DISABLE_TASK_HUB_MISSIONS", "1")
     assert task_hub_missions_enabled() is False
+
+
+# ─── Dev-mode defaults (PR #200 follow-up: loop_control integration) ─────
+
+
+def test_heartbeat_enabled_defaults_off_in_dev(monkeypatch):
+    """In ``UA_RUNTIME_STAGE=development``, heartbeat defaults OFF."""
+    from universal_agent.feature_flags import heartbeat_enabled
+
+    monkeypatch.setenv("UA_RUNTIME_STAGE", "development")
+    monkeypatch.delenv("UA_ENABLE_HEARTBEAT", raising=False)
+    monkeypatch.delenv("UA_DISABLE_HEARTBEAT", raising=False)
+    monkeypatch.delenv("UA_HEARTBEAT_ENABLED", raising=False)
+
+    assert heartbeat_enabled() is False
+
+
+def test_cron_enabled_defaults_off_in_dev(monkeypatch):
+    """In ``UA_RUNTIME_STAGE=development``, cron defaults OFF."""
+    from universal_agent.feature_flags import cron_enabled
+
+    monkeypatch.setenv("UA_RUNTIME_STAGE", "development")
+    monkeypatch.delenv("UA_ENABLE_CRON", raising=False)
+    monkeypatch.delenv("UA_DISABLE_CRON", raising=False)
+    monkeypatch.delenv("UA_CRON_ENABLED", raising=False)
+
+    assert cron_enabled() is False
+
+
+def test_heartbeat_legacy_enable_wins_over_dev_default(monkeypatch):
+    """``UA_ENABLE_HEARTBEAT=1`` must still force heartbeat ON in dev — operator override."""
+    from universal_agent.feature_flags import heartbeat_enabled
+
+    monkeypatch.setenv("UA_RUNTIME_STAGE", "development")
+    monkeypatch.setenv("UA_ENABLE_HEARTBEAT", "1")
+
+    assert heartbeat_enabled() is True
+
+
+def test_cron_legacy_enable_wins_over_dev_default(monkeypatch):
+    """``UA_ENABLE_CRON=1`` must still force cron ON in dev — operator override."""
+    from universal_agent.feature_flags import cron_enabled
+
+    monkeypatch.setenv("UA_RUNTIME_STAGE", "development")
+    monkeypatch.setenv("UA_ENABLE_CRON", "1")
+
+    assert cron_enabled() is True
+
+
+def test_heartbeat_modern_flag_wins_over_dev_default(monkeypatch):
+    """``UA_HEARTBEAT_ENABLED=1`` (modern flag) overrides dev-default-OFF."""
+    from universal_agent.feature_flags import heartbeat_enabled
+
+    monkeypatch.setenv("UA_RUNTIME_STAGE", "development")
+    monkeypatch.delenv("UA_ENABLE_HEARTBEAT", raising=False)
+    monkeypatch.delenv("UA_DISABLE_HEARTBEAT", raising=False)
+    monkeypatch.setenv("UA_HEARTBEAT_ENABLED", "1")
+
+    assert heartbeat_enabled() is True
+
+
+def test_heartbeat_explicit_off_in_prod(monkeypatch):
+    """``UA_HEARTBEAT_ENABLED=0`` turns heartbeat OFF even in production."""
+    from universal_agent.feature_flags import heartbeat_enabled
+
+    monkeypatch.setenv("UA_RUNTIME_STAGE", "production")
+    monkeypatch.delenv("UA_ENABLE_HEARTBEAT", raising=False)
+    monkeypatch.delenv("UA_DISABLE_HEARTBEAT", raising=False)
+    monkeypatch.setenv("UA_HEARTBEAT_ENABLED", "0")
+
+    assert heartbeat_enabled() is False


### PR DESCRIPTION
## Summary

Phase C.2 follow-up to PR #200, surfaced by Kevin's first end-to-end `just dev` verification on his desktop. The initial PR gated 5 loops correctly; this PR closes the remaining 4 services that were still firing in dev.

## What the desktop run revealed

When `just dev` started up, the new `loop_control` master switch correctly silenced the loops it knew about — but several services it didn't know about kept ticking and **did real work against prod resources from the dev box**:

- **🚨 Heartbeat fired a real Claude Agent SDK run** (~95s, real tool calls, real model quota burned). The `UA_HEARTBEAT_AUTONOMOUS_ENABLED` flag PR #200 refactored only controls a sub-behavior; `HeartbeatService` itself instantiated and the scheduler loop ticked.
- **🚨 AgentMail connected to prod inbox** (`oddcity216@agentmail.to`) via WebSocket and received an inbound message. Then `notification_dispatcher` flushed a queued backlog by **sending 3 real emails to operator's gmail**.
- **YouTube playlist watcher** polled Google's API every 60s.
- **Notification dispatcher** ticked every 30s.

## What this PR adds

Master gates on all four:

| Service | Gate | Behavior |
|---|---|---|
| HeartbeatService (entire service, not just autonomous tick) | `feature_flags.heartbeat_enabled()` now uses `should_run_loop("heartbeat")` | Service not instantiated in dev; legacy `UA_DISABLE_HEARTBEAT` / `UA_ENABLE_HEARTBEAT` still win. |
| CronService (entire service) | `feature_flags.cron_enabled()` now uses `should_run_loop("cron")` | Service not instantiated in dev. Independent of `UA_CRON_REGISTRATION_ENABLED` (PR #200) which only controls schedule registration. |
| AgentMailService | `should_run_loop("agentmail_service")` in `gateway_server.py` | No inbox connection, no WebSocket, no outbound email. Logs `⏸️ AgentMail service disabled` on skip. |
| Notification dispatcher | `_notification_dispatcher_enabled()` now uses `should_run_loop` | No 30s ticker; no email blast from queued backlog. |
| YouTube playlist watcher | `should_run_loop("youtube_playlist_watcher")` | No Google API quota burn from dev. |

**Plus:** `bootstrap_local_hq_dev.sh` now prints a "loops silenced" banner at the end listing every disabled loop and the `UA_<NAME>_ENABLED` env var to set in `.env` to opt back in for testing.

## Tests

`tests/unit/test_feature_flags_defaults.py` — 6 new tests:
- `heartbeat_enabled` defaults OFF in dev
- `cron_enabled` defaults OFF in dev
- Legacy `UA_ENABLE_HEARTBEAT` / `UA_ENABLE_CRON` still win in dev (operator override)
- Modern `UA_HEARTBEAT_ENABLED=1` wins over dev-default-OFF
- Explicit `UA_HEARTBEAT_ENABLED=0` turns off even in production

All 44 feature-flags + loop-control tests pass; full `tests/unit` suite remains green.

## Doc updates

`12_Local_Dev_Environment.md`:
- Pattern A "trigger a loop" table updated with the 4 newly-gated services + master gates with notes (e.g., "When OFF, no inbox polling, no WebSocket, no outbound email").
- § Audit pending now has a "Closed in Phase C.2 follow-up" sub-section paired with the existing "Closed in PR #200" sub-section.

## Production safety

- **Zero behavior change in prod.** `should_run_loop` returns the same answer the old per-service env-var defaults would have when `UA_RUNTIME_STAGE=production` (or unset).
- All legacy switches (`UA_ENABLE_HEARTBEAT`, `UA_DISABLE_HEARTBEAT`, `UA_ENABLE_CRON`, `UA_DISABLE_CRON`, `UA_NOTIFICATION_DISPATCHER_ENABLED`) continue to work as explicit overrides in both directions.
- No changes to `deploy.yml` or `pr-validate.yml`.

## Test plan

- [x] `pytest tests/unit -q` → all green (full suite, exit 0)
- [x] Targeted: `pytest tests/unit/{test_feature_flags_defaults,test_loop_control,test_cron_dormancy_defaults,test_ship_command_pr_only}.py` → 60 passed
- [x] `ruff check` on changed files → clean (gateway_server has 7 pre-existing errors unrelated to this PR)
- [x] `ast.parse(gateway_server.py)` → syntax OK
- [x] Smoke-test: `UA_RUNTIME_STAGE=development` → `heartbeat_enabled()=False`, `cron_enabled()=False`. Production / unset → both `True`.
- [ ] **Operator end-to-end re-verification** — Kevin runs `just dev` after merge; expects to see the new `⏸️ AgentMail service disabled`, `⏸️ YouTube playlist watcher disabled` log lines, no heartbeat tick, no real emails sent. **This is the gate that says Phase C.2 closed the gap.**

## Sequence note

This is the third PR in the local dev / prod separation series:
1. PR #199 (merged) — contract doc
2. PR #200 (merged) — initial implementation: `loop_control.py` + `justfile` + 5 loops gated
3. **This PR** — close the gap: 4 more services gated, bootstrap banner

After this lands and Kevin re-verifies on desktop, the contract doc graduates from "Contract draft" to "Canonical."

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_