### PR TITLE
docs+fix(claude): cheat sheet for Claude Code in local dev + wrapper auto-detect

### DIFF
--- a/docs/06_Deployment_And_Environments/12_Local_Dev_Environment.md
+++ b/docs/06_Deployment_And_Environments/12_Local_Dev_Environment.md
@@ -435,6 +435,7 @@ A second `just dev` run showed heartbeat + cron service + 5 cron jobs firing des
 
 ## Cross-references
 
+- **Running Claude Code in this dev env:** [`../development/CLAUDE_CODE_CHEAT_SHEET.md`](../development/CLAUDE_CODE_CHEAT_SHEET.md) — one-page cheat sheet for `bash scripts/claude_with_mcp_env.sh`, common flags, ZAI cheap-mode alternative.
 - **Lane definition:** [`05_Local_Runtime_Modes.md`](05_Local_Runtime_Modes.md) — defines HQ Dev Lane vs Desktop Worker Lane (this doc supersedes its HQ Dev Lane runbook).
 - **VPS-as-dev (now a fallback path):** [`11_Daily_Dev_Workflow.md`](11_Daily_Dev_Workflow.md) — Antigravity Remote-SSH workflow. Pre-2026-05-10 this was the canonical dev path. Post-inversion, **desktop dev (this doc) is canonical**; VPS-via-Remote-SSH is a fallback for cases where desktop dev isn't available.
 - **Branch + deploy model:** [`04_Branching_And_Release_Workflow.md`](04_Branching_And_Release_Workflow.md) — what happens after you commit + push.

--- a/docs/Documentation_Status.md
+++ b/docs/Documentation_Status.md
@@ -7,6 +7,7 @@
 | Doc | Subject |
 |-----|---------|
 | **`06_Deployment_And_Environments/12_Local_Dev_Environment.md`** | **CANONICAL (2026-05-11).** Desktop-local dev via `just dev`. Autonomous loops off by default. Bootstrap, daily workflow, loop opt-in pattern (`UA_DEV_<NAME>_FORCE_ON=1`), inspection CLI (`dev_tools`), prod snapshot script. |
+| **`development/CLAUDE_CODE_CHEAT_SHEET.md`** | **One-page cheat sheet (2026-05-11).** How to run Claude Code interactively from your desktop: `bash scripts/claude_with_mcp_env.sh` wrapper, common flags, ZAI cheap-mode alternative, slash commands, anti-patterns, troubleshooting. **Read before opening a Claude Code terminal in Antigravity.** |
 | `06_Deployment_And_Environments/13_Infisical_Dev_Env_Hygiene.md` | Optional Infisical `development` env cleanup checklist. |
 | `operations/2026-05-11_local_dev_initiative_briefing.md` | Cross-session briefing for concurrent AI sessions during the dev/prod separation rollout. |
 | `development/LOCAL_DEV.md` | ⚠️ **Superseded by Doc 12 (2026-05-11).** Describes a pre-initiative `.local` Infisical env + shell-script flow that's no longer canonical. Kept for historical reference. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@ Mistaking one for the other is the #1 source of confusion in this system. Before
 ## Development
 
 - **[Local Development Environment](06_Deployment_And_Environments/12_Local_Dev_Environment.md)** — **CANONICAL (2026-05-11).** How to run Universal Agent on your desktop at `http://localhost:3000` via `just dev`. Autonomous loops off by default. Same code as prod, separate dev SQLite, secrets via Infisical `development` env. Bootstrap, daily workflow, troubleshooting, prod-snapshot pattern.
+- **[Claude Code Cheat Sheet](development/CLAUDE_CODE_CHEAT_SHEET.md)** — One-page cheat sheet for running Claude Code in local dev. The `bash scripts/claude_with_mcp_env.sh` wrapper, common flags, the `zai` cheap-mode alternative, slash commands, anti-patterns, troubleshooting. **Read this before running `claude` in a desktop Antigravity terminal.**
 - **[Infisical Dev Env Hygiene](06_Deployment_And_Environments/13_Infisical_Dev_Env_Hygiene.md)** — Optional cleanup for Infisical's `development` env (remove `UA_*_ENABLED` flags mirrored from prod).
 - **[Local Dev Initiative Briefing (2026-05-11)](operations/2026-05-11_local_dev_initiative_briefing.md)** — Cross-session handoff for concurrent AI sessions working in the repo.
 - **[Local Development Guide (pre-2026-05-11, archived approach)](development/LOCAL_DEV.md)** — ⚠️ Superseded by Doc 12 above. Describes an older `.local` Infisical environment + shell-script flow that's no longer canonical.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -112,6 +112,7 @@ Fuller diagnostic table: [doc 11 § Recovery procedures](06_Deployment_And_Envir
 | Topic | Doc |
 |---|---|
 | **Canonical desktop-local dev runbook (`just dev`)** | [**doc 12**](06_Deployment_And_Environments/12_Local_Dev_Environment.md) |
+| **Running Claude Code in local dev — cheat sheet** | [**development/CLAUDE_CODE_CHEAT_SHEET.md**](development/CLAUDE_CODE_CHEAT_SHEET.md) |
 | Infisical dev-env hygiene (optional cleanup) | [doc 13](06_Deployment_And_Environments/13_Infisical_Dev_Env_Hygiene.md) |
 | Local runtime lane definitions (HQ Dev / Desktop Worker) | [doc 05](06_Deployment_And_Environments/05_Local_Runtime_Modes.md) |
 | VPS-as-dev fallback workflow (Antigravity Remote-SSH) | [doc 11](06_Deployment_And_Environments/11_Daily_Dev_Workflow.md) |

--- a/docs/development/CLAUDE_CODE_CHEAT_SHEET.md
+++ b/docs/development/CLAUDE_CODE_CHEAT_SHEET.md
@@ -1,0 +1,226 @@
+# Claude Code Cheat Sheet — Local Dev
+
+> **Audience:** Kevin running interactive Claude Code (Anthropic Max plan) from his desktop while `just dev` is running.
+>
+> **TL;DR:** Open a terminal at `/home/kjdragan/lrepos/universal_agent`, run `bash scripts/claude_with_mcp_env.sh`. That's it. The rest of this doc is flags, alternatives, and troubleshooting.
+
+---
+
+## 1. The one command you need
+
+From the repo root (`/home/kjdragan/lrepos/universal_agent`):
+
+```bash
+bash scripts/claude_with_mcp_env.sh
+```
+
+That launches Claude Code with:
+- **Anthropic Max** OAuth (real Opus 4.7 / Sonnet 4.6 / Haiku — not ZAI/GLM)
+- All MCP servers authenticated (Composio, edgartools, video_audio, youtube, zai_vision, etc. — the `${VAR}` placeholders in `.mcp.json` get resolved at startup)
+- Project-local skills, slash commands (`/ship`, `/dev`, etc.), agents discovered
+
+The wrapper handles two concerns at once: (a) Infisical secrets for MCPs, (b) preserving your Anthropic Max OAuth (it deliberately strips `ANTHROPIC_*` from Infisical-injected env so api.anthropic.com is the endpoint, not Z.AI).
+
+### Where the wrapper looks for `.env`
+
+The wrapper needs an Infisical-bootstrap `.env` to load secrets from. Auto-detection (2026-05-11):
+
+1. `UA_INSTALL_ROOT` env var if set (explicit override)
+2. `/opt/universal_agent/.env` (canonical VPS prod path)
+3. **The repo containing the script itself** (your desktop checkout — this is the default case)
+
+You shouldn't need to set `UA_INSTALL_ROOT` manually on your desktop — auto-detect handles it. If you have multiple checkouts and want to point at a specific one:
+
+```bash
+UA_INSTALL_ROOT=/home/kjdragan/lrepos/universal_agent bash scripts/claude_with_mcp_env.sh
+```
+
+If you see `❌ <path>/.env not found` at launch, the most common cause is you haven't run `bash scripts/bootstrap_local_hq_dev.sh` yet — that's what creates `.env` from your Infisical bootstrap creds.
+
+---
+
+## 2. Common flags
+
+Pass any of these AFTER the wrapper script:
+
+```bash
+# One-shot prompt mode (don't open the chat UI; print + exit)
+bash scripts/claude_with_mcp_env.sh -p "summarize what's in src/universal_agent/loop_control.py"
+
+# Pick a specific model
+bash scripts/claude_with_mcp_env.sh --model sonnet
+bash scripts/claude_with_mcp_env.sh --model haiku
+bash scripts/claude_with_mcp_env.sh --model opus           # default
+bash scripts/claude_with_mcp_env.sh --model claude-opus-4-7
+
+# Resume previous session
+bash scripts/claude_with_mcp_env.sh --resume
+
+# Skip permission prompts (auto-allow common tools — be careful with this)
+bash scripts/claude_with_mcp_env.sh --dangerously-skip-permissions
+
+# Show full help
+bash scripts/claude_with_mcp_env.sh --help
+```
+
+For the canonical full flag list: `claude --help` (works after launch too).
+
+---
+
+## 3. Cheap-mode alternative — `zai` (full GLM routing)
+
+When you want cheap inference (high-volume experimental work, bulk token burns where Claude quality isn't worth the Max plan tokens), use the `zai` shell function instead:
+
+```bash
+zai -p "summarize this file"
+zai --model glm-5.1
+```
+
+`zai` is a shell function (installed by `scripts/_claude_launcher.py` setup), not a script. It sets `ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic` + auth token + model mapping in the env, then launches `claude`. Everything else (slash commands, MCPs, agents) works the same — just the LLM endpoint changes.
+
+**When to use which:**
+
+| Scenario | Use |
+|---|---|
+| Daily interactive coding, debugging, refactoring | `bash scripts/claude_with_mcp_env.sh` (Anthropic Max) |
+| Bulk find/replace, mass refactor, batch analysis | `zai -p "..."` (cheap GLM) |
+| Anything that needs the strongest reasoning | `bash scripts/claude_with_mcp_env.sh --model opus` |
+| Quick one-liners where you don't need MCPs | `claude -p "..."` (plain; MCPs may fail but that's OK for trivial prompts) |
+
+---
+
+## 4. Slash commands you'll use most
+
+Once inside Claude (these are typed at the prompt, not in the shell):
+
+```
+/help                # full slash command list for the current session
+/clear               # clear context (start fresh)
+/model               # show current model + switch
+/cost                # show token usage for current session
+/login               # re-OAuth Anthropic Max (use when API returns 401)
+/ship                # commit + push current branch, open PR, enable auto-merge
+                     #   (see docs/operations/2026-05-11_autonomous_pr_and_deploy_flow_briefing.md)
+/dev                 # status / start / stop the local dev stack (if you have a /dev skill)
+```
+
+Custom slash commands live at `.claude/commands/<name>.md`. The `/ship` command is defined at `.claude/commands/ship.md`.
+
+---
+
+## 5. Verifying you're actually on Anthropic Max (not ZAI)
+
+After launching, sanity-check:
+
+```
+/model
+```
+
+Should show something like `claude-opus-4-7` or `claude-sonnet-4-6` — NOT `glm-5.1` or `glm-4.6`.
+
+Or from inside chat: ask `What model are you?` — Claude will say "Claude Opus" / "Claude Sonnet" / etc. If it says "GLM" you accidentally launched in ZAI mode.
+
+Or from your shell BEFORE launching:
+
+```bash
+env | grep ANTHROPIC_  # should be empty for Anthropic-Max mode
+                       # If you see ANTHROPIC_BASE_URL=z.ai... you're in ZAI mode
+```
+
+---
+
+## 6. Anti-patterns (per CLAUDE.md)
+
+| Don't | Why |
+|---|---|
+| `claude` plain (no wrapper) | MCP servers will fail with "no token" / placeholder unresolved errors because `${VAR}` in `.mcp.json` doesn't resolve without the wrapper's Infisical bootstrap |
+| `infisical run --env=development -- claude` | The Infisical CLI's auth context is unreliable; the Python SDK path (what the wrapper uses) is the canonical one |
+| Letting Claude Code Doctor / IDE plugin auto-resolve `${VAR}` in `.mcp.json` | If `git status` shows `.mcp.json` modified with `${VAR}` → literal substitutions, run `git checkout -- .mcp.json` immediately. The 2026-05-08 Hostinger token leak (see `docs/operations/2026-05-08_hostinger_token_remediation.md`) is the cautionary tale. |
+| `claude` with `ANTHROPIC_API_KEY` set in your environment | Claude Code treats that as an "external API key" and overrides your Max plan OAuth, giving you billed-API behavior instead of Max plan. The wrapper strips `ANTHROPIC_*` from Infisical injection to prevent this. |
+
+---
+
+## 7. Troubleshooting
+
+### `claude` says "Invalid API key · Fix external API key"
+
+Your environment leaked an `ANTHROPIC_*` var that's overriding OAuth. Fix:
+
+```bash
+unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN ANTHROPIC_BASE_URL ANTHROPIC_MODEL ANTHROPIC_DEFAULT_HAIKU_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL ANTHROPIC_DEFAULT_OPUS_MODEL
+bash scripts/claude_with_mcp_env.sh
+```
+
+Or refresh OAuth: `cd ~ && claude /login` (run from outside the repo to dodge any project-level `.env` injection).
+
+### MCP server fails to start with "missing env var" or "401"
+
+`${VAR}` placeholder in `.mcp.json` didn't resolve. Confirm the wrapper actually ran the bootstrap:
+
+```bash
+ls -l .env                          # should exist with INFISICAL_CLIENT_ID etc.
+bash scripts/bootstrap_local_hq_dev.sh   # re-bootstrap if needed
+bash scripts/claude_with_mcp_env.sh
+```
+
+### Side panel uses ZAI / wrong endpoint (in Antigravity)
+
+Reinstall the Claude Code extension on the **active** Antigravity window — i.e., on your local profile if you're in local dev, NOT on a Remote-SSH'd session.
+
+### "develop" branch error from `/ship`
+
+You're on the retired branch. `git checkout <feature>` first, then `/ship`. `develop` was retired 2026-05-10 (see [Doc 04](../06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md)).
+
+### Long-running session feels slow
+
+Run `/clear` to drop context. Or `/cost` to see token usage — if you're past 60K context, response latency creeps up.
+
+---
+
+## 8. Workflow examples
+
+### Start a new feature
+
+```bash
+# In Antigravity terminal at repo root
+git pull --ff-only origin main
+git checkout -b claude/my-feature-name
+just dev                            # starts gateway + api + web-ui in another terminal
+
+# In a SECOND terminal in Antigravity
+bash scripts/claude_with_mcp_env.sh
+
+# Inside Claude:
+"Implement X. Test it. Show me the diff before committing."
+
+# When happy:
+/ship                               # commits, pushes, opens PR, enables auto-merge — walk away
+```
+
+### Quick one-shot analysis
+
+```bash
+bash scripts/claude_with_mcp_env.sh -p "What does src/universal_agent/loop_control.py do? Summarize in 5 bullets."
+```
+
+### Cheap bulk task
+
+```bash
+zai -p "Read every .py file under src/universal_agent/services/ and list the ones that import 'requests'. Output as a markdown table."
+```
+
+### Resume yesterday's session
+
+```bash
+bash scripts/claude_with_mcp_env.sh --resume
+```
+
+---
+
+## 9. Related docs
+
+- **[Local Dev Environment (canonical)](../06_Deployment_And_Environments/12_Local_Dev_Environment.md)** — how `just dev` works, what's gated off in dev, how to opt loops in
+- **[Interactive Coding Environment (Claude routing internals)](../06_Deployment_And_Environments/10_Interactive_Coding_Environment.md)** — the full inversion mechanism, why `zai` is a function vs script, etc.
+- **[Secrets and Environments (Infisical canonical)](../deployment/secrets_and_environments.md)** — what the wrapper's bootstrap actually loads, `${VAR}` placeholder pattern in `.mcp.json`
+- **[Autonomous PR + Deploy Flow Briefing](../operations/2026-05-11_autonomous_pr_and_deploy_flow_briefing.md)** — what `/ship` does, how auto-merge fires, deploy mechanics
+- **[`scripts/claude_with_mcp_env.sh`](../../scripts/claude_with_mcp_env.sh)** — the wrapper script source itself; ~60 lines of bash, worth reading once

--- a/scripts/claude_with_mcp_env.sh
+++ b/scripts/claude_with_mcp_env.sh
@@ -49,12 +49,31 @@
 
 set -e
 
-UA_INSTALL_ROOT="${UA_INSTALL_ROOT:-/opt/universal_agent}"
-LAUNCHER="$(cd "$(dirname "$0")" && pwd)/_claude_launcher.py"
+# Resolve UA_INSTALL_ROOT with auto-detection (2026-05-11):
+#   1. Honor explicit UA_INSTALL_ROOT if set
+#   2. Otherwise try /opt/universal_agent (canonical VPS prod path)
+#   3. Otherwise fall back to the repo containing this script (desktop dev case)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT_FROM_SCRIPT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [ -z "${UA_INSTALL_ROOT:-}" ]; then
+    if [ -f "/opt/universal_agent/.env" ]; then
+        UA_INSTALL_ROOT="/opt/universal_agent"
+    elif [ -f "$REPO_ROOT_FROM_SCRIPT/.env" ]; then
+        UA_INSTALL_ROOT="$REPO_ROOT_FROM_SCRIPT"
+    else
+        UA_INSTALL_ROOT="/opt/universal_agent"   # default for error msg below
+    fi
+fi
+
+LAUNCHER="$SCRIPT_DIR/_claude_launcher.py"
 
 if [ ! -f "$UA_INSTALL_ROOT/.env" ]; then
     echo "❌ $UA_INSTALL_ROOT/.env not found." >&2
-    echo "   Set UA_INSTALL_ROOT to the prod checkout that has Infisical bootstrap creds." >&2
+    echo "   Auto-detection tried /opt/universal_agent/.env and $REPO_ROOT_FROM_SCRIPT/.env." >&2
+    echo "   Set UA_INSTALL_ROOT explicitly to a checkout with Infisical bootstrap creds:" >&2
+    echo "     export UA_INSTALL_ROOT=/path/to/universal_agent" >&2
+    echo "   Or run scripts/bootstrap_local_hq_dev.sh first to create the .env." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two paired changes:

### 1. New doc: `docs/development/CLAUDE_CODE_CHEAT_SHEET.md`

One-page operator cheat sheet for running Claude Code interactively from a desktop Antigravity terminal. Covers:

- The single command: `bash scripts/claude_with_mcp_env.sh`
- Common flags: `-p`, `--model`, `--resume`, `--dangerously-skip-permissions`, `--help`
- ZAI cheap-mode alternative (`zai` shell function) with a when-to-use-which table
- Slash commands inside Claude (`/help`, `/clear`, `/model`, `/ship`, `/login`)
- How to verify you're on Anthropic Max (not accidentally ZAI)
- Anti-patterns from CLAUDE.md (don't run `claude` plain; don't `infisical run --env=…--`; don't let Doctor auto-resolve `.mcp.json`)
- Troubleshooting (401 errors, MCP placeholder failures, side-panel-on-wrong-endpoint, `/ship` from develop)
- Workflow examples (new feature, one-shot analysis, cheap bulk task, resume)

Indexed from:
- `docs/README.md` § Development
- `docs/Documentation_Status.md` § Development
- `docs/WORKFLOW.md` § 6 pointer table
- `docs/06_Deployment_And_Environments/12_Local_Dev_Environment.md` § Cross-references

So you can find it from any canonical entry point.

### 2. Fix: `scripts/claude_with_mcp_env.sh` auto-detects `UA_INSTALL_ROOT`

**The bug:** the wrapper defaulted `UA_INSTALL_ROOT=/opt/universal_agent` (the VPS prod path). On desktop, this fails with:

```
❌ /opt/universal_agent/.env not found.
   Set UA_INSTALL_ROOT to the prod checkout that has Infisical bootstrap creds.
```

**The fix:** auto-detect — fall back to the repo containing the script when the prod path doesn't exist. New resolution order:

1. `UA_INSTALL_ROOT` explicit override (unchanged)
2. `/opt/universal_agent/.env` if present (VPS prod — unchanged)
3. Repo root containing the script (desktop dev — **new fallback**)

Plus the error message now tells the operator both paths it tried and suggests running `bootstrap_local_hq_dev.sh`.

**Net effect:** operators on desktop can now run `bash scripts/claude_with_mcp_env.sh` from any repo checkout WITHOUT setting `UA_INSTALL_ROOT`. Production behavior on VPS is unchanged (prod path still wins).

## Production safety

- Wrapper change is operator-side tooling; not invoked by any service.
- Auto-detection prefers prod path first → VPS behavior unchanged.
- Doc-only otherwise; `paths-ignore` covers `docs/**` and `**.md`.

## Test plan

- [x] `bash -n scripts/claude_with_mcp_env.sh` → syntax OK
- [x] Manually traced both paths:
  - VPS: `/opt/universal_agent/.env` exists → uses it (no change)
  - Desktop: prod path missing → falls back to repo root with bootstrap-creds `.env`
- [ ] **Operator validation (Kevin):** run `bash scripts/claude_with_mcp_env.sh --dangerously-skip-permissions` from `/home/kjdragan/lrepos/universal_agent` without setting `UA_INSTALL_ROOT`. Should launch Claude Code with Anthropic Max OAuth and resolved MCP servers.

## Series context

Follows the local-dev / prod-separation initiative (PRs #199, #200, #202, #206, #211, #212, #214, #216) — fills in the "how do I actually run Claude Code in the new local dev environment" gap that the operator hit when trying to use the wrapper from desktop.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UHW2wci9HP4jE5Rx9HAKeY)_