### PR TITLE
chore(crons): spread schedules to dodge bunching + hackernews_snapshot ticks

### DIFF
--- a/.github/workflows/nightly-doc-drift-audit.yml
+++ b/.github/workflows/nightly-doc-drift-audit.yml
@@ -2,12 +2,14 @@ name: Nightly Documentation Drift Audit
 
 on:
   schedule:
-    # 12:17 UTC ≈ 7:17 AM CDT / 6:17 AM CST — inside the operating-hours
-    # window per docs/operations/operating_hours_dormancy.md (the
-    # operator wants no overnight workflow noise). Pre-2026-05-10 this
-    # ran at 08:17 UTC (3:17 AM CDT) which violated the dormancy default.
-    # 17-minute offset is GHA scheduling-delay mitigation (off-peak minute).
-    - cron: '17 12 * * *'
+    # 18:35 UTC ≈ 1:35 PM CDT / 12:35 PM CST — inside the operating-hours
+    # window per docs/operations/operating_hours_dormancy.md.
+    # 2026-05-11: moved out of the 7-8 AM CDT bunch (was 12:17 UTC) into
+    # the early-afternoon quiet slot between proactive_report_midday
+    # (12:05 PM) and csi_demo_triage_rank #2 (3:05 PM). 35-min minute
+    # offset is GHA scheduling-delay mitigation AND dodges the half-
+    # hourly hackernews_snapshot ticks at :00 / :30.
+    - cron: '35 18 * * *'
   workflow_dispatch:
     inputs:
       since_hours:

--- a/.github/workflows/openclaw-release-sync.yml
+++ b/.github/workflows/openclaw-release-sync.yml
@@ -2,12 +2,13 @@ name: OpenClaw Release Sync
 
 on:
   schedule:
-    # Twice weekly: Tuesday 12:13 UTC and Friday 12:13 UTC
-    # ≈ 7:13 AM CDT / 6:13 AM CST — inside the operating-hours window
-    # per docs/operations/operating_hours_dormancy.md. Pre-2026-05-10
-    # this ran at 10:13 UTC (5:13 AM CDT) which violated the dormancy
-    # default. 13-minute offset is GHA scheduling-delay mitigation.
-    - cron: '13 12 * * 2,5'
+    # Twice weekly: Tuesday 20:35 UTC and Friday 20:35 UTC
+    # ≈ 3:35 PM CDT / 2:35 PM CST — inside the operating-hours window
+    # per docs/operations/operating_hours_dormancy.md. 2026-05-11: moved
+    # out of the 7-8 AM CDT bunch (was 12:13 UTC) into the mid-afternoon
+    # slot between csi_demo_triage_rank #2 (3:05 PM) and proactive_report
+    # _afternoon (4:05 PM). 35-min offset dodges hackernews_snapshot ticks.
+    - cron: '35 20 * * 2,5'
   workflow_dispatch:
     inputs:
       force_rescan:

--- a/docs/operations/operating_hours_dormancy.md
+++ b/docs/operations/operating_hours_dormancy.md
@@ -68,23 +68,36 @@ These services run inside the dormancy window with documented justification:
 
 These run only during 6 AM – 9 PM Houston:
 
+All times Houston (America/Chicago) unless noted. Schedules spread on 2026-05-11 — see "Cron spread (2026-05-11)" below for rationale.
+
 | Service | Schedule | Source |
 |---|---|---|
-| `vp_coder_workspace_pruning` | 7:00 AM Sun Houston (weekly) | [`gateway_server.py:17921`](../../src/universal_agent/gateway_server.py#L17921) |
-| `morning_briefing` | 6:30 AM daily Houston | [`gateway_server.py:18238`](../../src/universal_agent/gateway_server.py#L18238) |
-| `hackernews_snapshot` | every 30m, 6 AM–9 PM Houston | [`gateway_server.py:18256`](../../src/universal_agent/gateway_server.py#L18256) |
-| `proactive_report_morning` | 7:00 AM daily Houston | [`gateway_server.py:18270`](../../src/universal_agent/gateway_server.py#L18270) |
-| `proactive_report_midday` | 12:00 PM daily Houston | [`gateway_server.py:18284`](../../src/universal_agent/gateway_server.py#L18284) |
-| `proactive_report_afternoon` | 4:00 PM daily Houston | [`gateway_server.py:18298`](../../src/universal_agent/gateway_server.py#L18298) |
-| `proactive_artifact_digest` | 8:00 AM daily Houston | [`gateway_server.py:18312`](../../src/universal_agent/gateway_server.py#L18312) |
-| `csi_demo_triage_rank` | 8:15 AM, 2:15 PM CDT (twice daily) | [`gateway_server.py:18480`](../../src/universal_agent/gateway_server.py#L18480) |
+| `morning_briefing` | 6:30 AM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `proactive_report_morning` | 7:05 AM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `proactive_artifact_digest` | 8:35 AM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `csi_demo_triage_rank` | 10:05 AM, 3:05 PM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `proactive_report_midday` | 12:05 PM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `proactive_report_afternoon` | 4:05 PM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `vp_coder_workspace_pruning` | Sun 5:05 PM (weekly) | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `hackernews_snapshot` | every 30m, 6 AM–9 PM (at :00 and :30) | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
 
-GitHub Actions schedules:
+GitHub Actions schedules (UTC, no DST handling):
 
 | Workflow | Schedule | Source |
 |---|---|---|
-| `nightly-doc-drift-audit` | 12:17 UTC daily ≈ 7:17 AM CDT | [`.github/workflows/nightly-doc-drift-audit.yml`](../../.github/workflows/nightly-doc-drift-audit.yml) |
-| `openclaw-release-sync` | 12:13 UTC Tue/Fri ≈ 7:13 AM CDT | [`.github/workflows/openclaw-release-sync.yml`](../../.github/workflows/openclaw-release-sync.yml) |
+| `nightly-doc-drift-audit` | 18:35 UTC daily ≈ 1:35 PM CDT / 12:35 PM CST | [`.github/workflows/nightly-doc-drift-audit.yml`](../../.github/workflows/nightly-doc-drift-audit.yml) |
+| `openclaw-release-sync` | 20:35 UTC Tue/Fri ≈ 3:35 PM CDT / 2:35 PM CST | [`.github/workflows/openclaw-release-sync.yml`](../../.github/workflows/openclaw-release-sync.yml) |
+
+## Cron spread (2026-05-11)
+
+Before today, six cron jobs fired between 6:30 and 8:20 AM Houston (morning_briefing, proactive_report_morning, vp_coder_workspace_pruning, openclaw-release-sync, nightly-doc-drift-audit, proactive_artifact_digest, csi_demo_triage_rank #1), with hackernews_snapshot ticking at the :00 and :30 minute marks on top. That bunch caused contention — agents busy at the same time, jobs queueing behind each other, no headroom to add new proactive verbs without picking another saturated slot.
+
+Today's spread uses two simple primitives:
+
+1. **Minute offsets of `:05` and `:35`** to dodge the half-hourly `hackernews_snapshot` ticks.
+2. **Hour spacing** so heavy proactive jobs have ≥1h of breathing room.
+
+`morning_briefing` (6:30 AM) and `nightly_wiki` (3:15 AM, exception row) stay fixed because they have explicit consumption-time semantics (operator reads briefing on wake; nightly_wiki feeds briefing). Everything else moved to fill gaps.
 
 ## Adding a new cron job
 

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -18028,7 +18028,7 @@ def _ensure_vp_coder_workspace_pruning_cron_job() -> Optional[dict[str, Any]]:
     """
     return _register_system_cron_job(
         system_job="vp_coder_workspace_pruning",
-        default_cron="0 7 * * 0",
+        default_cron="5 17 * * 0",
         default_timezone="America/Chicago",
         command="!script universal_agent.scripts.vp_coder_workspace_pruner",
         description="Weekly pruning of stale VP-coder workspace subdirectories (default: archive after 7 days).",
@@ -18415,7 +18415,7 @@ def _ensure_atlas_direct_dispatch_cron_job() -> Optional[dict[str, Any]]:
 def _ensure_proactive_report_morning_cron_job() -> Optional[dict[str, Any]]:
     return _register_system_cron_job(
         system_job="proactive_report_morning",
-        default_cron="0 7 * * *",
+        default_cron="5 7 * * *",
         default_timezone="America/Chicago",
         command="!script universal_agent.scripts.proactive_report_agent",
         description="Morning proactive intelligence report — pipeline stats + LLM analysis.",
@@ -18429,7 +18429,7 @@ def _ensure_proactive_report_morning_cron_job() -> Optional[dict[str, Any]]:
 def _ensure_proactive_report_midday_cron_job() -> Optional[dict[str, Any]]:
     return _register_system_cron_job(
         system_job="proactive_report_midday",
-        default_cron="0 12 * * *",
+        default_cron="5 12 * * *",
         default_timezone="America/Chicago",
         command="!script universal_agent.scripts.proactive_report_agent",
         description="Midday proactive intelligence report — pipeline stats + LLM analysis.",
@@ -18443,7 +18443,7 @@ def _ensure_proactive_report_midday_cron_job() -> Optional[dict[str, Any]]:
 def _ensure_proactive_report_afternoon_cron_job() -> Optional[dict[str, Any]]:
     return _register_system_cron_job(
         system_job="proactive_report_afternoon",
-        default_cron="0 16 * * *",
+        default_cron="5 16 * * *",
         default_timezone="America/Chicago",
         command="!script universal_agent.scripts.proactive_report_agent",
         description="Afternoon proactive intelligence report — pipeline stats + LLM analysis.",
@@ -18457,7 +18457,7 @@ def _ensure_proactive_report_afternoon_cron_job() -> Optional[dict[str, Any]]:
 def _ensure_proactive_artifact_digest_cron_job() -> Optional[dict[str, Any]]:
     return _register_system_cron_job(
         system_job="proactive_artifact_digest",
-        default_cron="0 8 * * *",
+        default_cron="35 8 * * *",
         default_timezone="America/Chicago",
         command="!script universal_agent.scripts.proactive_digest_agent",
         description="Daily proactive artifact digest — surfaces unseen CODIE PRs, tutorial builds, and convergence insights via email.",
@@ -18629,8 +18629,8 @@ def _ensure_csi_demo_triage_rank_cron_job() -> Optional[dict[str, Any]]:
         return None
     return _register_system_cron_job(
         system_job="csi_demo_triage_rank",
-        default_cron="15 13,19 * * *",
-        default_timezone="UTC",
+        default_cron="5 10,15 * * *",
+        default_timezone="America/Chicago",
         command="!script universal_agent.scripts.csi_demo_triage_rank",
         description="Rank pending CSI demo triage candidates with an LLM.",
         timeout_seconds=600,

--- a/tests/unit/test_cron_dormancy_defaults.py
+++ b/tests/unit/test_cron_dormancy_defaults.py
@@ -190,14 +190,21 @@ def test_hackernews_snapshot_uses_active_hour_range() -> None:
 
 
 def test_vp_coder_workspace_pruning_moved_to_active_hours() -> None:
-    """The 4 AM Sunday cleanup was moved to 7 AM Sunday on 2026-05-10."""
+    """vp_coder_workspace_pruning runs Sunday afternoon.
+
+    2026-05-10: moved from 4 AM Sun → 7 AM Sun (dormancy default).
+    2026-05-11: moved from 7 AM Sun → 5:05 PM Sun as part of the
+    cron-spread refactor. 7 AM Sunday was bunching with
+    proactive_report_morning at 7:05 AM.
+    """
     content = GATEWAY_SERVER.read_text(encoding="utf-8")
     assert (
-        'default_cron="0 7 * * 0"' in content
+        'default_cron="5 17 * * 0"' in content
         and '"vp_coder_workspace_pruning"' in content
     ), (
-        "vp_coder_workspace_pruning must default to '0 7 * * 0' America/Chicago. "
-        "Pre-2026-05-10 it was '0 4 * * 0' (4 AM Sunday Houston, inside dormancy)."
+        "vp_coder_workspace_pruning must default to '5 17 * * 0' America/Chicago "
+        "(Sunday 5:05 PM Houston). 2026-05-11 spread refactor moved it from "
+        "7 AM Sun (which collided with proactive_report_morning) to 5:05 PM."
     )
 
 


### PR DESCRIPTION
## Summary

Six cron jobs were bunched between 6:30 and 8:20 AM Houston (morning_briefing, proactive_report_morning, vp_coder_workspace_pruning, openclaw-release-sync, nightly-doc-drift-audit, proactive_artifact_digest, csi_demo_triage_rank #1), with hackernews_snapshot ticking every :00 and :30 on top of that. No headroom to add new proactive verbs without picking another saturated slot.

Spread uses two primitives:
1. **Minute offsets of \`:05\` and \`:35\`** dodge the half-hourly hackernews_snapshot ticks.
2. **Hour spacing** so heavy proactive jobs have ≥1h breathing room.

\`morning_briefing\` (6:30 AM) and \`nightly_wiki\` (3:15 AM, exception row) stay fixed because they have explicit consumption-time semantics. Everything else moved to fill gaps.

## Changes

| Job | Before | After |
|---|---|---|
| vp_coder_workspace_pruning | Sun 07:00 Houston | Sun 17:05 Houston |
| proactive_report_morning | 07:00 Houston | 07:05 Houston |
| proactive_report_midday | 12:00 Houston | 12:05 Houston |
| proactive_report_afternoon | 16:00 Houston | 16:05 Houston |
| proactive_artifact_digest | 08:00 Houston | 08:35 Houston |
| csi_demo_triage_rank | 13:15, 19:15 UTC | 10:05, 15:05 America/Chicago |
| nightly-doc-drift-audit | 12:17 UTC | 18:35 UTC (≈1:35 PM CDT) |
| openclaw-release-sync | 12:13 UTC Tue/Fri | 20:35 UTC Tue/Fri (≈3:35 PM CDT) |

Doc tables in \`docs/operations/operating_hours_dormancy.md\` refreshed and new \"Cron spread (2026-05-11)\" section explains the rationale so future cron authors don't re-bunch. Dormancy guard test pin updated for vp_coder_workspace_pruning.

## Test plan

- [x] \`uv run pytest tests/unit/test_cron_dormancy_defaults.py -q\` → 9 passed
- [ ] PR-Validate CI green
- [ ] Post-merge: confirm cron registry shows new times in next gateway restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)