### PR TITLE
chore+docs+ci: clarify dormancy scope, file CI failure issues, .mcp.json fix

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -1,0 +1,96 @@
+name: CI Failure Issue Filer
+
+# Surfaces failed workflow runs as GitHub issues so the operator (and any
+# AI session reading the issue feed) discovers them immediately instead of
+# learning hours later that PR #N's Validate run failed silently.
+#
+# Background (observed 2026-05-11): PR #221 had a failing `Validate PR`
+# run that sat unnoticed for hours. The operator's prompt — "Do we not
+# have a process to follow up on it or retry until successful or fixed?"
+# — exposed the gap: GitHub's notification UI surfaces failures, but
+# autonomous AI sessions don't watch the UI and operator inbox volume
+# meant the email got lost.
+#
+# Mechanism: `workflow_run` triggers on any registered workflow finishing.
+# We filter to `conclusion == failure` and open one issue per failed run
+# (dedup is per-run-id — re-runs get their own issue).
+#
+# Runs 24/7. Per docs/operations/operating_hours_dormancy.md § "Scope":
+# infrastructure-event handlers like CI failure handling are NOT subject
+# to the active-hours dormancy default. A PR that fails at 3 AM should be
+# surfaced for morning fix, not silently broken until 6 AM.
+
+on:
+  workflow_run:
+    workflows:
+      - Deploy
+      - PR Validate
+      - PR Auto-Merge
+      - Post-Merge Deploy Dispatcher
+      - Auto-Promote to Production
+      - Nightly Documentation Drift Audit
+      - OpenClaw Release Sync
+    types: [completed]
+
+permissions:
+  issues: write
+  contents: read
+  actions: read
+
+jobs:
+  file-issue:
+    if: github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Ensure ci-failure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create ci-failure \
+            --repo "${REPO}" \
+            --color B60205 \
+            --description "Auto-filed by ci-failure-issue.yml when a workflow run fails" \
+            2>/dev/null || true
+
+      - name: Open issue for failed run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EVENT: ${{ github.event.workflow_run.event }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          TITLE="[ci-watchdog] ${WORKFLOW_NAME} failed on ${HEAD_BRANCH} (${SHORT_SHA})"
+
+          # Dedup: don't re-file if an issue already exists for this exact run.
+          EXISTING=$(gh issue list \
+            --label ci-failure \
+            --state open \
+            --search "in:title \"${RUN_ID}\"" \
+            --json number \
+            --jq 'length')
+          if [ "${EXISTING}" -gt 0 ]; then
+            echo "Issue already exists for run ${RUN_ID}; skipping."
+            exit 0
+          fi
+
+          {
+            printf 'Workflow **%s** failed.\n\n' "${WORKFLOW_NAME}"
+            printf -- '- Run: [%s](%s)\n' "${RUN_ID}" "${RUN_URL}"
+            printf -- '- Branch: `%s`\n' "${HEAD_BRANCH}"
+            printf -- '- Head SHA: `%s`\n' "${SHORT_SHA}"
+            printf -- '- Triggering event: `%s`\n\n' "${EVENT}"
+            printf -- '---\n\n'
+            printf 'Auto-filed by `ci-failure-issue.yml`. Close once fixed or superseded by a passing re-run.\n'
+          } > /tmp/issue-body.md
+
+          gh issue create \
+            --title "${TITLE} — run_id=${RUN_ID}" \
+            --body-file /tmp/issue-body.md \
+            --label ci-failure

--- a/.mcp.json
+++ b/.mcp.json
@@ -51,8 +51,6 @@
       ]
     },
 
-    "_comment_zai_scope": "The two MCPs below (web-reader, web-search-prime) are ZAI-tier-gated remote HTTP MCPs designed for the GLM Coding Plan. They consume ZAI plan quota (Max = 4000 reads + searches/month combined). APPROPRIATE in autonomous mode (Atlas/Simone/Cody-normal/cron — anything inferred via the Z.ai Anthropic-compat endpoint at https://api.z.ai/api/anthropic). NOT APPROPRIATE for Kevin's interactive Anthropic-Max sessions or for /opt/ua_demos/ workspaces — those should use Anthropic-native tools (WebFetch, WebSearch). See docs/06_Deployment_And_Environments/10_Interactive_Coding_Environment.md § 'Tool Surface by Execution Mode' for the full matrix. CLAUDE.md Pre-Implementation Reading also points here.",
-
     "web-reader": {
       "type": "http",
       "url": "https://api.z.ai/api/mcp/web_reader/mcp",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,11 +113,13 @@ The ClaudeDevs X intel pipeline is undergoing a v2 rebuild. Two living docs trac
 
 **Active window: 6:00 AM – 9:00 PM Houston time.** **Dormant window: 9:00 PM – 6:00 AM Houston time.**
 
-By default, every cron job, polling loop, scheduled GitHub Actions workflow, or background service runs **only during the active window**. Use `default_timezone="America/Chicago"` (or `TZ=America/Chicago` in cron strings) so DST is handled automatically. GitHub Actions schedules are UTC-only — express in UTC and accept the 1h DST drift.
+By default, **content-generation** cron jobs, polling loops, and scheduled GitHub Actions workflows run **only during the active window**. Use `default_timezone="America/Chicago"` (or `TZ=America/Chicago` in cron strings) so DST is handled automatically. GitHub Actions schedules are UTC-only — express in UTC and accept the 1h DST drift.
 
-**Why:** the operator does not want infrastructure burning quota / firing emails / restarting processes / running LLM calls while he's asleep. Most "intelligence" surfaces are read in the morning anyway — generating them at 3 AM provides zero operational value but adds cost.
+**Scope: dormancy is a content-policy, not a global cron gate.** It applies to crons that burn quota/tokens to produce intelligence nobody reads until morning (HackerNews polls, briefing materials, drift audits). It does **NOT** apply to infrastructure-event handlers — deploy workflows, auto-merge, CI/PR failure handling, error alerting. Those run 24/7 because a merge can land or a CI run can fail at any wall-clock time, and silently broken production until 6 AM is unacceptable. Event-driven GHA workflows (triggered by `push`/`pull_request`/`workflow_run`) are not subject to dormancy mechanically either.
 
-**Adding a new cron job:** check whether it qualifies as a documented exception (downstream-consumer dependency during dormancy / transient-data capture / latency-sensitive incident response). If none apply, schedule inside the active window. See [`docs/operations/operating_hours_dormancy.md`](docs/operations/operating_hours_dormancy.md) for the exception checklist + currently-registered exceptions.
+**Why:** the operator does not want infrastructure burning quota / firing emails / restarting processes / running LLM calls while he's asleep. Most "intelligence" surfaces are read in the morning anyway — generating them at 3 AM provides zero operational value but adds cost. Infrastructure event handling is the opposite — its cost is near-zero and the cost of delay is high.
+
+**Adding a new cron job:** classify it first. Content-generation → respect dormancy. Infrastructure-event handler → 24/7, add to `DOCUMENTED_EXCEPTIONS` citing Exception #3 (latency-sensitive incident response). See [`docs/operations/operating_hours_dormancy.md`](docs/operations/operating_hours_dormancy.md) for the full scope rules + currently-registered exceptions.
 
 A guard test (`tests/unit/test_cron_dormancy_defaults.py`) pins active-hour schedules and asserts new crons fall inside the active window unless they're listed as exceptions in the doc.
 

--- a/docs/operations/operating_hours_dormancy.md
+++ b/docs/operations/operating_hours_dormancy.md
@@ -25,6 +25,26 @@ The operator (Kevin) does not want infrastructure burning quota / firing emails 
 
 Default-dormant moves the operating tempo to the operator's actual day.
 
+## Scope: this is a content-generation policy, not a global cron gate
+
+The dormancy default exists to suppress **wasteful work** — crons that burn quota or tokens to produce material no human will read until morning. It is **not** a license to turn off production-health automation overnight.
+
+**Subject to dormancy (default 6 AM – 9 PM Houston):**
+
+- Content-generation crons: HackerNews snapshot, briefing materials, proactive reports, doc drift audit, openclaw release sync, intel pipeline material production
+- Quota-burning polls: scheduled LLM runs that synthesize observations into briefings
+- Anything that costs API calls / tokens / network calls to produce intelligence
+
+**NOT subject to dormancy (24/7 by design):**
+
+- Deploy workflows (`deploy.yml`, `post-merge-deploy.yml`) — a merge to main can happen at any wall-clock time and the resulting deploy must fire
+- Auto-merge (`pr-auto-merge.yml`) — PRs land when CI completes, regardless of clock
+- CI / PR failure handling (`ci-failure-issue.yml`) — a failed run at 3 AM should be surfaced for morning fix, not silently broken for 7 hours
+- Error alerting, secret rotation alerts, security event handlers
+- GitHub Actions workflows triggered by `push` / `pull_request` / `workflow_run` events — these are event-driven, not scheduled, so the policy doesn't apply mechanically
+
+**Decision rule when registering a new cron:** if disabling the cron during sleep hours loses the operator nothing (intel will be regenerated in the morning anyway), it belongs in the active window. If disabling it during sleep hours means production is broken / merges are stuck / failures are silent until 6 AM, it must run 24/7 (add to `DOCUMENTED_EXCEPTIONS` with rationale citing Exception #3 below — latency-sensitive incident response).
+
 ## Exceptions
 
 Some services genuinely need 24/7 operation. Adding a new cron requires this checklist:

--- a/tests/unit/test_cron_dormancy_defaults.py
+++ b/tests/unit/test_cron_dormancy_defaults.py
@@ -23,6 +23,8 @@ GATEWAY_SERVER = Path("src/universal_agent/gateway_server.py")
 NIGHTLY_DOC_DRIFT = Path(".github/workflows/nightly-doc-drift-audit.yml")
 OPENCLAW_SYNC = Path(".github/workflows/openclaw-release-sync.yml")
 DORMANCY_DOC = Path("docs/operations/operating_hours_dormancy.md")
+POST_MERGE_DEPLOY = Path(".github/workflows/post-merge-deploy.yml")
+CI_FAILURE_ISSUE = Path(".github/workflows/ci-failure-issue.yml")
 
 # Documented exceptions (services that genuinely run inside the dormancy
 # window per the exception checklist in operating_hours_dormancy.md).
@@ -230,4 +232,54 @@ def test_openclaw_release_sync_runs_in_active_hours() -> None:
         f"openclaw-release-sync cron={cron!r} hits UTC hour(s) "
         f"{sorted(hours - safe_utc_active)} outside the safe DST-overlap "
         f"active window 12-01 UTC."
+    )
+
+
+# ─── infrastructure-event-handler tripwires ───────────────────────────
+# These are NOT subject to dormancy (they handle real-world events whose
+# timing is uncontrollable — merges, PR failures, deploys). See
+# docs/operations/operating_hours_dormancy.md § "Scope". Tests here just
+# pin that the files exist so a future cleanup can't silently remove them
+# and re-introduce the gaps that PR #224 / this PR closed.
+
+
+def test_post_merge_deploy_workflow_exists() -> None:
+    """Bridge workflow that dispatches Deploy on PR merge.
+
+    Closes the GITHUB_TOKEN downstream-trigger suppression gap. If this
+    file goes missing, merges to main stop firing Deploy and production
+    silently drifts behind main. Added 2026-05-11 via PR #224.
+    """
+    assert POST_MERGE_DEPLOY.exists(), (
+        f"Missing {POST_MERGE_DEPLOY} — without it, merges to main via "
+        f"the GITHUB_TOKEN-driven pr-auto-merge.yml will NOT trigger "
+        f"deploy.yml (per GitHub's downstream-trigger suppression rule). "
+        f"Restore the file or update the PR-merge flow to use a PAT."
+    )
+    body = POST_MERGE_DEPLOY.read_text(encoding="utf-8")
+    assert "pull_request" in body and "closed" in body
+    assert "workflow run deploy.yml" in body, (
+        "post-merge-deploy.yml must dispatch deploy.yml via workflow_dispatch; "
+        "that's the whole point — workflow_dispatch IS on GitHub's allow-list "
+        "of GITHUB_TOKEN-triggerable workflows."
+    )
+
+
+def test_ci_failure_issue_filer_workflow_exists() -> None:
+    """Workflow that opens an issue on failed workflow runs.
+
+    Surfaces silent CI failures (like PR #221's Validate failure that sat
+    unnoticed) so autonomous AI sessions and the operator both discover
+    them immediately. Added 2026-05-11.
+    """
+    assert CI_FAILURE_ISSUE.exists(), (
+        f"Missing {CI_FAILURE_ISSUE} — without it, failed workflow runs "
+        f"can sit unnoticed for hours. Restore the file or replace with "
+        f"a different notification mechanism."
+    )
+    body = CI_FAILURE_ISSUE.read_text(encoding="utf-8")
+    assert "workflow_run" in body
+    assert "conclusion == 'failure'" in body, (
+        "ci-failure-issue.yml must gate on conclusion=='failure'; otherwise "
+        "it spams issues on every successful run."
     )


### PR DESCRIPTION
## Summary

Three small but related production-health changes:

1. **Dormancy scope clarification** (CLAUDE.md + `docs/operations/operating_hours_dormancy.md`) — the active-hours default is a *content-generation* policy, not a global cron gate. Infrastructure-event handlers (deploy, auto-merge, CI failure handling) run 24/7 because their event timing is uncontrollable.
2. **CI failure issue filer** (`.github/workflows/ci-failure-issue.yml`) — new `workflow_run` listener that opens a `ci-failure`-labeled issue on any failed run of Deploy / PR Validate / Auto-Merge / Post-Merge Deploy / Auto-Promote / nightly-drift / openclaw-release-sync. Closes the gap that surfaced with PR #221's silent Validate failure.
3. **Tripwire tests** so `post-merge-deploy.yml` (from PR #224) and `ci-failure-issue.yml` can't silently regress.
4. **`.mcp.json` schema fix** — removed `_comment_zai_scope` key from inside `mcpServers` (MCP schema only allows real server entries). Was breaking `/doctor`.

## Why this exists

The operator's question — "Do we not have a process to follow up on PRs or retry until successful?" — exposed that:

- PR #221 had a failing Validate that sat unnoticed for hours
- 4 PRs today merged via GITHUB_TOKEN without firing Deploy (fixed by PR #224)
- No autonomous AI session watches the GitHub notifications UI

PR #224 closed the merge-without-deploy gap. This PR closes the silent-failure gap by filing an issue (which AI sessions and the operator both can scan) on every failed CI run.

The dormancy clarification is a separate but related fix: my first cut at the watchdog was active-hours-only, which defeats the purpose. Codifying the content-vs-infrastructure distinction in CLAUDE.md prevents that mistake recurring.

## Test plan

- [x] `uv run pytest tests/unit/test_cron_dormancy_defaults.py` → 9 passed (includes 2 new tripwires)
- [x] `python3 -c "import json; json.load(open('.mcp.json'))"` → ok
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-failure-issue.yml'))"` → ok
- [x] `uv run ruff check tests/unit/test_cron_dormancy_defaults.py` → All checks passed
- [ ] Post-merge: verify the new `ci-failure-issue.yml` workflow appears in Actions list
- [ ] Post-merge: any future failed run files an issue with the `ci-failure` label

🤖 Generated with [Claude Code](https://claude.com/claude-code)