### PR TITLE
fix(ci): pr-auto-merge.yml uses AUTO_MERGE_PAT to escape GITHUB_TOKEN suppression

### DIFF
--- a/.github/workflows/pr-auto-merge.yml
+++ b/.github/workflows/pr-auto-merge.yml
@@ -43,7 +43,15 @@ jobs:
     steps:
       - name: Enable auto-merge via gh
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # 2026-05-11: swapped GITHUB_TOKEN -> AUTO_MERGE_PAT so the
+          # downstream squash-merge `push` event isn't suppressed by
+          # GitHub's "events triggered by GITHUB_TOKEN don't fire new
+          # workflows" rule. Falls back to GITHUB_TOKEN if the secret is
+          # not configured so the workflow stays functional (just
+          # without deploy auto-firing). See operating note in
+          # docs/06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md
+          # and the post-merge-deploy.yml comment block.
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           PR_NUM="${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

Fixes the silent-deploy-skip bug we hit on PRs #228, #229, #230 (the three Hermes phases). When \`pr-auto-merge.yml\` uses \`GITHUB_TOKEN\` to enable auto-merge, GitHub then squash-merges the PR — but the resulting \`push\` to main is "triggered by GITHUB_TOKEN" and gets suppressed per [GitHub's docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication), so \`deploy.yml\` never fires. Production drifts until manual \`workflow_dispatch\`.

This swaps the env to use a fine-grained PAT (\`AUTO_MERGE_PAT\`) which is attributed to a user identity, NOT GITHUB_TOKEN. The downstream \`push\` event then fires \`deploy.yml\` normally. Falls back to \`GITHUB_TOKEN\` when the secret isn't set so the workflow stays functional during the bootstrap window.

## Operator setup BEFORE merge (so this PR's merge itself fires deploy)

1. **Create the PAT**:
   - github.com → Settings → Developer settings → Personal access tokens → Fine-grained tokens → **Generate new token**.
   - Token name: \`universal_agent auto-merge dispatcher\`.
   - Repository access: **Only select repositories** → \`Kjdragan/universal_agent\`.
   - Repository permissions:
     - Contents: **Read and write** (required for squash-merge)
     - Pull requests: **Read and write** (required for \`gh pr merge --auto\`)
     - Metadata: Read (auto)
   - Everything else unselected.
   - Generate → copy the \`github_pat_...\` value (won't see again).

2. **Add the secret**:
   - Repo → Settings → Secrets and variables → Actions → **New repository secret**.
   - Name: \`AUTO_MERGE_PAT\` (exact name).
   - Value: paste the \`github_pat_...\`.
   - Save.

3. **Merge this PR**. If steps 1+2 are done first, the synchronize event on this PR will re-run pr-auto-merge.yml with the PAT, and the eventual squash-merge will fire deploy.yml.

If you merge this PR BEFORE doing steps 1+2, the fallback kicks in (uses GITHUB_TOKEN) and the merge of this PR itself won't fire deploy — but it's fine, the fix lands and the NEXT \`claude/*\` PR works.

## Test plan

- [ ] Operator creates PAT + adds secret per above.
- [ ] CI on this PR passes.
- [ ] Merge this PR.
- [ ] Confirm next \`claude/*\` PR merge automatically triggers deploy.yml (event=push, not workflow_dispatch).

## Maintenance

PAT expires (default 1 year) → auto-merge fails with 401/403 → operator regenerates token and overwrites the same secret. No workflow change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)