### PR TITLE
fix(cron): reject sub-minute every_seconds intervals

### DIFF
--- a/src/universal_agent/cron_service.py
+++ b/src/universal_agent/cron_service.py
@@ -26,6 +26,7 @@ logger = logging.getLogger(__name__)
 
 MIN_CRON_TIMEOUT_SECONDS = 1
 MAX_CRON_TIMEOUT_SECONDS = 7200
+MIN_CRON_INTERVAL_SECONDS = 60
 _CRON_DB_LOCK_RETRY_DELAY_SECONDS = 1.0
 _CRON_DB_LOCK_RETRY_MAX = 5
 
@@ -614,11 +615,17 @@ class CronService:
         metadata: Optional[dict[str, Any]] = None,
     ) -> CronJob:
         every_seconds = _parse_duration_seconds(every_raw, 0) if every_raw else 0
-        
+
         # Validate scheduling - must have at least one method
         if every_seconds <= 0 and not cron_expr and run_at is None:
             raise ValueError("Must provide at least one of: every, cron_expr, or run_at")
-        
+
+        if 0 < every_seconds < MIN_CRON_INTERVAL_SECONDS:
+            raise ValueError(
+                f"every_seconds={every_seconds} is below the minimum interval "
+                f"({MIN_CRON_INTERVAL_SECONDS}s). Use cron_expr for finer scheduling."
+            )
+
         # Validate cron expression if provided
         if cron_expr:
             try:
@@ -670,7 +677,13 @@ class CronService:
             job.enabled = bool(updates["enabled"])
         if "every" in updates or "every_seconds" in updates:
             raw = updates.get("every") or updates.get("every_seconds")
-            job.every_seconds = _parse_duration_seconds(str(raw), job.every_seconds)
+            new_every = _parse_duration_seconds(str(raw), job.every_seconds)
+            if 0 < new_every < MIN_CRON_INTERVAL_SECONDS:
+                raise ValueError(
+                    f"every_seconds={new_every} is below the minimum interval "
+                    f"({MIN_CRON_INTERVAL_SECONDS}s). Use cron_expr for finer scheduling."
+                )
+            job.every_seconds = new_every
         if "cron_expr" in updates:
             cron_expr = updates["cron_expr"]
             if cron_expr:

--- a/tests/unit/test_cron_min_interval_guard.py
+++ b/tests/unit/test_cron_min_interval_guard.py
@@ -1,0 +1,88 @@
+"""Guard against sub-minute cron intervals via the every_seconds path.
+
+Motivation: 2026-05-11 a pair of test crons were created with every_seconds=2
+("cron schedule" / "cron test" placeholder commands), ran every 2 seconds for
+~10 hours, and generated a retry-storm of ~30 warning emails to the operator.
+The cron service had no minimum-interval validation on the `every_seconds`
+path (the alternative-to-cron_expr simple-interval mode). All 17 legitimate
+production crons use cron_expr; nothing uses every_seconds. This guard
+prevents the misuse without removing the API surface.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from universal_agent.cron_service import MIN_CRON_INTERVAL_SECONDS, CronService
+
+
+class _StubGateway:
+    async def create_session(self, user_id: str, workspace_dir: str):
+        return SimpleNamespace(user_id=user_id, workspace_dir=workspace_dir)
+
+    async def run_query(self, session, request, **_kwargs):
+        return SimpleNamespace(response_text="")
+
+
+def _service(tmp_path: Path) -> CronService:
+    return CronService(_StubGateway(), tmp_path)
+
+
+def test_add_job_rejects_two_second_interval(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    with pytest.raises(ValueError, match="below the minimum interval"):
+        service.add_job(
+            user_id="cron",
+            workspace_dir=str(tmp_path / "cron_test"),
+            command="echo hi",
+            every_raw="2s",
+        )
+
+
+def test_add_job_rejects_just_under_minimum(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    with pytest.raises(ValueError, match="below the minimum interval"):
+        service.add_job(
+            user_id="cron",
+            workspace_dir=str(tmp_path / "cron_test"),
+            command="echo hi",
+            every_raw=f"{MIN_CRON_INTERVAL_SECONDS - 1}s",
+        )
+
+
+def test_add_job_accepts_minimum_interval(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    job = service.add_job(
+        user_id="cron",
+        workspace_dir=str(tmp_path / "cron_ok"),
+        command="echo hi",
+        every_raw=f"{MIN_CRON_INTERVAL_SECONDS}s",
+    )
+    assert job.every_seconds == MIN_CRON_INTERVAL_SECONDS
+
+
+def test_add_job_cron_expr_path_unaffected(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    job = service.add_job(
+        user_id="cron",
+        workspace_dir=str(tmp_path / "cron_expr"),
+        command="echo hi",
+        cron_expr="*/5 * * * *",
+    )
+    assert job.cron_expr == "*/5 * * * *"
+    assert job.every_seconds == 0
+
+
+def test_update_job_rejects_sub_minimum_every_seconds(tmp_path: Path) -> None:
+    service = _service(tmp_path)
+    job = service.add_job(
+        user_id="cron",
+        workspace_dir=str(tmp_path / "cron_update"),
+        command="echo hi",
+        every_raw="5m",
+    )
+    with pytest.raises(ValueError, match="below the minimum interval"):
+        service.update_job(job.job_id, {"every_seconds": 2})
+    # job state must be unchanged after the rejected update
+    assert service.get_job(job.job_id).every_seconds == 300


### PR DESCRIPTION
## Summary

- Adds `MIN_CRON_INTERVAL_SECONDS = 60` guard to `cron_service.add_job` and `update_job`
- Triggered by a real incident on 2026-05-11: two test crons with `every_seconds=2` (placeholder commands `"cron schedule"` / `"cron test"`) ran every 2 seconds for ~10 hours and generated ~30 retry-storm warning emails to Simone before the operator caught it
- All 17 legitimate production crons use `cron_expr`; nothing uses `every_seconds`. This guard prevents the misuse without removing the API surface

## Why 60s

Cron jobs are for periodic background work. Sub-minute scheduling is virtually always a mistake (the only legitimate use cases are heartbeats, which are a separate code path with its own minimum-interval guard). 60s is conservative and matches the floor of standard cron syntax (`* * * * *`).

## Test plan

- [x] `python -m py_compile src/universal_agent/cron_service.py tests/unit/test_cron_min_interval_guard.py`
- [x] `uv run --offline ruff check --select E9,F --ignore E402,F401,F541,F811,F841 --no-cache` — clean
- [x] `uv run --offline pytest tests/unit/test_cron_min_interval_guard.py -x -q` — 5/5 pass
- [x] Full unit suite delta: only pre-existing `test_dispatch_sweep_releases_stale_assignment_with_default_config` failure (verified to fail identically on `main` without these changes; CI is green on recent PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)