### PR TITLE
feat(hermes-e): Cody Anthropic/ZAI toggle (CLI path)

### DIFF
--- a/docs/reports/hermes-adaptation-phased-plan-2026-05-10.md
+++ b/docs/reports/hermes-adaptation-phased-plan-2026-05-10.md
@@ -33,7 +33,8 @@
 | **B.2** — dashboard failure-context endpoint + drawer UI + 4 unstick buttons | [#220](https://github.com/Kjdragan/universal_agent/pull/220) | `c1c121e5` | ✅ shipped to `main` 2026-05-11 |
 | **C** — Atlas-direct-dispatch + Simone awareness (independent cron-registered dispatcher) | [#221](https://github.com/Kjdragan/universal_agent/pull/221) | — | ✅ scaffolded 2026-05-11; default OFF via `UA_ATLAS_DIRECT_DISPATCH_ENABLED=0`; operator flips on after dry-run |
 | **D.1** — `task_hub_runs` attempt-history table + claim/finalize wiring | [#222](https://github.com/Kjdragan/universal_agent/pull/222) | `e00842d2` | ✅ shipped to `main` 2026-05-11; additive — D.2 (prompt/UI consumers) follows |
-| **D.2** — Phase B `re_evaluate` verb + dashboard drawer consume `task_hub_runs` | — | — | ✅ shipped to `main` 2026-05-11 (this PR); 3 new unit tests pass on top of D.1 (9/9 failure-context, 10/10 task_hub_runs, 12/12 unstick verbs) |
+| **D.2** — Phase B `re_evaluate` verb + dashboard drawer consume `task_hub_runs` | [#228](https://github.com/Kjdragan/universal_agent/pull/228) | `9866f18d` | ✅ shipped to `main` 2026-05-11; 3 new unit tests on top of D.1 |
+| **E.1 + E.2.a + E.3** — Cody Anthropic/ZAI toggle (CLI path) | — | — | 🟢 in flight 2026-05-11 (this branch); per-task `cody_mode` column, `services/cody_mode.resolve_cody_mode`, CLI `_build_cli_env(cody_mode=...)` strips ANTHROPIC_* + forces agent-teams, VPAgentHealthTile surfaces active anthropic missions. 13 new unit tests. **E.2.b SDK in-process adapter routing deferred** — see § Phase E follow-ups below. |
 
 > **Operator-supporting interludes (2026-05-11):** PR #218 added a minimum-interval guard on the cron `every_seconds` create path. PR #219 added a periodic `_vp_stale_reconcile_loop`. Both close real operator-burden vectors orthogonal to the lettered phases.
 

--- a/src/universal_agent/services/cody_mode.py
+++ b/src/universal_agent/services/cody_mode.py
@@ -1,0 +1,77 @@
+"""Hermes Phase E.1 — Cody execution-mode resolver.
+
+Picks between ``"zai"`` (default — cheap, ZAI/GLM proxy) and
+``"anthropic"`` (real Anthropic Max plan via OAuth) per task.
+
+Resolution order:
+    1. ``task.cody_mode`` — per-task override on ``task_hub_items``
+    2. ``UA_CODY_DEFAULT_MODE`` env var — system-wide default
+    3. ``"zai"`` — hard default
+
+The resolved value flows through ``vp_dispatch_mission`` into
+``vp_missions.payload_json["cody_mode"]`` so the VP worker (CLI or
+SDK adapter) can scrub ANTHROPIC_* env vars or otherwise route to
+Anthropic Max for high-stakes coding tasks.
+
+Today only the CLI execution mode applies the toggle (E.2.a — see
+``vp/clients/claude_cli_client.py:_build_cli_env``). SDK in-process
+mode (E.2.b) is a planned follow-up; the existing SDK code path
+ignores the value and operates on whatever runtime env it inherits.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Literal
+
+CodyMode = Literal["zai", "anthropic"]
+
+_ENV_VAR = "UA_CODY_DEFAULT_MODE"
+_VALID_MODES: set[str] = {"zai", "anthropic"}
+_DEFAULT_MODE: CodyMode = "zai"
+
+
+def _normalize(raw: Any) -> str:
+    return str(raw or "").strip().lower()
+
+
+def resolve_cody_mode(task: dict[str, Any] | None = None) -> CodyMode:
+    """Return the effective Cody execution mode for a task.
+
+    Args:
+        task: A ``task_hub_items`` row (or compatible dict). May be
+            ``None`` to short-circuit to env/default.
+
+    Returns:
+        Either ``"zai"`` or ``"anthropic"``.
+    """
+    if task:
+        per_task = _normalize(task.get("cody_mode"))
+        if per_task in _VALID_MODES:
+            return per_task  # type: ignore[return-value]
+
+    env_mode = _normalize(os.getenv(_ENV_VAR))
+    if env_mode in _VALID_MODES:
+        return env_mode  # type: ignore[return-value]
+
+    return _DEFAULT_MODE
+
+
+def resolve_from_payload(payload: dict[str, Any] | None) -> CodyMode:
+    """Resolve directly from a mission payload that already carries cody_mode.
+
+    Used downstream of dispatch (VP worker, CLI client) where the task
+    row is no longer in scope but the resolved value lives in the
+    mission's ``payload.cody_mode``.
+    """
+    if payload:
+        mode = _normalize(payload.get("cody_mode"))
+        if mode in _VALID_MODES:
+            return mode  # type: ignore[return-value]
+    env_mode = _normalize(os.getenv(_ENV_VAR))
+    if env_mode in _VALID_MODES:
+        return env_mode  # type: ignore[return-value]
+    return _DEFAULT_MODE
+
+
+__all__ = ["CodyMode", "resolve_cody_mode", "resolve_from_payload"]

--- a/src/universal_agent/services/mission_control_tiles.py
+++ b/src/universal_agent/services/mission_control_tiles.py
@@ -693,8 +693,36 @@ class VPAgentHealthTile(Tile):
             return TileState(
                 color=COLOR_YELLOW,
                 one_line_status="no VP missions in last 7d",
-                evidence={"per_vp": per_vp},
+                evidence={"per_vp": per_vp, "active_anthropic_modes": []},
             )
+
+        # Hermes Phase E.3 — surface active Cody-on-Anthropic missions so an
+        # operator looking at "active_coder=1" understands the session has
+        # internal Agent-Team fan-out (more cost, more capability) than the
+        # bare count implies.
+        anthropic_active: list[dict[str, str]] = []
+        try:
+            anthropic_rows = conn.execute(
+                """
+                SELECT task_id, source_ref, updated_at
+                FROM task_hub_items
+                WHERE source_kind = 'vp_mission'
+                  AND status IN ('open', 'in_progress', 'delegated')
+                  AND json_extract(metadata_json, '$.cody_mode') = 'anthropic'
+                ORDER BY updated_at DESC
+                LIMIT 10
+                """
+            ).fetchall()
+            for row in anthropic_rows:
+                anthropic_active.append(
+                    {
+                        "task_id": str(row["task_id"]),
+                        "vp_id": str(row["source_ref"] or ""),
+                        "updated_at": str(row["updated_at"] or ""),
+                    }
+                )
+        except sqlite3.OperationalError:
+            anthropic_active = []
 
         # Red if any VP has >=3 failures and zero completions in window;
         # yellow if any VP failure rate >50% over >=3 missions; otherwise
@@ -716,10 +744,12 @@ class VPAgentHealthTile(Tile):
         if worst_color == COLOR_GREEN:
             total_completed = sum(v["completed"] for v in per_vp.values())
             worst_summary = f"both VPs healthy, {total_completed} completed in 7d"
+        if anthropic_active:
+            worst_summary = f"{worst_summary} · {len(anthropic_active)} on Anthropic"
         return TileState(
             color=worst_color,
             one_line_status=worst_summary,
-            evidence={"per_vp": per_vp},
+            evidence={"per_vp": per_vp, "active_anthropic_modes": anthropic_active},
         )
 
 

--- a/src/universal_agent/task_hub.py
+++ b/src/universal_agent/task_hub.py
@@ -270,6 +270,7 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
             feedback_json TEXT NOT NULL DEFAULT '{}',
             metadata_json TEXT NOT NULL DEFAULT '{}',
             max_retries INTEGER,
+            cody_mode TEXT,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
@@ -435,6 +436,12 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         # task in needs_review. Hermes-adaptation Phase A.1 (2026-05-10) —
         # see docs/reports/hermes-adaptation-phased-plan-2026-05-10.md.
         "ALTER TABLE task_hub_items ADD COLUMN max_retries INTEGER",
+        # Per-task override for the Cody execution model. NULL inherits from
+        # UA_CODY_DEFAULT_MODE env (default "zai"). Values: "zai" | "anthropic".
+        # Resolved via services/cody_mode.resolve_cody_mode at dispatch time
+        # and plumbed into vp_missions.payload_json for worker_loop. See
+        # docs/reports/hermes-adaptation-phased-plan-2026-05-10.md § Phase E.
+        "ALTER TABLE task_hub_items ADD COLUMN cody_mode TEXT",
     ):
         try:
             conn.execute(ddl)
@@ -1099,6 +1106,16 @@ def upsert_item(conn: sqlite3.Connection, item: dict[str, Any]) -> dict[str, Any
             else None
         )
 
+    # Hermes Phase E.1 — per-task cody_mode override. NULL inherits from
+    # UA_CODY_DEFAULT_MODE env (default "zai"). Only "zai" / "anthropic"
+    # are accepted; anything else is normalized to NULL.
+    if "cody_mode" in item:
+        _raw_cody = str(item.get("cody_mode") or "").strip().lower()
+        cody_mode_value: Optional[str] = _raw_cody if _raw_cody in {"zai", "anthropic"} else None
+    else:
+        _existing_cody = str(existing.get("cody_mode") or "").strip().lower()
+        cody_mode_value = _existing_cody if _existing_cody in {"zai", "anthropic"} else None
+
     payload = {
         "task_id": task_id,
         "source_kind": str(item.get("source_kind") or existing.get("source_kind") or "internal"),
@@ -1124,6 +1141,7 @@ def upsert_item(conn: sqlite3.Connection, item: dict[str, Any]) -> dict[str, Any
         "trigger_type": trigger_type,
         "metadata_json": _json_dumps(metadata),
         "max_retries": max_retries_value,
+        "cody_mode": cody_mode_value,
         "created_at": str(existing.get("created_at") or item.get("created_at") or now_iso),
         "updated_at": now_iso,
     }
@@ -1134,12 +1152,12 @@ def upsert_item(conn: sqlite3.Connection, item: dict[str, Any]) -> dict[str, Any
             task_id, source_kind, source_ref, title, description, project_key, priority, due_at,
             labels_json, status, must_complete, incident_key, workstream_id, subtask_role,
             parent_task_id, agent_ready, score, score_confidence, stale_state, seizure_state,
-            mirror_status, trigger_type, metadata_json, max_retries, created_at, updated_at
+            mirror_status, trigger_type, metadata_json, max_retries, cody_mode, created_at, updated_at
         ) VALUES (
             :task_id, :source_kind, :source_ref, :title, :description, :project_key, :priority, :due_at,
             :labels_json, :status, :must_complete, :incident_key, :workstream_id, :subtask_role,
             :parent_task_id, :agent_ready, :score, :score_confidence, :stale_state, :seizure_state,
-            :mirror_status, :trigger_type, :metadata_json, :max_retries, :created_at, :updated_at
+            :mirror_status, :trigger_type, :metadata_json, :max_retries, :cody_mode, :created_at, :updated_at
         )
         ON CONFLICT(task_id) DO UPDATE SET
             source_kind=excluded.source_kind,
@@ -1165,6 +1183,7 @@ def upsert_item(conn: sqlite3.Connection, item: dict[str, Any]) -> dict[str, Any
             trigger_type=excluded.trigger_type,
             metadata_json=excluded.metadata_json,
             max_retries=excluded.max_retries,
+            cody_mode=excluded.cody_mode,
             updated_at=excluded.updated_at
         """,
         payload,

--- a/src/universal_agent/tools/vp_orchestration.py
+++ b/src/universal_agent/tools/vp_orchestration.py
@@ -247,6 +247,45 @@ async def _vp_dispatch_mission_impl(args: dict[str, Any]) -> dict[str, Any]:
     if not source_session_id:
         source_session_id = "internal.vp_tool"
 
+    # Hermes Phase E.1 — resolve cody_mode and plumb it into mission
+    # metadata so vp_missions.payload_json carries the toggle for the
+    # VP worker (CLI/SDK adapter) to honor. Resolution order:
+    #   1. explicit args["cody_mode"]
+    #   2. task row's cody_mode (if a linked task_id is supplied)
+    #   3. UA_CODY_DEFAULT_MODE env
+    #   4. "zai" default
+    raw_metadata = (
+        args.get("metadata") if isinstance(args.get("metadata"), dict) else {}
+    )
+    explicit_cody_mode = str(args.get("cody_mode") or raw_metadata.get("cody_mode") or "").strip().lower()
+    if explicit_cody_mode in {"zai", "anthropic"}:
+        resolved_cody_mode: str = explicit_cody_mode
+    else:
+        from universal_agent.services.cody_mode import resolve_cody_mode
+
+        # Try to load the linked task row to pick up its per-task override.
+        linked_task_id = str(args.get("task_id") or raw_metadata.get("task_id") or "").strip()
+        linked_task: dict[str, Any] | None = None
+        if linked_task_id:
+            try:
+                from universal_agent import task_hub
+                from universal_agent.durable.db import (
+                    connect_runtime_db,
+                    get_activity_db_path,
+                )
+
+                th_conn = connect_runtime_db(get_activity_db_path())
+                try:
+                    linked_task = task_hub.get_item(th_conn, linked_task_id)
+                finally:
+                    th_conn.close()
+            except Exception:
+                linked_task = None
+        resolved_cody_mode = resolve_cody_mode(linked_task)
+
+    mission_metadata = dict(raw_metadata)
+    mission_metadata["cody_mode"] = resolved_cody_mode
+
     conn = _connect_vp_db()
     try:
         row = dispatch_mission_with_retry(
@@ -265,9 +304,7 @@ async def _vp_dispatch_mission_impl(args: dict[str, Any]) -> dict[str, Any]:
                 run_id=run_id or None,
                 execution_mode=str(args.get("execution_mode") or "sdk").strip()
                 or "sdk",
-                metadata=args.get("metadata")
-                if isinstance(args.get("metadata"), dict)
-                else {},
+                metadata=mission_metadata,
             ),
         )
         mission = _mission_to_dict(row) or {}

--- a/src/universal_agent/vp/clients/claude_cli_client.py
+++ b/src/universal_agent/vp/clients/claude_cli_client.py
@@ -90,6 +90,21 @@ class ClaudeCodeCLIClient(VpClient):
         skill_name = str(payload.get("skill") or "").strip()
         enable_agent_teams = bool(payload.get("enable_agent_teams", True))
 
+        # Hermes Phase E.2.a — resolve Cody execution mode from the
+        # mission's metadata block. Falls back to env / "zai" default
+        # if the mission row predates Phase E.1.
+        from universal_agent.services.cody_mode import resolve_from_payload
+
+        cody_mode = resolve_from_payload(
+            payload.get("metadata") if isinstance(payload.get("metadata"), dict) else None
+        )
+        if cody_mode == "anthropic":
+            logger.info(
+                "CLI mission %s — Cody mode=anthropic; scrubbing ANTHROPIC_* env "
+                "and forcing CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1",
+                mission_id,
+            )
+
         workspace_dir = _resolve_workspace(mission_id, workspace_root, payload)
         workspace_dir.mkdir(parents=True, exist_ok=True)
 
@@ -142,6 +157,7 @@ class ClaudeCodeCLIClient(VpClient):
                     timeout_seconds=timeout_seconds,
                     enable_agent_teams=enable_agent_teams,
                     mission_id=mission_id,
+                    cody_mode=cody_mode,
                 )
 
                 if outcome.status == "completed":
@@ -173,10 +189,11 @@ async def _execute_cli_session(
     timeout_seconds: int,
     enable_agent_teams: bool,
     mission_id: str,
+    cody_mode: str = "zai",
 ) -> MissionOutcome:
     """Spawn a claude CLI subprocess and monitor its output."""
 
-    env = _build_cli_env(enable_agent_teams, workspace_dir)
+    env = _build_cli_env(enable_agent_teams, workspace_dir, cody_mode=cody_mode)
 
     cmd = [
         "claude",
@@ -388,12 +405,31 @@ async def _monitor_cli_output(
     )
 
 
-def _build_cli_env(enable_agent_teams: bool, workspace_dir: Path) -> dict[str, str]:
-    """Build the environment for the CLI subprocess."""
-    env = dict(os.environ)
+def _build_cli_env(
+    enable_agent_teams: bool,
+    workspace_dir: Path,
+    *,
+    cody_mode: str = "zai",
+) -> dict[str, str]:
+    """Build the environment for the CLI subprocess.
 
-    if enable_agent_teams:
+    Hermes Phase E.2.a — when ``cody_mode == "anthropic"``, every
+    ``ANTHROPIC_*`` env var is scrubbed so the spawned ``claude``
+    subprocess falls through to its workspace-local OAuth (the user's
+    Anthropic Max plan) instead of the UA daemon's ZAI routing. This
+    mirrors the pattern in ``services/cody_implementation._scrubbed_env``
+    that demo workspaces already use unconditionally.
+
+    Defaulted to "zai" (current behavior — inherit parent ZAI routing).
+    """
+    if cody_mode == "anthropic":
+        env = {k: v for k, v in os.environ.items() if not k.startswith("ANTHROPIC_")}
+        # Agent Teams is the whole point of Anthropic mode — force on.
         env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
+    else:
+        env = dict(os.environ)
+        if enable_agent_teams:
+            env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "1"
 
     env["CURRENT_RUN_WORKSPACE"] = str(workspace_dir)
     env["CURRENT_SESSION_WORKSPACE"] = str(workspace_dir)

--- a/tests/unit/test_cody_mode.py
+++ b/tests/unit/test_cody_mode.py
@@ -1,0 +1,185 @@
+"""Hermes Phase E.1 + E.2.a — Cody execution-mode toggle unit tests.
+
+Verifies the resolver, schema persistence, and CLI env-scrub behavior.
+
+* E.1 — `resolve_cody_mode` returns "zai" by default, "anthropic" only
+  when a valid task override or env var asks for it.
+* E.1 — `task_hub_items.cody_mode` column round-trips through
+  `upsert_item` / `get_item`.
+* E.2.a — `_build_cli_env(cody_mode="anthropic")` strips every
+  ANTHROPIC_* env var and forces CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1.
+* E.2.a — `_build_cli_env(cody_mode="zai")` inherits ANTHROPIC_* from
+  the parent env (current behavior — no regression).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services.cody_mode import (
+    resolve_cody_mode,
+    resolve_from_payload,
+)
+from universal_agent.vp.clients.claude_cli_client import _build_cli_env
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    task_hub.ensure_schema(c)
+    yield c
+    c.close()
+
+
+# ── E.1: resolve_cody_mode ─────────────────────────────────────────────────
+
+
+def test_resolve_defaults_to_zai_with_no_task_no_env(monkeypatch) -> None:
+    monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
+    assert resolve_cody_mode(None) == "zai"
+    assert resolve_cody_mode({}) == "zai"
+
+
+def test_resolve_honors_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "anthropic")
+    assert resolve_cody_mode(None) == "anthropic"
+    assert resolve_cody_mode({}) == "anthropic"
+
+
+def test_resolve_task_override_wins_over_env(monkeypatch) -> None:
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "anthropic")
+    assert resolve_cody_mode({"cody_mode": "zai"}) == "zai"
+
+
+def test_resolve_invalid_task_value_falls_through(monkeypatch) -> None:
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "anthropic")
+    # garbage value should be ignored, env wins
+    assert resolve_cody_mode({"cody_mode": "garbage"}) == "anthropic"
+
+
+def test_resolve_invalid_env_falls_through_to_default(monkeypatch) -> None:
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "not-a-mode")
+    assert resolve_cody_mode(None) == "zai"
+
+
+def test_resolve_from_payload_reads_payload(monkeypatch) -> None:
+    monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
+    assert resolve_from_payload({"cody_mode": "anthropic"}) == "anthropic"
+    assert resolve_from_payload({"cody_mode": "zai"}) == "zai"
+    assert resolve_from_payload(None) == "zai"
+
+
+# ── E.1: schema column round-trip ──────────────────────────────────────────
+
+
+def test_cody_mode_column_persists_through_upsert(conn: sqlite3.Connection) -> None:
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": "task:cody-anth",
+            "source_kind": "internal",
+            "title": "anthropic-mode task",
+            "cody_mode": "anthropic",
+        },
+    )
+    row = task_hub.get_item(conn, "task:cody-anth")
+    assert row is not None
+    assert row["cody_mode"] == "anthropic"
+
+
+def test_cody_mode_null_when_not_set(conn: sqlite3.Connection) -> None:
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": "task:no-mode",
+            "source_kind": "internal",
+            "title": "no mode",
+        },
+    )
+    row = task_hub.get_item(conn, "task:no-mode")
+    assert row is not None
+    assert row.get("cody_mode") in (None, "")
+
+
+def test_cody_mode_invalid_value_normalized_to_null(conn: sqlite3.Connection) -> None:
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": "task:bad-mode",
+            "source_kind": "internal",
+            "title": "bad mode",
+            "cody_mode": "junk",
+        },
+    )
+    row = task_hub.get_item(conn, "task:bad-mode")
+    assert row is not None
+    assert row.get("cody_mode") in (None, "")
+
+
+def test_cody_mode_preserved_on_re_upsert(conn: sqlite3.Connection) -> None:
+    """Per-task override survives an upsert that doesn't mention cody_mode."""
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": "task:keep-anth",
+            "source_kind": "internal",
+            "title": "first",
+            "cody_mode": "anthropic",
+        },
+    )
+    # Re-upsert without cody_mode key — must NOT clobber the existing value.
+    task_hub.upsert_item(
+        conn,
+        {"task_id": "task:keep-anth", "title": "second"},
+    )
+    row = task_hub.get_item(conn, "task:keep-anth")
+    assert row is not None
+    assert row["cody_mode"] == "anthropic"
+
+
+# ── E.2.a: _build_cli_env env scrubbing ────────────────────────────────────
+
+
+def test_build_cli_env_zai_inherits_anthropic_vars(tmp_path: Path, monkeypatch) -> None:
+    """Default zai mode: parent ANTHROPIC_* env survives into subprocess env."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-zai-routed-token")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/anthropic")
+    env = _build_cli_env(enable_agent_teams=False, workspace_dir=tmp_path, cody_mode="zai")
+    assert env.get("ANTHROPIC_API_KEY") == "fake-zai-routed-token"
+    assert env.get("ANTHROPIC_BASE_URL") == "https://api.z.ai/anthropic"
+
+
+def test_build_cli_env_anthropic_strips_all_anthropic_vars(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Anthropic mode: every ANTHROPIC_* env var is scrubbed before exec."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-zai-routed-token")
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://api.z.ai/anthropic")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "leaky")
+    env = _build_cli_env(
+        enable_agent_teams=False, workspace_dir=tmp_path, cody_mode="anthropic"
+    )
+    leaked = {k: v for k, v in env.items() if k.startswith("ANTHROPIC_")}
+    assert leaked == {}, f"Anthropic vars leaked through: {leaked}"
+    # Anthropic mode forces agent teams on (the whole point of Anthropic mode).
+    assert env.get("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS") == "1"
+
+
+def test_build_cli_env_anthropic_preserves_workspace_signal(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Anthropic-mode scrub must not nuke workspace context env vars."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "fake-token")
+    env = _build_cli_env(
+        enable_agent_teams=False, workspace_dir=tmp_path, cody_mode="anthropic"
+    )
+    assert env["CURRENT_RUN_WORKSPACE"] == str(tmp_path)
+    assert env["CURRENT_SESSION_WORKSPACE"] == str(tmp_path)


### PR DESCRIPTION
## Summary

Phase E.1 + E.2.a + E.3 of the Hermes adaptation — per-task Cody execution-mode toggle so operators (and Simone, eventually) can flip individual coding tasks to the Anthropic Max plan when they need full Claude capability, while the default stays cheap-ZAI everywhere else.

### What ships in this PR

- **E.1 — Resolver + schema**: nullable `cody_mode` column on \`task_hub_items\`; new \`services/cody_mode.resolve_cody_mode\`; \`vp_dispatch_mission\` plumbs the resolved value into \`vp_missions.payload_json[\"metadata\"][\"cody_mode\"]\`.
- **E.2.a — CLI env scrub**: \`_build_cli_env(cody_mode=\"anthropic\")\` strips every \`ANTHROPIC_*\` env var before spawning \`claude\` and forces \`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1\`. ZAI behavior unchanged.
- **E.3 — Dashboard surface**: \`VPAgentHealthTile\` surfaces \"· N on Anthropic\" in its one-line status when any active VP mission has \`cody_mode=anthropic\`; \`evidence.active_anthropic_modes\` carries per-task details.

### What's deferred to a follow-up

- **E.2.b — SDK in-process adapter routing.** Today autonomous in-process SDK calls share the parent's ZAI-routed env; flipping ANTHROPIC_* vars mid-run is race-prone. The cleanest operator path for Anthropic Max coding is to use \`execution_mode=\"cli\"\` (which now honors the toggle). A future PR will extend \`EngineConfig\` with a \`model_routing_override\` field so the SDK adapter can re-resolve routing per-call.

## Test plan

- [x] \`uv run --offline pytest tests/unit/test_cody_mode.py -x -q\` — 13/13 passing
- [x] Sanity: \`tests/unit/test_task_hub_lifecycle.py\` + \`tests/unit/test_task_hub_schema_extensions.py\` + \`tests/unit/test_task_hub_max_retries_override.py\` — 57/57 passing (no schema regression)
- [x] \`ruff check\` + \`py_compile\` clean
- [ ] CI PR-Validate
- [ ] Post-deploy verification — operator sets \`cody_mode=\"anthropic\"\` on a test task with \`execution_mode=\"cli\"\`, dispatches via vp_dispatch_mission, confirms VPAgentHealthTile shows \"on Anthropic\" and CLI subprocess env has no \`ANTHROPIC_*\` vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)