### PR TITLE
chore(memory): session memory snapshot 2026-05-11 (pt 3)

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -9,6 +9,7 @@ Persistent context for the agent.
 ## [RECENT_CONTEXT]
 Recent context snapshots (most recent first):
 
+- 2026-05-11T04:39:05.716410+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1003146s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-11T04:00:00.650041+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000801s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-11T03:59:35.229842+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000775s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-11T03:29:32.567830+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 998973s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
@@ -18,5 +19,4 @@ Recent context snapshots (most recent first):
 - 2026-05-10T02:37:46.413955+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 909466s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:45:16.135377+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 701116s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 - 2026-05-07T16:40:06.982338+00:00: Proactive task completed successfully: Create proactive cleanup brief Source: proactive_codie | Duration: 715207s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
-- 2026-05-07T16:39:58.294306+00:00: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 700798s This type of proactive work was productive. (tags: proactive_outcome, success, source:proactive_codie)
 

--- a/memory/2026-05-11.md
+++ b/memory/2026-05-11.md
@@ -52,3 +52,12 @@ Proactive task completed successfully: Digest proactive task
 Source: proactive_codie | Duration: 1000801s
 This type of proactive work was productive.
 
+## 2026-05-11T04:39:05.716410+00:00 — proactive_outcome
+- session: unknown
+- tags: proactive_outcome, success, source:proactive_codie
+- summary: Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1003146s This type of proactive work was productive.
+
+Proactive task completed successfully: Digest proactive task
+Source: proactive_codie | Duration: 1003146s
+This type of proactive work was productive.
+

--- a/memory/index.json
+++ b/memory/index.json
@@ -843,5 +843,20 @@
     "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1000801s This type of proactive work was productive.",
     "file_path": "/home/user/universal_agent/memory/2026-05-11.md",
     "content_hash": "35668424e7f5281423b3a0678806b4877a01b09d2ad1eae71ac488f7fd58cc54"
+  },
+  {
+    "entry_id": "df90a9f6-1cf6-434e-92a7-e849f7654e29",
+    "timestamp": "2026-05-11T04:39:05.716410+00:00",
+    "source": "proactive_outcome",
+    "session_id": null,
+    "tags": [
+      "proactive_outcome",
+      "success",
+      "source:proactive_codie"
+    ],
+    "summary": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1003146s This type of proactive work was productive.",
+    "preview": "Proactive task completed successfully: Digest proactive task Source: proactive_codie | Duration: 1003146s This type of proactive work was productive.",
+    "file_path": "/home/user/universal_agent/memory/2026-05-11.md",
+    "content_hash": "733fae26a97c7acf3e3f90b1e84b0d1a98dd24880c11cad352c6b6a0c1ab00d0"
   }
 ]


### PR DESCRIPTION
## Summary

Routine session-state snapshot during today's local-dev/prod-separation work + the deploy-venv fix follow-up. Mirrors prior precedent: `b4833512` (2026-05-10), `dc33b803` (PR #201, 2026-05-11 pt 1), and the auto-merged "(pt 2)" PR #203.

## Files

- `MEMORY.md` — top-level memory pointer (+1/−1 lines)
- `memory/2026-05-11.md` — daily memory accumulator (+18 lines)
- `memory/index.json` — index entries (+8 lines)

## Production safety

- State-only — `deploy.yml`'s `paths-ignore` covers `memory/**` and `**.md`; no production deploy triggered on merge.
- No code changes.
- Unrelated to PR #204 (the prod-down deploy fix) — that PR stays scoped to the deploy-script change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_