### PR TITLE
fix(vp): periodic stale-mission reconciliation (close 8h stuck-mission gap)

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -2435,6 +2435,17 @@ _vp_stale_reconcile_seconds = max(
     60,
     int(os.getenv("UA_VP_STALE_RECONCILE_SECONDS", "").strip() or 15 * 60),
 )
+# How often to sweep for stale VP missions. Without this loop, reconciliation
+# only runs at gateway startup — so a VP daemon that stopped polling at 6 AM
+# leaves its missions in `running` state until the next deploy. 5 min default
+# bounds the worst case to ~5 min instead of "until next restart". Floor 60s
+# matches the cron min-interval guard (PR #218).
+_vp_stale_reconcile_interval_seconds = max(
+    60,
+    int(os.getenv("UA_VP_STALE_RECONCILE_INTERVAL_SECONDS", "").strip() or 5 * 60),
+)
+_vp_stale_reconcile_task: Optional[asyncio.Task] = None
+_vp_stale_reconcile_stop: Optional[asyncio.Event] = None
 _channel_probe_results: dict[str, dict] = {}
 _notifications: list[dict] = []
 _notifications_max = int(os.getenv("UA_NOTIFICATIONS_MAX", "500"))
@@ -8853,6 +8864,38 @@ async def _factory_staleness_enforcement_loop(stop_event: asyncio.Event) -> None
                 logger.warning("Factory staleness enforcement failed: %s", exc)
 
 
+async def _vp_stale_reconcile_loop(stop_event: asyncio.Event) -> None:
+    """Periodically finalize VP missions whose external runtime stopped polling.
+
+    Mirrors the existing on-startup reconciler (`_reconcile_stale_vp_missions_on_startup`)
+    but runs continuously. Without this loop, a VP daemon that stops polling
+    the `vp_missions` table leaves its missions stuck in `running` state until
+    the next gateway restart — which is how the 2026-05-11 VP Coder mission
+    sat in `running` for 8+ hours after the work had already shipped via PR.
+
+    The underlying `_reconcile_stale_vp_missions_once` only finalizes rows
+    that exceed `_vp_stale_reconcile_seconds` of inactivity, so legitimate
+    in-progress missions are never disturbed.
+    """
+    interval = max(60.0, float(_vp_stale_reconcile_interval_seconds))
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            pass
+        if stop_event.is_set():
+            break
+        try:
+            reconciled = _reconcile_stale_vp_missions_on_startup()
+            if reconciled > 0:
+                logger.warning(
+                    "🧹 Periodic sweep reconciled %d stale running VP mission(s)",
+                    reconciled,
+                )
+        except Exception as exc:
+            logger.warning("Periodic VP stale-mission reconciliation failed: %s", exc)
+
+
 async def _hq_self_heartbeat_loop(stop_event: asyncio.Event) -> None:
     """Periodically refresh HQ's own factory registration so it stays 'online'."""
     _hq_heartbeat_interval = 60.0
@@ -14042,6 +14085,7 @@ async def lifespan(app: FastAPI):
     # Initialize SQLite-backed factory registry (survives gateway restarts)
     global _factory_registry, _factory_staleness_task, _factory_staleness_stop
     global _hq_self_heartbeat_task, _hq_self_heartbeat_stop
+    global _vp_stale_reconcile_task, _vp_stale_reconcile_stop
     try:
         _registry_conn = connect_registry_db()
         _factory_registry = FactoryRegistry(_registry_conn)
@@ -14691,6 +14735,20 @@ async def lifespan(app: FastAPI):
         else:
             logger.info("🧹 No stale running VP missions detected on startup")
 
+    # --- Periodic VP stale-mission reconciliation (covers daemons that stop
+    # polling between deploys; on-startup reconcile alone leaves multi-hour gaps). ---
+    if _vp_stale_reconcile_enabled:
+        _vp_stale_reconcile_stop = asyncio.Event()
+        _vp_stale_reconcile_task = asyncio.create_task(
+            _vp_stale_reconcile_loop(_vp_stale_reconcile_stop)
+        )
+        logger.info(
+            "🧹 VP stale-mission periodic sweep enabled "
+            "(interval=%ds, stale_threshold=%ds)",
+            _vp_stale_reconcile_interval_seconds,
+            _vp_stale_reconcile_seconds,
+        )
+
     if _vp_event_bridge_enabled:
         _vp_event_bridge_stop_event = asyncio.Event()
         _vp_event_bridge_task = asyncio.create_task(_vp_event_bridge_loop())
@@ -14776,6 +14834,13 @@ async def lifespan(app: FastAPI):
     if _hq_self_heartbeat_task is not None:
         try:
             await _hq_self_heartbeat_task
+        except Exception:
+            pass
+    if _vp_stale_reconcile_stop is not None:
+        _vp_stale_reconcile_stop.set()
+    if _vp_stale_reconcile_task is not None:
+        try:
+            await _vp_stale_reconcile_task
         except Exception:
             pass
     if _mission_control_sweeper_stop is not None:

--- a/tests/unit/test_vp_stale_reconcile_loop.py
+++ b/tests/unit/test_vp_stale_reconcile_loop.py
@@ -1,0 +1,138 @@
+"""Periodic VP stale-mission reconciliation loop.
+
+Motivation: 2026-05-11 VP Coder mission `vp-mission-aac933ded3b0d7238eabee89`
+sat in `status=running` for 8+ hours after its external daemon stopped polling
+and after the actual work shipped via a separate PR. The on-startup reconciler
+caught nothing because the gateway had not restarted in that window. This loop
+runs the reconciler periodically so the worst-case stuck-mission window is
+bounded by `_vp_stale_reconcile_interval_seconds` (default 5 min) instead of
+"until next deploy".
+"""
+
+import asyncio
+
+import pytest
+
+from universal_agent import gateway_server
+
+
+@pytest.mark.asyncio
+async def test_loop_calls_reconciler_each_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The loop invokes the underlying reconciler on each tick until stopped."""
+    call_count = {"n": 0}
+
+    def _fake_reconcile() -> int:
+        call_count["n"] += 1
+        return 0
+
+    monkeypatch.setattr(
+        gateway_server,
+        "_reconcile_stale_vp_missions_on_startup",
+        _fake_reconcile,
+    )
+    monkeypatch.setattr(gateway_server, "_vp_stale_reconcile_interval_seconds", 60)
+
+    stop_event = asyncio.Event()
+
+    async def _run_briefly() -> None:
+        # Drive the loop's asyncio.wait_for(stop_event, timeout=interval) using
+        # a tiny effective timeout by intercepting wait_for. We patch it so the
+        # first iteration completes immediately.
+        original_wait_for = asyncio.wait_for
+
+        async def _fast_wait_for(coro, timeout):  # noqa: ARG001
+            # Fire-and-forget the coroutine to avoid "coroutine was never awaited"
+            task = asyncio.create_task(coro)
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            raise asyncio.TimeoutError
+
+        monkeypatch.setattr(asyncio, "wait_for", _fast_wait_for)
+        try:
+            loop_task = asyncio.create_task(
+                gateway_server._vp_stale_reconcile_loop(stop_event)
+            )
+            # Let the loop tick a few times.
+            await asyncio.sleep(0.05)
+            stop_event.set()
+            monkeypatch.setattr(asyncio, "wait_for", original_wait_for)
+            await asyncio.wait_for(loop_task, timeout=2.0)
+        finally:
+            monkeypatch.setattr(asyncio, "wait_for", original_wait_for)
+
+    await _run_briefly()
+    assert call_count["n"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_loop_terminates_promptly_on_stop_event() -> None:
+    """Setting stop_event during the wait must terminate the loop quickly."""
+    stop_event = asyncio.Event()
+    loop_task = asyncio.create_task(
+        gateway_server._vp_stale_reconcile_loop(stop_event)
+    )
+    # Loop is sleeping. Signal stop and confirm it exits within a few seconds.
+    stop_event.set()
+    await asyncio.wait_for(loop_task, timeout=2.0)
+    assert loop_task.done()
+
+
+@pytest.mark.asyncio
+async def test_loop_survives_reconciler_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A throwing reconciler must not kill the loop — log and continue."""
+    call_count = {"n": 0}
+
+    def _raising_reconcile() -> int:
+        call_count["n"] += 1
+        raise RuntimeError("transient db error")
+
+    monkeypatch.setattr(
+        gateway_server,
+        "_reconcile_stale_vp_missions_on_startup",
+        _raising_reconcile,
+    )
+
+    stop_event = asyncio.Event()
+
+    async def _fast_wait_for(coro, timeout):  # noqa: ARG001
+        task = asyncio.create_task(coro)
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
+        raise asyncio.TimeoutError
+
+    original_wait_for = asyncio.wait_for
+    monkeypatch.setattr(asyncio, "wait_for", _fast_wait_for)
+    try:
+        loop_task = asyncio.create_task(
+            gateway_server._vp_stale_reconcile_loop(stop_event)
+        )
+        await asyncio.sleep(0.05)
+        stop_event.set()
+        monkeypatch.setattr(asyncio, "wait_for", original_wait_for)
+        await asyncio.wait_for(loop_task, timeout=2.0)
+    finally:
+        monkeypatch.setattr(asyncio, "wait_for", original_wait_for)
+
+    # Reconciler was called and the loop did not crash despite exceptions.
+    assert call_count["n"] >= 1
+    assert loop_task.done()
+    assert loop_task.exception() is None
+
+
+def test_interval_env_var_has_minimum_floor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """UA_VP_STALE_RECONCILE_INTERVAL_SECONDS below 60 must clamp to 60."""
+    # The constant is computed at import time, so re-derive using the same
+    # expression to confirm the floor behavior. This pins the contract that
+    # an operator can't accidentally schedule a sub-minute reconcile sweep.
+    monkeypatch.setenv("UA_VP_STALE_RECONCILE_INTERVAL_SECONDS", "5")
+    derived = max(
+        60,
+        int(__import__("os").getenv("UA_VP_STALE_RECONCILE_INTERVAL_SECONDS", "").strip() or 5 * 60),
+    )
+    assert derived == 60


### PR DESCRIPTION
## Summary

- Adds `_vp_stale_reconcile_loop`, a periodic async task that runs the existing on-startup VP stale-mission reconciler every `UA_VP_STALE_RECONCILE_INTERVAL_SECONDS` (default 5 min, floor 60s)
- Bounds worst-case stuck-mission window to ~5 min instead of "until next gateway restart"
- Mirrors the existing pattern of `_factory_staleness_enforcement_loop` and `_hq_self_heartbeat_loop`

## Why

Triggered by a real incident on 2026-05-11: VP Coder mission `vp-mission-aac933ded3b0d7238eabee89` sat in `status=running` for 8+ hours after its external daemon stopped polling the `vp_missions` table. The work it was assigned (ruff isort import-ordering cleanup) had already shipped via a separate PR hours earlier. The on-startup reconciler `_reconcile_stale_vp_missions_on_startup` correctly identifies stale missions and finalizes them — but only at gateway restart, which leaves a multi-hour gap any time a VP daemon dies between deploys.

This was flagged in the [Hermes plan doc § A.2 follow-on consideration](docs/reports/hermes-adaptation-phased-plan-2026-05-10.md#L161) but deferred. The 2026-05-11 incident moved it from "nice to have" to "next operator burden to remove."

## Behavior

| Knob | Env var | Default | Floor |
|---|---|---|---|
| Enabled | `UA_VP_STALE_RECONCILE_ENABLED` (existing, gated via `should_run_loop`) | true | n/a |
| Stale threshold | `UA_VP_STALE_RECONCILE_SECONDS` (existing) | 900s (15 min) | 60s |
| Sweep interval (new) | `UA_VP_STALE_RECONCILE_INTERVAL_SECONDS` | 300s (5 min) | 60s |

The stale threshold remains 15 min, so legitimate in-progress missions are never finalized — only rows with no updates for >15 min are touched.

## Test plan

- [x] `python -m py_compile src/universal_agent/gateway_server.py tests/unit/test_vp_stale_reconcile_loop.py`
- [x] `uv run --offline ruff check --select E9,F` — clean
- [x] `uv run --offline pytest tests/unit/test_vp_stale_reconcile_loop.py -v` — 4/4 pass:
  - `test_loop_calls_reconciler_each_interval`
  - `test_loop_terminates_promptly_on_stop_event`
  - `test_loop_survives_reconciler_exceptions`
  - `test_interval_env_var_has_minimum_floor`
- [x] Reuses battle-tested `_reconcile_stale_vp_missions_once` (5+ existing tests in `test_ops_api.py` lines 3656/3715)
- [x] Pattern identical to `_factory_staleness_enforcement_loop` (8839) and `_hq_self_heartbeat_loop` (8856)

🤖 Generated with [Claude Code](https://claude.com/claude-code)