### PR TITLE
fix(deploy): detect Python version mismatch in existing venv, force rebuild

### DIFF
--- a/scripts/deploy_validate_runtime.sh
+++ b/scripts/deploy_validate_runtime.sh
@@ -108,12 +108,39 @@ remove_runtime_venv() {
 
 ensure_existing_venv_is_usable() {
   echo "--> Checking whether the existing venv is usable by $SERVICE_USER..."
-  if [[ -e "$APP_ROOT/.venv/bin/python3" ]]; then
-    if ! run_as_service_user "readlink -f \"$APP_ROOT/.venv/bin/python3\" >/dev/null 2>&1"; then
-      echo "--> Existing venv interpreter is not accessible to $SERVICE_USER; removing stale .venv for clean rebuild..."
-      remove_runtime_venv
-    fi
+  if [[ ! -e "$APP_ROOT/.venv/bin/python3" ]]; then
+    return
   fi
+
+  # Symlink-accessibility check (existing behavior).
+  if ! run_as_service_user "readlink -f \"$APP_ROOT/.venv/bin/python3\" >/dev/null 2>&1"; then
+    echo "--> Existing venv interpreter is not accessible to $SERVICE_USER; removing stale .venv for clean rebuild..."
+    remove_runtime_venv
+    return
+  fi
+
+  # Python-version check (added 2026-05-11 after deploy #449 incident).
+  #
+  # The previous symlink-accessibility check was insufficient: a venv built
+  # with Python 3.12 looks "usable" (the symlink resolves to a working
+  # interpreter) but `uv sync --python 3.13` will then refuse it with
+  # "Project virtual environment directory ... cannot be used because it is
+  # not a valid Python environment (no Python executable was found)" —
+  # which is uv-speak for "no Python AT THE REQUIRED VERSION." We catch
+  # the version mismatch up front and force a clean rebuild.
+  local venv_version
+  venv_version="$(run_as_service_user "\"$APP_ROOT/.venv/bin/python3\" -c \"import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')\" 2>/dev/null" || true)"
+  if [[ -z "$venv_version" ]]; then
+    echo "--> Existing venv interpreter could not report its version; removing stale .venv for clean rebuild..."
+    remove_runtime_venv
+    return
+  fi
+  if [[ "$venv_version" != "3.13" ]]; then
+    echo "--> Existing venv uses Python $venv_version but deploy requires 3.13; removing stale .venv for clean rebuild..."
+    remove_runtime_venv
+    return
+  fi
+  echo "--> Existing venv Python version OK ($venv_version)."
 }
 
 ensure_python_runtime() {

--- a/scripts/deploy_validate_runtime.sh
+++ b/scripts/deploy_validate_runtime.sh
@@ -108,39 +108,36 @@ remove_runtime_venv() {
 
 ensure_existing_venv_is_usable() {
   echo "--> Checking whether the existing venv is usable by $SERVICE_USER..."
-  if [[ ! -e "$APP_ROOT/.venv/bin/python3" ]]; then
-    return
-  fi
+  if [[ -e "$APP_ROOT/.venv/bin/python3" ]]; then
+    if ! run_as_service_user "readlink -f \"$APP_ROOT/.venv/bin/python3\" >/dev/null 2>&1"; then
+      echo "--> Existing venv interpreter is not accessible to $SERVICE_USER; removing stale .venv for clean rebuild..."
+      remove_runtime_venv
+      return
+    fi
 
-  # Symlink-accessibility check (existing behavior).
-  if ! run_as_service_user "readlink -f \"$APP_ROOT/.venv/bin/python3\" >/dev/null 2>&1"; then
-    echo "--> Existing venv interpreter is not accessible to $SERVICE_USER; removing stale .venv for clean rebuild..."
-    remove_runtime_venv
-    return
+    # Python-version check (added 2026-05-11 after deploy #449 incident).
+    #
+    # The symlink-accessibility check above is necessary but not sufficient:
+    # a venv built with Python 3.12 looks "usable" (the symlink resolves to
+    # a working interpreter), but `uv sync --python 3.13` then refuses it
+    # with "Project virtual environment directory ... cannot be used because
+    # it is not a valid Python environment (no Python executable was
+    # found)" — which is uv-speak for "no Python AT THE REQUIRED VERSION."
+    # We catch the version mismatch up front and force a clean rebuild.
+    local venv_version
+    venv_version="$(run_as_service_user "\"$APP_ROOT/.venv/bin/python3\" -c \"import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')\" 2>/dev/null" || true)"
+    if [[ -z "$venv_version" ]]; then
+      echo "--> Existing venv interpreter could not report its version; removing stale .venv for clean rebuild..."
+      remove_runtime_venv
+      return
+    fi
+    if [[ "$venv_version" != "3.13" ]]; then
+      echo "--> Existing venv uses Python $venv_version but deploy requires 3.13; removing stale .venv for clean rebuild..."
+      remove_runtime_venv
+      return
+    fi
+    echo "--> Existing venv Python version OK ($venv_version)."
   fi
-
-  # Python-version check (added 2026-05-11 after deploy #449 incident).
-  #
-  # The previous symlink-accessibility check was insufficient: a venv built
-  # with Python 3.12 looks "usable" (the symlink resolves to a working
-  # interpreter) but `uv sync --python 3.13` will then refuse it with
-  # "Project virtual environment directory ... cannot be used because it is
-  # not a valid Python environment (no Python executable was found)" —
-  # which is uv-speak for "no Python AT THE REQUIRED VERSION." We catch
-  # the version mismatch up front and force a clean rebuild.
-  local venv_version
-  venv_version="$(run_as_service_user "\"$APP_ROOT/.venv/bin/python3\" -c \"import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')\" 2>/dev/null" || true)"
-  if [[ -z "$venv_version" ]]; then
-    echo "--> Existing venv interpreter could not report its version; removing stale .venv for clean rebuild..."
-    remove_runtime_venv
-    return
-  fi
-  if [[ "$venv_version" != "3.13" ]]; then
-    echo "--> Existing venv uses Python $venv_version but deploy requires 3.13; removing stale .venv for clean rebuild..."
-    remove_runtime_venv
-    return
-  fi
-  echo "--> Existing venv Python version OK ($venv_version)."
 }
 
 ensure_python_runtime() {


### PR DESCRIPTION
## Summary — Prod-down fix

**Production has been 500ing since at least 03:30 UTC today** because every Deploy fails fast at `uv sync --python 3.13`:

```
error: Project virtual environment directory `/opt/universal_agent/.venv`
cannot be used because it is not a valid Python environment
(no Python executable was found)
```

## Root cause (verified on the VPS)

Inspected `/opt/universal_agent/.venv/pyvenv.cfg` after Deploy #449 failed:

```
home = /home/ua/.local/share/uv/python/cpython-3.12-linux-x86_64-gnu/bin
version_info = 3.12.12
```

The venv on disk is built with Python **3.12**. The deploy demands **3.13**. `uv sync --python 3.13` refuses to operate on a venv built against a different Python version — and the error message "no Python executable was found" is uv-speak for "no Python AT THE REQUIRED VERSION", not "directory is empty."

The pre-existing `ensure_existing_venv_is_usable()` check in `deploy_validate_runtime.sh` only verifies that `.venv/bin/python3` is accessible to the service user. It does NOT check the Python version. So it sees a "usable" 3.12 symlink and leaves it alone → next step fails.

## What this PR changes

One file, one function — `scripts/deploy_validate_runtime.sh:ensure_existing_venv_is_usable()`. Added two new guards after the existing symlink-accessibility check:

1. **Version-report check** — run `python -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')"` on the existing venv interpreter. If it can't report its version (corrupt), remove the venv.
2. **Version-match check** — if the reported version isn't `3.13`, remove the venv before `uv sync --python 3.13` runs.

When triggered, the existing `remove_runtime_venv()` helper handles the cleanup; `uv sync --python 3.13` then builds a fresh 3.13 venv.

## Expected sequence after merge

1. Auto-merge fires once PR Validate passes
2. Merge to `main` triggers Deploy
3. Deploy rsyncs the new script to `/opt/universal_agent/scripts/`
4. `ensure_existing_venv_is_usable()` runs the new version check
5. Sees Python 3.12, removes `/opt/universal_agent/.venv`
6. `uv sync --python 3.13` builds a fresh 3.13 venv (couple of minutes)
7. Service restart succeeds, gateway comes up
8. `https://app.clearspringcg.com/api/v1/version` returns 200 with the new SHA

## Production safety

- **One change in one deploy-time script.** No production application code touched.
- **Idempotent.** If the venv is already 3.13, the new check is a no-op; existing logic flows through unchanged.
- **Behavior on the venv being absent** is unchanged (line 1 of the function: `if [[ ! -e ... ]]; then return; fi`).
- **No new sudo, no new auth surface** — runs as the existing service user via the existing `run_as_service_user` wrapper.

## Test plan

- [x] `bash -n scripts/deploy_validate_runtime.sh` → syntax OK
- [x] Manually traced through new branch logic with the actual `pyvenv.cfg` from the VPS — version_info=3.12.12 → reports `3.12` → mismatch → removes venv. Confirmed expected path.
- [ ] **Live verification after merge:** watch Deploy run, expect to see `--> Existing venv uses Python 3.12 but deploy requires 3.13; removing stale .venv for clean rebuild...` in the log, then a successful `uv sync` run, then Deploy goes green.

## Series context

This is the 4th PR in today's local-dev / prod-separation series:
- #199 (merged) — contract doc
- #200 (merged) — loop_control + justfile
- #202 (merged) — Phase C.2 service gates
- **This PR (#203)** — unrelated to the local-dev work; this is the unblock for the prod-down situation that's been preventing ANY of the above PRs from actually deploying. None of my local-dev PRs are live on the VPS until this lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_