### PR TITLE
chore(memory): session memory snapshot 2026-05-11 (pt 2)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -9,6 +9,8 @@ Persistent context for the agent.
 ## [RECENT_CONTEXT]
 Recent context snapshots (most recent first):
 
+- 2026-05-11T04:00:00.650041+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000801s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
+- 2026-05-11T03:59:35.229842+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000775s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-11T03:29:32.567830+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 998973s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-11T03:27:11.626148+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 998832s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-11T03:22:30.615484+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 998551s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
@@ -17,6 +19,4 @@ Recent context snapshots (most recent first):
 - 2026-05-07T16:45:16.135377+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 701116s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:40:06.982338+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 715207s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:39:58.294306+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 700798s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-05-07T16:37:57.557301+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 715077s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-05-07T16:36:42.914196+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 715003s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 

--- a/memory/2026-05-11.md
+++ b/memory/2026-05-11.md
@@ -34,3 +34,21 @@ Proactive task completed successfully: Digest proactive task
 Source: proactive_codie | Duration: 998973s
 This type of proactive work was productive.
 
+## 2026-05-11T03:59:35.229842+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000775s This type of proactive work was productive.
+
+Proactive task completed successfully: Digest proactive task
+Source: proactive_codie | Duration: 1000775s
+This type of proactive work was productive.
+
+## 2026-05-11T04:00:00.650041+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000801s This type of proactive work was productive.
+
+Proactive task completed successfully: Digest proactive task
+Source: proactive_codie | Duration: 1000801s
+This type of proactive work was productive.
+

--- a/memory/index.json
+++ b/memory/index.json
@@ -813,5 +813,35 @@
     "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 998973s This type of proactive work was productive.",
     "file_path": "/home/user/universal_agent/memory/2026-05-11.md",
     "content_hash": "035d2c44af542db28c662a9811d3337ef4b56e6d059e910452820eec21a2ef10"
+  },
+  {
+    "entry_id": "08ef9efa-4f3a-4e92-afe0-a71ed6567e58",
+    "timestamp": "2026-05-11T03:59:35.229842+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000775s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000775s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-11.md",
+    "content_hash": "08ae7f5f681773443c7d684e4e679b891f5781744ad48cbedee9aa57d1bab7a0"
+  },
+  {
+    "entry_id": "16a03a8c-2e30-42d5-8840-e5e1c8bfedc8",
+    "timestamp": "2026-05-11T04:00:00.650041+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000801s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000801s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-11.md",
+    "content_hash": "35668424e7f5281423b3a0678806b4877a01b09d2ad1eae71ac488f7fd58cc54"
   }
 ]


### PR DESCRIPTION
## Summary

Routine session-state snapshot, second batch for 2026-05-11. Mirrors PR #201's `chore(memory): session memory snapshot 2026-05-11`. Captures the proactive-outcome ledger entries that accumulated during the Phase C.2 follow-up work (PR #202 — gating remaining services that ticked in dev).

## Files

- `MEMORY.md` — top-level memory pointer (+/-)
- `memory/index.json` — index entries (+30)
- `memory/2026-05-11.md` — additional daily memory entries (+18)

## Production safety

- Doc/state-only — `deploy.yml`'s `paths-ignore` includes `memory/**` and `**.md`, so the merge does NOT trigger production deploy.
- No code changes.
- Unrelated to PR #202 — that PR stays scoped to the loop-gating work.

## Test plan

- [x] No tests required — state-only commit
- [x] `paths-ignore: memory/**` and `**.md` confirmed in `deploy.yml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_