### PR TITLE
feat(hermes-c): Atlas-direct-dispatch + Simone awareness

### DIFF
--- a/docs/operations/operating_hours_dormancy.md
+++ b/docs/operations/operating_hours_dormancy.md
@@ -42,6 +42,7 @@ These services run inside the dormancy window with documented justification:
 | Service | Schedule | Rationale |
 |---|---|---|
 | `nightly_wiki` | 3:15 AM Houston | Generates overnight wiki output that `morning_briefing` (6:30 AM) reads. Dormancy-window run gives the briefing fresh material. Exception #1 (downstream consumer). See [`gateway_server.py:18217`](../../src/universal_agent/gateway_server.py#L18217). |
+| `atlas_direct_dispatch` | Every 60s, 24/7, UTC | Hermes Phase C (PR #221) — independent dispatcher for tasks tagged `metadata.preferred_vp = "vp.general.primary"`. Exception #3 (latency-sensitive): Atlas-eligible tasks must dispatch within ~60s of being queued; waiting until 6 AM defeats the purpose. **Default OFF** via `UA_ATLAS_DIRECT_DISPATCH_ENABLED=0` — operator opts in after dry-run, so the 24/7 schedule has zero quota cost until enabled. The cron registration also goes through `_proactive_cron_enabled`, AND the script itself re-checks the env var before doing any work (belt-and-suspenders against accidental activation). See [`gateway_server.py:_ensure_atlas_direct_dispatch_cron_job`](../../src/universal_agent/gateway_server.py) and [`docs/reports/hermes-adaptation-phased-plan-2026-05-10.md`](../reports/hermes-adaptation-phased-plan-2026-05-10.md) § Phase C. |
 
 ## Active-hour services (subject to dormancy default)
 

--- a/docs/reports/hermes-adaptation-phased-plan-2026-05-10.md
+++ b/docs/reports/hermes-adaptation-phased-plan-2026-05-10.md
@@ -32,11 +32,11 @@
 | **B.1** — operator unstick verbs (`rehydrate` / `re_evaluate` / `redirect_to` / `request_revision`) | [#195](https://github.com/Kjdragan/universal_agent/pull/195) | shipped via [#198](https://github.com/Kjdragan/universal_agent/pull/198) | ✅ shipped to `main` 2026-05-11 |
 | **B.2** — dashboard failure-context endpoint + drawer UI + 4 unstick buttons | [#220](https://github.com/Kjdragan/universal_agent/pull/220) | `c1c121e5` | ✅ shipped to `main` 2026-05-11 |
 | **C** — Atlas-direct-dispatch + Simone awareness (independent cron-registered dispatcher) | [#221](https://github.com/Kjdragan/universal_agent/pull/221) | — | ✅ scaffolded 2026-05-11; default OFF via `UA_ATLAS_DIRECT_DISPATCH_ENABLED=0`; operator flips on after dry-run |
-| **D.1** — `task_hub_runs` attempt-history table + claim/finalize wiring | (current PR — see `claude/hermes-phase-d-task-hub-runs`) | — | ✅ shipped 2026-05-11; additive — D.2 (prompt/UI consumers) follows |
+| **D.1** — `task_hub_runs` attempt-history table + claim/finalize wiring | [#222](https://github.com/Kjdragan/universal_agent/pull/222) | `e00842d2` | ✅ shipped to `main` 2026-05-11; additive — D.2 (prompt/UI consumers) follows |
 
-> **Operator-supporting interlude (2026-05-11):** While B.2 was in flight, a stuck VP Coder mission ran `status=running` for 8+ hours after its external daemon stopped polling (workflow-side gap, not a Hermes regression). Two surgical follow-ups shipped same day: PR #218 added a minimum-interval guard to the cron `every_seconds` create path (closed a real retry-storm vector — two test crons with `every_seconds=2`), and PR #219 added a periodic `_vp_stale_reconcile_loop` so VP mission staleness is now reconciled every 5 min instead of "only at gateway startup". These bound the worst-case stuck-mission window to ~5 min and were not in the original phase scope but addressed the same operator-burden class the Hermes plan targets.
+> **Operator-supporting interludes (2026-05-11):** PR #218 added a minimum-interval guard on the cron `every_seconds` create path. PR #219 added a periodic `_vp_stale_reconcile_loop`. Both close real operator-burden vectors orthogonal to the lettered phases.
 
-### Phase B.1 — SHIPPED
+### Phase B.1 — SHIPPED via #198
 
 * **Branch:** `claude/hermes-phase-b1-unstick-verbs` (created off `origin/feature/latest2`, no commits yet at time of writing).
 * **Confirmed defaults from Kevin (2026-05-11 sync):**

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -14307,6 +14307,7 @@ async def lifespan(app: FastAPI):
                 _ensure_proactive_artifact_digest_cron_job()
                 _ensure_vp_coder_workspace_pruning_cron_job()
                 _ensure_hackernews_snapshot_cron_job()
+                _ensure_atlas_direct_dispatch_cron_job()
             except Exception as exc:
                 logger.warning("Failed ensuring autonomous cron jobs: %s", exc)
         else:
@@ -18381,6 +18382,33 @@ def _ensure_hackernews_snapshot_cron_job() -> Optional[dict[str, Any]]:
         enabled=_proactive_cron_enabled("UA_HACKERNEWS_SNAPSHOT_ENABLED"),
         cron_env_var="UA_HACKERNEWS_SNAPSHOT_CRON",
         timezone_env_var="UA_HACKERNEWS_SNAPSHOT_TIMEZONE",
+    )
+
+
+def _ensure_atlas_direct_dispatch_cron_job() -> Optional[dict[str, Any]]:
+    """Hermes Phase C — independent Atlas dispatcher.
+
+    Runs every 60s to dispatch tasks tagged `metadata.preferred_vp =
+    "vp.general.primary"` directly, bypassing Simone's heartbeat throttle.
+    Default OFF: operator opts in via `UA_ATLAS_DIRECT_DISPATCH_ENABLED=1`
+    after dry-run testing. The script itself also gates on that env var so
+    accidentally-enabled crons are still a no-op.
+
+    See `docs/reports/hermes-adaptation-phased-plan-2026-05-10.md` § Phase C.
+    """
+    return _register_system_cron_job(
+        system_job="atlas_direct_dispatch",
+        default_cron="*/1 * * * *",
+        default_timezone="UTC",
+        command="!script universal_agent.scripts.atlas_direct_dispatch",
+        description=(
+            "Independent Atlas dispatcher for preferred_vp-tagged tasks; "
+            "bypasses Simone-heartbeat throttle (Hermes Phase C)."
+        ),
+        timeout_seconds=60,
+        enabled=_proactive_cron_enabled("UA_ATLAS_DIRECT_DISPATCH_ENABLED"),
+        cron_env_var="UA_ATLAS_DIRECT_DISPATCH_CRON",
+        timezone_env_var="UA_ATLAS_DIRECT_DISPATCH_TIMEZONE",
     )
 
 

--- a/src/universal_agent/heartbeat_service.py
+++ b/src/universal_agent/heartbeat_service.py
@@ -492,6 +492,34 @@ def _compose_heartbeat_prompt(
                     lines.append("  → Delegation IS available. Use it for disparate tasks.")
                 else:
                     lines.append("  → All VP slots occupied. DEFER delegation or process yourself.")
+
+                # ── Hermes Phase C: Atlas-direct-dispatch FYI ──
+                # Surface tasks the independent Atlas-direct dispatcher has
+                # routed in the last 15 minutes so Simone retains situational
+                # awareness without going through her own heartbeat throttle.
+                try:
+                    from universal_agent.services.atlas_direct_dispatch import (
+                        list_recent_atlas_direct_dispatches,
+                    )
+                    recent = list_recent_atlas_direct_dispatches(
+                        runtime_conn, within_minutes=15, limit=10
+                    )
+                    if recent:
+                        lines.append("")
+                        lines.append(
+                            f"## Atlas Direct-Dispatch (last 15m, {len(recent)} mission(s))"
+                        )
+                        for entry in recent:
+                            preview = (entry.get("objective_preview") or "")[:80]
+                            tid = entry.get("task_id", "")
+                            status = entry.get("status", "")
+                            suffix = f" — {status}" if status else ""
+                            lines.append(f"  - {tid}{suffix}: {preview}")
+                        lines.append(
+                            "  → To take over: redirect_to(task_id, agent_id='simone')."
+                        )
+                except Exception as _atlas_fyi_exc:
+                    logger.debug("atlas_direct FYI injection failed: %s", _atlas_fyi_exc)
             except Exception as _cap_exc:
                 logger.debug("VP capacity injection failed: %s", _cap_exc)
 

--- a/src/universal_agent/scripts/atlas_direct_dispatch.py
+++ b/src/universal_agent/scripts/atlas_direct_dispatch.py
@@ -1,0 +1,59 @@
+"""Cron entrypoint — invoked via `!script universal_agent.scripts.atlas_direct_dispatch`.
+
+Hermes Phase C — runs every 60s when enabled. Dispatches Atlas-pre-tagged
+tasks without waiting for Simone's heartbeat. See
+`services/atlas_direct_dispatch.py` for the design rationale and
+`docs/reports/hermes-adaptation-phased-plan-2026-05-10.md` § Phase C.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from universal_agent.durable.db import connect_runtime_db, get_runtime_db_path
+from universal_agent.services.atlas_direct_dispatch import (
+    _is_enabled,
+    dispatch_atlas_candidates_once,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    if not _is_enabled():
+        logger.info(
+            "atlas_direct_dispatch disabled (UA_ATLAS_DIRECT_DISPATCH_ENABLED!=1); skipping"
+        )
+        return 0
+
+    try:
+        conn = connect_runtime_db(get_runtime_db_path())
+    except Exception:
+        logger.exception("atlas_direct_dispatch could not open runtime DB")
+        return 1
+
+    try:
+        result = asyncio.run(dispatch_atlas_candidates_once(conn))
+    except Exception:
+        logger.exception("atlas_direct_dispatch sweep crashed")
+        return 1
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    logger.info(
+        "atlas_direct_dispatch: dispatched=%d skipped=%d slots_at_start=%d reason=%s",
+        result.get("dispatched", 0),
+        result.get("skipped", 0),
+        result.get("remaining_slots_at_start", 0),
+        result.get("reason", ""),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/universal_agent/services/atlas_direct_dispatch.py
+++ b/src/universal_agent/services/atlas_direct_dispatch.py
@@ -1,0 +1,334 @@
+"""Hermes Phase C — Atlas-direct-dispatch service.
+
+Bypasses the Simone-heartbeat throttle for tasks pre-tagged with
+``metadata.preferred_vp = "vp.general.primary"``. Runs every 60s via a
+cron-registered ``!script`` entrypoint (``scripts/atlas_direct_dispatch``).
+
+Architectural context:
+  * Today, only Simone calls ``dispatch_vp_mission`` for Atlas (via her
+    heartbeat). When her heartbeat is busy or stalled, Atlas-eligible
+    work sits in ``task_hub_items`` even though Atlas has free slots.
+  * Phase C adds an independent caller that does the same dispatch
+    without waiting for Simone. The signal-curator pattern at
+    ``heartbeat_service.py:2225-2253`` is the precedent for this
+    bypass; Phase C generalizes it.
+
+v3 JSON-path: candidates are filtered on top-level
+``metadata.preferred_vp`` (the path used by ``proactive_convergence.py:562,
+646`` producers), NOT ``metadata.dispatch.preferred_vp``. The Atlas-direct
+TRACKING fields we ADD go under ``metadata.dispatch.atlas_direct_*`` for
+namespace consistency with retry counters.
+
+Safety:
+  * Default OFF — ``UA_ATLAS_DIRECT_DISPATCH_ENABLED=0`` (operator opts in
+    after dry-run). The cron registration also goes through
+    ``_proactive_cron_enabled``.
+  * Respects ``UA_MAX_CONCURRENT_VP_GENERAL`` slot cap (default 2).
+  * Idempotency at two layers: (1) atomic SQL claim via
+    ``json_set`` UPDATE on ``metadata.dispatch.atlas_direct_dispatched_at``
+    only matches NULL rows; (2) ``dispatch_vp_mission`` carries its own
+    ``idempotency_key=f"atlas-direct-{task_id}"`` so re-dispatch after
+    crash is caught downstream too.
+  * Filters out ``source_kind = "vp_mission"`` rows defensively
+    (the VP mirror rows from ``vp_orchestration.py:296-305``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from universal_agent import task_hub
+
+logger = logging.getLogger(__name__)
+
+
+# ── Configuration knobs ────────────────────────────────────────────────────
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, "").strip() or default)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _is_enabled() -> bool:
+    return str(os.getenv("UA_ATLAS_DIRECT_DISPATCH_ENABLED", "0")).strip() in {
+        "1",
+        "true",
+        "True",
+        "yes",
+    }
+
+
+# ── Pure functions (easy to unit-test) ─────────────────────────────────────
+
+
+def find_atlas_direct_candidates(
+    conn: sqlite3.Connection,
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Return task_hub_items rows eligible for Atlas-direct dispatch.
+
+    Eligibility:
+        * status = 'open'
+        * agent_ready = 1
+        * source_kind != 'vp_mission' (defensive: don't claim VP mirror rows)
+        * metadata.preferred_vp = 'vp.general.primary' (v3 top-level path)
+        * metadata.dispatch.atlas_direct_dispatched_at IS NULL (not claimed)
+
+    Returns up to ``limit`` rows, oldest first (FIFO).
+    """
+    if limit <= 0:
+        return []
+    rows = conn.execute(
+        """
+        SELECT task_id, title, description, metadata_json, project_key, priority
+        FROM task_hub_items
+        WHERE status = ?
+          AND agent_ready = 1
+          AND COALESCE(source_kind, '') != 'vp_mission'
+          AND json_extract(metadata_json, '$.preferred_vp') = ?
+          AND json_extract(metadata_json, '$.dispatch.atlas_direct_dispatched_at') IS NULL
+        ORDER BY created_at ASC
+        LIMIT ?
+        """,
+        (task_hub.TASK_STATUS_OPEN, "vp.general.primary", int(limit)),
+    ).fetchall()
+    candidates: list[dict[str, Any]] = []
+    for row in rows:
+        candidates.append(
+            {
+                "task_id": str(row["task_id"]),
+                "title": row["title"],
+                "description": row["description"],
+                "metadata_json": row["metadata_json"],
+                "project_key": row["project_key"],
+                "priority": row["priority"],
+            }
+        )
+    return candidates
+
+
+def try_claim_atlas_direct(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    now_iso: str | None = None,
+    assignee: str = "vp.general.primary",
+    objective_preview: str = "",
+) -> bool:
+    """Atomically mark a task as claimed for Atlas-direct dispatch.
+
+    Returns True if this caller successfully claimed (rowcount=1); False
+    if another sweep got there first (rowcount=0). This is the only
+    safe concurrency primitive in the dispatch path.
+    """
+    ts = now_iso or datetime.now(timezone.utc).isoformat()
+    preview = (objective_preview or "")[:120]
+    cursor = conn.execute(
+        """
+        UPDATE task_hub_items
+        SET metadata_json = json_set(
+                json_set(
+                    json_set(
+                        json_set(
+                            COALESCE(metadata_json, '{}'),
+                            '$.dispatch',
+                            COALESCE(json_extract(metadata_json, '$.dispatch'), json('{}'))
+                        ),
+                        '$.dispatch.atlas_direct_dispatched_at', ?
+                    ),
+                    '$.dispatch.atlas_direct_lane', ?
+                ),
+                '$.dispatch.atlas_direct_assignee', ?
+            ),
+            updated_at = ?
+        WHERE task_id = ?
+          AND json_extract(metadata_json, '$.dispatch.atlas_direct_dispatched_at') IS NULL
+        """,
+        (ts, "atlas_direct", assignee, ts, task_id),
+    )
+    claimed = cursor.rowcount == 1
+    if claimed and preview:
+        conn.execute(
+            "UPDATE task_hub_items SET metadata_json = json_set(metadata_json, "
+            "'$.dispatch.atlas_direct_objective_preview', ?) WHERE task_id = ?",
+            (preview, task_id),
+        )
+    return claimed
+
+
+def count_active_general_slots(conn: sqlite3.Connection) -> int:
+    """Count active general-VP assignments via the canonical task_hub helper.
+
+    Mirrors ``todo_dispatch_service._vp_active_counts`` but keeps the
+    full call self-contained (the helper there takes a list; we pass
+    the list pulled fresh from ``get_agent_activity``).
+    """
+    from universal_agent.services.todo_dispatch_service import _vp_active_counts
+
+    activity = task_hub.get_agent_activity(conn)
+    active_assignments = (
+        activity.get("active_assignments") if isinstance(activity, dict) else []
+    )
+    _coder, general = _vp_active_counts(active_assignments)
+    return int(general)
+
+
+# ── Orchestrator (async, callable from script or tests) ────────────────────
+
+
+async def dispatch_atlas_candidates_once(
+    conn: sqlite3.Connection,
+    *,
+    max_general_slots: int | None = None,
+    dispatch_fn: Any = None,
+) -> dict[str, Any]:
+    """One pass of the Atlas-direct dispatch sweep.
+
+    Args:
+        conn: Open SQLite connection to the runtime DB.
+        max_general_slots: Override for ``UA_MAX_CONCURRENT_VP_GENERAL``.
+            Defaults to the env value (or 2 if unset).
+        dispatch_fn: Injection seam for the dispatch coroutine. Defaults
+            to ``tools.vp_orchestration.dispatch_vp_mission``. Tests pass
+            a stub.
+
+    Returns: ``{"dispatched": N, "skipped": M, "remaining_slots_at_start":
+        K, "reason": <string when no dispatch>}``.
+    """
+    if dispatch_fn is None:
+        from universal_agent.tools.vp_orchestration import dispatch_vp_mission
+
+        dispatch_fn = dispatch_vp_mission
+
+    max_general = (
+        max_general_slots
+        if max_general_slots is not None
+        else _env_positive_int("UA_MAX_CONCURRENT_VP_GENERAL", 2)
+    )
+    active_general = count_active_general_slots(conn)
+    remaining = max_general - active_general
+    if remaining <= 0:
+        return {
+            "dispatched": 0,
+            "skipped": 0,
+            "remaining_slots_at_start": 0,
+            "reason": "atlas_at_capacity",
+        }
+
+    candidates = find_atlas_direct_candidates(conn, limit=remaining)
+    if not candidates:
+        return {
+            "dispatched": 0,
+            "skipped": 0,
+            "remaining_slots_at_start": remaining,
+            "reason": "no_candidates",
+        }
+
+    dispatched = 0
+    skipped = 0
+    for candidate in candidates:
+        task_id = candidate["task_id"]
+        description = str(candidate.get("description") or candidate.get("title") or "")
+        objective_preview = description[:120]
+        claimed = try_claim_atlas_direct(
+            conn,
+            task_id=task_id,
+            assignee="vp.general.primary",
+            objective_preview=objective_preview,
+        )
+        conn.commit()
+        if not claimed:
+            skipped += 1
+            continue
+        try:
+            await dispatch_fn(
+                vp_id="vp.general.primary",
+                objective=description,
+                mission_type="proactive_general",
+                idempotency_key=f"atlas-direct-{task_id}",
+                source_session_id="atlas_direct_dispatch",
+            )
+            dispatched += 1
+            logger.info(
+                "atlas_direct: dispatched task_id=%s objective_preview=%r",
+                task_id,
+                objective_preview[:60],
+            )
+        except Exception as exc:
+            # Record the failure on the task so the next sweep doesn't retry
+            # blindly. The atlas_direct_dispatched_at field stays set (the
+            # claim was real), so a second pass won't re-dispatch — operator
+            # must rehydrate via the Phase B.1 verbs to retry.
+            logger.warning(
+                "atlas_direct: dispatch_vp_mission failed for task_id=%s: %s",
+                task_id,
+                exc,
+            )
+            try:
+                conn.execute(
+                    "UPDATE task_hub_items SET metadata_json = json_set("
+                    "metadata_json, '$.dispatch.atlas_direct_dispatch_error', ?) "
+                    "WHERE task_id = ?",
+                    (str(exc)[:240], task_id),
+                )
+                conn.commit()
+            except Exception:
+                logger.exception(
+                    "atlas_direct: also failed to record dispatch error on task"
+                )
+
+    return {
+        "dispatched": dispatched,
+        "skipped": skipped,
+        "remaining_slots_at_start": remaining,
+        "reason": "ok" if dispatched else "all_claims_lost",
+    }
+
+
+def list_recent_atlas_direct_dispatches(
+    conn: sqlite3.Connection,
+    *,
+    within_minutes: int = 15,
+    limit: int = 25,
+) -> list[dict[str, Any]]:
+    """For Simone's briefing assembly (C.2).
+
+    Returns recently Atlas-direct-dispatched task summaries — task_id,
+    objective_preview, dispatched_at — for tasks still in flight.
+    """
+    rows = conn.execute(
+        """
+        SELECT task_id,
+               json_extract(metadata_json, '$.dispatch.atlas_direct_dispatched_at') AS dispatched_at,
+               json_extract(metadata_json, '$.dispatch.atlas_direct_objective_preview') AS objective_preview,
+               status
+        FROM task_hub_items
+        WHERE json_extract(metadata_json, '$.dispatch.atlas_direct_dispatched_at') IS NOT NULL
+          AND json_extract(metadata_json, '$.dispatch.atlas_direct_dispatched_at') >
+              datetime('now', ?)
+        ORDER BY json_extract(metadata_json, '$.dispatch.atlas_direct_dispatched_at') DESC
+        LIMIT ?
+        """,
+        (f"-{int(within_minutes)} minutes", int(limit)),
+    ).fetchall()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        out.append(
+            {
+                "task_id": str(row["task_id"]),
+                "dispatched_at": row["dispatched_at"],
+                "objective_preview": row["objective_preview"] or "",
+                "status": row["status"],
+            }
+        )
+    return out

--- a/tests/unit/test_atlas_direct_dispatch.py
+++ b/tests/unit/test_atlas_direct_dispatch.py
@@ -1,0 +1,334 @@
+"""Hermes Phase C — Atlas-direct-dispatch unit tests.
+
+Covers the service module that bypasses Simone's heartbeat throttle for
+tasks pre-tagged with ``metadata.preferred_vp = "vp.general.primary"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from typing import Any
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services import atlas_direct_dispatch as ada
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    task_hub.ensure_schema(conn)
+    return conn
+
+
+def _seed_task(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    status: str = task_hub.TASK_STATUS_OPEN,
+    agent_ready: bool = True,
+    source_kind: str = "internal",
+    metadata: dict[str, Any] | None = None,
+    description: str = "do the thing",
+) -> dict[str, Any]:
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": task_id,
+            "source_kind": source_kind,
+            "title": f"task {task_id}",
+            "description": description,
+            "status": status,
+            "agent_ready": agent_ready,
+            "metadata": metadata or {},
+        },
+    )
+    return task_hub.get_item(conn, task_id)
+
+
+# ── find_atlas_direct_candidates ──────────────────────────────────────────
+
+
+def test_finds_preferred_vp_tagged_open_task() -> None:
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="t1",
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+        candidates = ada.find_atlas_direct_candidates(conn, limit=5)
+        assert len(candidates) == 1
+        assert candidates[0]["task_id"] == "t1"
+    finally:
+        conn.close()
+
+
+def test_skips_untagged_task() -> None:
+    conn = _conn()
+    try:
+        _seed_task(conn, task_id="t2", metadata={})
+        assert ada.find_atlas_direct_candidates(conn, limit=5) == []
+    finally:
+        conn.close()
+
+
+def test_skips_vp_mission_mirror_rows() -> None:
+    """source_kind='vp_mission' is the VP mirror lane; never claim those."""
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="t3",
+            source_kind="vp_mission",
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+        assert ada.find_atlas_direct_candidates(conn, limit=5) == []
+    finally:
+        conn.close()
+
+
+def test_skips_already_dispatched_task() -> None:
+    """Idempotency: once atlas_direct_dispatched_at is set, never re-pick."""
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="t4",
+            metadata={
+                "preferred_vp": "vp.general.primary",
+                "dispatch": {"atlas_direct_dispatched_at": "2026-05-11T15:00:00+00:00"},
+            },
+        )
+        assert ada.find_atlas_direct_candidates(conn, limit=5) == []
+    finally:
+        conn.close()
+
+
+def test_skips_non_open_status() -> None:
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="t5",
+            status=task_hub.TASK_STATUS_REVIEW,
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+        assert ada.find_atlas_direct_candidates(conn, limit=5) == []
+    finally:
+        conn.close()
+
+
+# ── try_claim_atlas_direct ────────────────────────────────────────────────
+
+
+def test_claim_sets_tracking_fields_first_time() -> None:
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="claim1",
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+        ok = ada.try_claim_atlas_direct(
+            conn,
+            task_id="claim1",
+            now_iso="2026-05-11T15:00:00+00:00",
+            objective_preview="do this thing now",
+        )
+        assert ok is True
+        item = task_hub.get_item(conn, "claim1")
+        dispatch = (item.get("metadata") or {}).get("dispatch", {})
+        assert dispatch["atlas_direct_dispatched_at"] == "2026-05-11T15:00:00+00:00"
+        assert dispatch["atlas_direct_lane"] == "atlas_direct"
+        assert dispatch["atlas_direct_assignee"] == "vp.general.primary"
+        assert dispatch["atlas_direct_objective_preview"] == "do this thing now"
+    finally:
+        conn.close()
+
+
+def test_claim_rejects_second_call() -> None:
+    """Atomic claim: the second caller must get False, no fields overwritten."""
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="claim2",
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+        first = ada.try_claim_atlas_direct(
+            conn, task_id="claim2", now_iso="2026-05-11T15:00:00+00:00"
+        )
+        second = ada.try_claim_atlas_direct(
+            conn, task_id="claim2", now_iso="2026-05-11T15:05:00+00:00"
+        )
+        assert first is True
+        assert second is False
+        item = task_hub.get_item(conn, "claim2")
+        # First claim's timestamp is preserved.
+        assert (item["metadata"]["dispatch"]["atlas_direct_dispatched_at"]
+                == "2026-05-11T15:00:00+00:00")
+    finally:
+        conn.close()
+
+
+# ── dispatch_atlas_candidates_once ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_dispatches_and_records_idempotency() -> None:
+    """End-to-end: candidate found → claim sets fields → dispatch_fn called once."""
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="e2e1",
+            description="generate the daily briefing",
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+
+        dispatched_calls: list[dict[str, Any]] = []
+
+        async def _stub_dispatch(**kwargs) -> dict[str, Any]:
+            dispatched_calls.append(kwargs)
+            return {"ok": True, "mission_id": "vp-mission-stub"}
+
+        result = await ada.dispatch_atlas_candidates_once(
+            conn,
+            max_general_slots=2,
+            dispatch_fn=_stub_dispatch,
+        )
+        assert result["dispatched"] == 1
+        assert result["skipped"] == 0
+        assert len(dispatched_calls) == 1
+        call = dispatched_calls[0]
+        assert call["vp_id"] == "vp.general.primary"
+        assert call["mission_type"] == "proactive_general"
+        assert call["idempotency_key"] == "atlas-direct-e2e1"
+        assert call["source_session_id"] == "atlas_direct_dispatch"
+        assert call["objective"] == "generate the daily briefing"
+
+        item = task_hub.get_item(conn, "e2e1")
+        dispatch = (item.get("metadata") or {}).get("dispatch", {})
+        assert dispatch.get("atlas_direct_dispatched_at")
+        assert dispatch.get("atlas_direct_assignee") == "vp.general.primary"
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_respects_max_slots() -> None:
+    conn = _conn()
+    try:
+        for i in range(3):
+            _seed_task(
+                conn,
+                task_id=f"slot{i}",
+                metadata={"preferred_vp": "vp.general.primary"},
+            )
+
+        called: list[Any] = []
+
+        async def _stub_dispatch(**kwargs):
+            called.append(kwargs)
+            return {"ok": True, "mission_id": f"mid-{len(called)}"}
+
+        result = await ada.dispatch_atlas_candidates_once(
+            conn,
+            max_general_slots=2,  # cap = 2 slots, 0 active → 2 remaining
+            dispatch_fn=_stub_dispatch,
+        )
+        assert result["dispatched"] == 2
+        assert len(called) == 2
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_records_error_and_locks_task_when_dispatch_fails() -> None:
+    """If dispatch_vp_mission raises, the task is claim-locked + error recorded.
+
+    The next sweep MUST NOT re-dispatch (operator must rehydrate via B.1).
+    """
+    conn = _conn()
+    try:
+        _seed_task(
+            conn,
+            task_id="fail1",
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+
+        async def _failing_dispatch(**kwargs) -> dict[str, Any]:
+            raise RuntimeError("upstream VP unreachable")
+
+        result = await ada.dispatch_atlas_candidates_once(
+            conn,
+            max_general_slots=2,
+            dispatch_fn=_failing_dispatch,
+        )
+        assert result["dispatched"] == 0
+        item = task_hub.get_item(conn, "fail1")
+        dispatch = (item.get("metadata") or {}).get("dispatch", {})
+        # Claim went through (task is locked) AND error was recorded.
+        assert dispatch.get("atlas_direct_dispatched_at")
+        assert "upstream VP unreachable" in dispatch.get(
+            "atlas_direct_dispatch_error", ""
+        )
+
+        # Second sweep: claim already taken, no candidates remain.
+        assert ada.find_atlas_direct_candidates(conn, limit=5) == []
+    finally:
+        conn.close()
+
+
+# ── list_recent_atlas_direct_dispatches (C.2 briefing) ──────────────────
+
+
+def test_list_recent_returns_dispatched_tasks_only() -> None:
+    conn = _conn()
+    try:
+        # Dispatched recently.
+        ada.try_claim_atlas_direct(
+            conn,
+            task_id="recent1",
+            now_iso="2026-05-11T15:00:00+00:00",
+            objective_preview="recent task",
+        )
+        _seed_task(
+            conn,
+            task_id="recent1",
+            metadata={
+                "preferred_vp": "vp.general.primary",
+                "dispatch": {
+                    "atlas_direct_dispatched_at": "2026-05-11T15:00:00+00:00",
+                    "atlas_direct_objective_preview": "recent task",
+                },
+            },
+        )
+        # Not dispatched.
+        _seed_task(
+            conn,
+            task_id="never",
+            metadata={"preferred_vp": "vp.general.primary"},
+        )
+        # The within_minutes filter uses datetime('now', '-15 minutes') in
+        # SQLite, so seed a row with a fresh-enough timestamp via a direct
+        # update relative to the SQLite session's now().
+        conn.execute(
+            "UPDATE task_hub_items SET metadata_json = json_set(metadata_json, "
+            "'$.dispatch.atlas_direct_dispatched_at', "
+            "strftime('%Y-%m-%dT%H:%M:%fZ', datetime('now', '-2 minutes'))) "
+            "WHERE task_id = ?",
+            ("recent1",),
+        )
+        rows = ada.list_recent_atlas_direct_dispatches(
+            conn, within_minutes=15, limit=10
+        )
+        ids = [r["task_id"] for r in rows]
+        assert "recent1" in ids
+        assert "never" not in ids
+    finally:
+        conn.close()

--- a/tests/unit/test_cron_dormancy_defaults.py
+++ b/tests/unit/test_cron_dormancy_defaults.py
@@ -31,6 +31,12 @@ DORMANCY_DOC = Path("docs/operations/operating_hours_dormancy.md")
 # section of the operating_hours_dormancy.md doc.
 DOCUMENTED_EXCEPTIONS = {
     "nightly_wiki",  # 3:15 AM Houston — feeds 6:30 AM morning briefing
+    # Hermes Phase C (PR #221): every-60s dispatcher for tasks tagged
+    # metadata.preferred_vp = "vp.general.primary". Default OFF via
+    # UA_ATLAS_DIRECT_DISPATCH_ENABLED=0. Exception #3 (latency-sensitive):
+    # Atlas-eligible tasks must dispatch within ~60s of being queued, not
+    # wait until 6 AM. See operating_hours_dormancy.md exceptions table.
+    "atlas_direct_dispatch",
 }
 
 # Hours considered active in America/Chicago. 6 AM start (operator wakes),


### PR DESCRIPTION
## Summary

Closes Phase C of the [Hermes adaptation plan](docs/reports/hermes-adaptation-phased-plan-2026-05-10.md). Stops throttling Atlas behind Simone's heartbeat by adding an independent cron-registered dispatcher that calls \`dispatch_vp_mission\` directly for tasks tagged \`metadata.preferred_vp = \"vp.general.primary\"\`. Simone retains awareness via a new briefing FYI section.

## What's in this PR

**C.1 — Independent dispatcher**
- New \`src/universal_agent/services/atlas_direct_dispatch.py\` (testable service)
- New \`src/universal_agent/scripts/atlas_direct_dispatch.py\` (thin \`!script\` cron entrypoint)
- \`gateway_server.py\` — new \`_ensure_atlas_direct_dispatch_cron_job()\` (every 60s, default OFF) wired into startup

**C.2 — Simone briefing FYI**
- \`heartbeat_service.py\` — extends VP Capacity block with \"Atlas Direct-Dispatch (last 15m)\" section listing task_id + objective_preview + status, plus operator guidance directing Simone to \`redirect_to(task_id, agent_id='simone')\` if she wants to take over

## Safety

- **Default OFF** — \`UA_ATLAS_DIRECT_DISPATCH_ENABLED=0\`. The cron registration goes through \`_proactive_cron_enabled\` AND the script body re-checks the env var (belt-and-suspenders). Operator flips it on after dry-run.
- **Slot cap respected** — uses \`_vp_active_counts\` to clamp dispatches to \`UA_MAX_CONCURRENT_VP_GENERAL\` (default 2).
- **Two-layer idempotency** — (1) atomic SQL claim only matches rows where \`atlas_direct_dispatched_at IS NULL\`; (2) downstream \`dispatch_vp_mission\` carries \`idempotency_key=f\"atlas-direct-{task_id}\"\` to catch any reorderings.

## v3 correctness

Per the plan doc's v3 correction note: filter reads top-level \`metadata.preferred_vp\` (the path set by \`proactive_convergence.py:562, 646\` producers), NOT \`metadata.dispatch.preferred_vp\`. Tracking fields we ADD live under \`metadata.dispatch.atlas_direct_*\` for namespace consistency with retry counters.

## Test plan

- [x] \`python -m py_compile\` — all 5 touched files
- [x] \`uv run --offline ruff check --select E9,F\` — clean
- [x] \`uv run --offline pytest tests/unit/test_atlas_direct_dispatch.py -v\` — 11/11 pass:
  - \`test_finds_preferred_vp_tagged_open_task\` (positive)
  - \`test_skips_untagged_task\`
  - \`test_skips_vp_mission_mirror_rows\`
  - \`test_skips_already_dispatched_task\` (idempotency)
  - \`test_skips_non_open_status\`
  - \`test_claim_sets_tracking_fields_first_time\`
  - \`test_claim_rejects_second_call\` (atomic claim)
  - \`test_orchestrator_dispatches_and_records_idempotency\` (end-to-end with stub)
  - \`test_orchestrator_respects_max_slots\`
  - \`test_orchestrator_records_error_and_locks_task_when_dispatch_fails\`
  - \`test_list_recent_returns_dispatched_tasks_only\` (C.2 briefing)
- [ ] **Operator dry-run** — once merged + deployed, flip \`UA_ATLAS_DIRECT_DISPATCH_ENABLED=1\` (Infisical) and watch \`journalctl -u universal-agent-gateway\` for \`atlas_direct: dispatched task_id=...\` log lines, plus check Simone's next heartbeat briefing for the new FYI section

🤖 Generated with [Claude Code](https://claude.com/claude-code)