### PR TITLE
feat(hermes-e2a): Cody anthropic-default + operator UI toggle + auto-CLI routing

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -22670,6 +22670,73 @@ async def dashboard_todolist_get_failure_context(task_id: str):
             conn.close()
 
 
+# ── Cody Mode Settings (Hermes Phase E.2 — operator UI toggle) ───────
+
+
+@app.get("/api/v1/cody/mode-setting")
+async def cody_mode_setting_get():
+    """Return the current operator-configured Cody default mode.
+
+    Response shape:
+        {
+            "mode": "anthropic" | "zai",
+            "source": "db_setting" | "env_var" | "hardcoded_default",
+            "updated_at": ISO string or "",
+            "updated_by": str or "",
+            "available_modes": ["zai", "anthropic"]
+        }
+
+    The dashboard tile uses ``source`` to decide whether to show "(default)"
+    next to the mode label and ``updated_at`` to render "last changed N
+    days ago".
+    """
+    from universal_agent.services.cody_mode import get_default_mode_state
+
+    with _activity_store_lock:
+        conn = _task_hub_open_conn()
+        try:
+            state = get_default_mode_state(conn)
+        finally:
+            conn.close()
+    state["available_modes"] = ["zai", "anthropic"]
+    return state
+
+
+@app.post("/api/v1/cody/mode-setting")
+async def cody_mode_setting_post(payload: dict):
+    """Persist the operator-configured Cody default mode.
+
+    Body: ``{"mode": "anthropic" | "zai", "updated_by": "operator"}``.
+    Returns the new state in the same shape as ``GET /cody/mode-setting``.
+    """
+    from universal_agent.services.cody_mode import (
+        get_default_mode_state,
+        set_default_mode,
+    )
+
+    raw_mode = ""
+    raw_updated_by = "operator"
+    if isinstance(payload, dict):
+        raw_mode = str(payload.get("mode") or "").strip()
+        raw_updated_by = str(payload.get("updated_by") or "operator").strip() or "operator"
+
+    if not raw_mode:
+        raise HTTPException(status_code=400, detail="mode is required")
+
+    with _activity_store_lock:
+        conn = _task_hub_open_conn()
+        try:
+            try:
+                set_default_mode(conn, raw_mode, updated_by=raw_updated_by)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            state = get_default_mode_state(conn)
+        finally:
+            conn.close()
+    state["available_modes"] = ["zai", "anthropic"]
+    return state
+
+
 # ── Brainstorm Refinement Endpoints ───────────────────────────────────
 
 @app.post("/api/v1/dashboard/todolist/tasks/{task_id}/refine")

--- a/src/universal_agent/services/cody_mode.py
+++ b/src/universal_agent/services/cody_mode.py
@@ -1,46 +1,83 @@
 """Hermes Phase E.1 — Cody execution-mode resolver.
 
-Picks between ``"zai"`` (default — cheap, ZAI/GLM proxy) and
-``"anthropic"`` (real Anthropic Max plan via OAuth) per task.
+Picks between ``"zai"`` (cheap, ZAI/GLM proxy) and ``"anthropic"``
+(real Anthropic Max plan via OAuth) per task.
 
-Resolution order:
-    1. ``task.cody_mode`` — per-task override on ``task_hub_items``
-    2. ``UA_CODY_DEFAULT_MODE`` env var — system-wide default
-    3. ``"zai"`` — hard default
+Resolution order (highest priority first):
+    1. ``task.cody_mode`` — per-task override on ``task_hub_items``.
+    2. DB setting ``cody_default_mode`` — operator-configurable via the
+       dashboard tile. Persisted in ``task_hub_settings``.
+    3. ``UA_CODY_DEFAULT_MODE`` env var — deploy-time override; kept for
+       ops use but typically unset in normal operation.
+    4. ``"anthropic"`` — hardcoded fallback (flipped from "zai" on
+       2026-05-11 PM per operator decision; Cody now defaults to running
+       on real Anthropic Max unless explicitly overridden).
 
-The resolved value flows through ``vp_dispatch_mission`` into
-``vp_missions.payload_json["cody_mode"]`` so the VP worker (CLI or
-SDK adapter) can scrub ANTHROPIC_* env vars or otherwise route to
-Anthropic Max for high-stakes coding tasks.
-
-Today only the CLI execution mode applies the toggle (E.2.a — see
-``vp/clients/claude_cli_client.py:_build_cli_env``). SDK in-process
-mode (E.2.b) is a planned follow-up; the existing SDK code path
-ignores the value and operates on whatever runtime env it inherits.
+When the resolved mode is ``anthropic``, ``vp_dispatch_mission``
+auto-routes the mission through ``execution_mode="cli"`` so the
+spawned ``claude`` subprocess uses workspace-local OAuth (Anthropic
+Max) instead of the gateway's ZAI-routed env. See
+``vp/clients/claude_cli_client.py:_build_cli_env`` for the env-scrub
+behavior.
 """
 
 from __future__ import annotations
 
 import os
-from typing import Any, Literal
+from typing import Any, Literal, Optional
 
 CodyMode = Literal["zai", "anthropic"]
 
 _ENV_VAR = "UA_CODY_DEFAULT_MODE"
+_DB_SETTING_KEY = "cody_default_mode"
 _VALID_MODES: set[str] = {"zai", "anthropic"}
-_DEFAULT_MODE: CodyMode = "zai"
+# 2026-05-11 PM: flipped from "zai" → "anthropic" per operator decision.
+# Cody now runs on real Anthropic by default; operator can flip to "zai"
+# via the dashboard UI when they want to save cost.
+_HARDCODED_FALLBACK_MODE: CodyMode = "anthropic"
 
 
 def _normalize(raw: Any) -> str:
     return str(raw or "").strip().lower()
 
 
-def resolve_cody_mode(task: dict[str, Any] | None = None) -> CodyMode:
+def _resolve_db_setting(conn: Any) -> Optional[CodyMode]:
+    """Look up the operator-configured default mode from task_hub_settings.
+
+    Returns ``None`` when no setting has been written. Defensive on
+    every failure path — if anything goes wrong reading the setting, we
+    fall through to env / hardcoded default rather than break dispatch.
+    """
+    if conn is None:
+        return None
+    try:
+        from universal_agent.task_hub import _get_setting
+
+        record = _get_setting(conn, _DB_SETTING_KEY, default={})
+    except Exception:
+        return None
+    if not isinstance(record, dict):
+        return None
+    mode = _normalize(record.get("mode"))
+    if mode in _VALID_MODES:
+        return mode  # type: ignore[return-value]
+    return None
+
+
+def resolve_cody_mode(
+    task: dict[str, Any] | None = None,
+    *,
+    conn: Any = None,
+) -> CodyMode:
     """Return the effective Cody execution mode for a task.
 
     Args:
         task: A ``task_hub_items`` row (or compatible dict). May be
-            ``None`` to short-circuit to env/default.
+            ``None`` to short-circuit to setting/env/default.
+        conn: Optional sqlite3 connection to the activity DB for
+            reading the operator-configured DB setting. When omitted,
+            DB-setting resolution is skipped (env + hardcoded default
+            still apply).
 
     Returns:
         Either ``"zai"`` or ``"anthropic"``.
@@ -50,11 +87,15 @@ def resolve_cody_mode(task: dict[str, Any] | None = None) -> CodyMode:
         if per_task in _VALID_MODES:
             return per_task  # type: ignore[return-value]
 
+    db_mode = _resolve_db_setting(conn)
+    if db_mode is not None:
+        return db_mode
+
     env_mode = _normalize(os.getenv(_ENV_VAR))
     if env_mode in _VALID_MODES:
         return env_mode  # type: ignore[return-value]
 
-    return _DEFAULT_MODE
+    return _HARDCODED_FALLBACK_MODE
 
 
 def resolve_from_payload(payload: dict[str, Any] | None) -> CodyMode:
@@ -62,16 +103,93 @@ def resolve_from_payload(payload: dict[str, Any] | None) -> CodyMode:
 
     Used downstream of dispatch (VP worker, CLI client) where the task
     row is no longer in scope but the resolved value lives in the
-    mission's ``payload.cody_mode``.
+    mission's ``payload.cody_mode`` / ``payload.metadata.cody_mode``.
+
+    Does NOT consult the DB setting — by the time a mission payload is
+    being executed the dispatch decision is already baked in. Falls
+    through to env / hardcoded default only as defense.
     """
     if payload:
         mode = _normalize(payload.get("cody_mode"))
         if mode in _VALID_MODES:
             return mode  # type: ignore[return-value]
+        # vp_orchestration plumbs cody_mode under metadata.cody_mode —
+        # check there too for robustness.
+        metadata = payload.get("metadata") if isinstance(payload, dict) else None
+        if isinstance(metadata, dict):
+            nested = _normalize(metadata.get("cody_mode"))
+            if nested in _VALID_MODES:
+                return nested  # type: ignore[return-value]
     env_mode = _normalize(os.getenv(_ENV_VAR))
     if env_mode in _VALID_MODES:
         return env_mode  # type: ignore[return-value]
-    return _DEFAULT_MODE
+    return _HARDCODED_FALLBACK_MODE
 
 
-__all__ = ["CodyMode", "resolve_cody_mode", "resolve_from_payload"]
+def set_default_mode(conn: Any, mode: str, *, updated_by: str = "operator") -> CodyMode:
+    """Persist the operator-configured default Cody mode.
+
+    Validates the input and writes a structured record to
+    ``task_hub_settings`` under the ``cody_default_mode`` key. Raises
+    ``ValueError`` for invalid mode values so callers (the settings
+    endpoint) can surface a 400.
+    """
+    from datetime import datetime, timezone
+
+    from universal_agent.task_hub import _set_setting
+
+    normalized = _normalize(mode)
+    if normalized not in _VALID_MODES:
+        raise ValueError(
+            f"mode must be one of {sorted(_VALID_MODES)} (got {mode!r})"
+        )
+    record = {
+        "mode": normalized,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "updated_by": str(updated_by or "operator"),
+    }
+    _set_setting(conn, _DB_SETTING_KEY, record)
+    return normalized  # type: ignore[return-value]
+
+
+def get_default_mode_state(conn: Any) -> dict[str, Any]:
+    """Return the operator-configured default mode + audit fields.
+
+    Used by the dashboard tile to show "current default + when changed
+    + who changed it". When no setting has been written, returns the
+    effective default (env or hardcoded) with empty audit fields so
+    the UI can render "Default: anthropic (system default)" cleanly.
+    """
+    from universal_agent.task_hub import _get_setting
+
+    record = _get_setting(conn, _DB_SETTING_KEY, default={}) if conn is not None else {}
+    if isinstance(record, dict) and _normalize(record.get("mode")) in _VALID_MODES:
+        return {
+            "mode": _normalize(record.get("mode")),
+            "updated_at": record.get("updated_at") or "",
+            "updated_by": record.get("updated_by") or "",
+            "source": "db_setting",
+        }
+    env_mode = _normalize(os.getenv(_ENV_VAR))
+    if env_mode in _VALID_MODES:
+        return {
+            "mode": env_mode,
+            "updated_at": "",
+            "updated_by": "",
+            "source": "env_var",
+        }
+    return {
+        "mode": _HARDCODED_FALLBACK_MODE,
+        "updated_at": "",
+        "updated_by": "",
+        "source": "hardcoded_default",
+    }
+
+
+__all__ = [
+    "CodyMode",
+    "resolve_cody_mode",
+    "resolve_from_payload",
+    "set_default_mode",
+    "get_default_mode_state",
+]

--- a/src/universal_agent/tools/vp_orchestration.py
+++ b/src/universal_agent/tools/vp_orchestration.py
@@ -247,13 +247,14 @@ async def _vp_dispatch_mission_impl(args: dict[str, Any]) -> dict[str, Any]:
     if not source_session_id:
         source_session_id = "internal.vp_tool"
 
-    # Hermes Phase E.1 — resolve cody_mode and plumb it into mission
+    # Hermes Phase E — resolve cody_mode and plumb it into mission
     # metadata so vp_missions.payload_json carries the toggle for the
     # VP worker (CLI/SDK adapter) to honor. Resolution order:
     #   1. explicit args["cody_mode"]
     #   2. task row's cody_mode (if a linked task_id is supplied)
-    #   3. UA_CODY_DEFAULT_MODE env
-    #   4. "zai" default
+    #   3. DB setting `cody_default_mode` (operator UI toggle)
+    #   4. UA_CODY_DEFAULT_MODE env
+    #   5. "anthropic" hardcoded fallback (flipped 2026-05-11 PM)
     raw_metadata = (
         args.get("metadata") if isinstance(args.get("metadata"), dict) else {}
     )
@@ -263,28 +264,54 @@ async def _vp_dispatch_mission_impl(args: dict[str, Any]) -> dict[str, Any]:
     else:
         from universal_agent.services.cody_mode import resolve_cody_mode
 
-        # Try to load the linked task row to pick up its per-task override.
+        # Load the linked task row (if any) and pass the same conn into
+        # the resolver so it can read the operator DB setting.
         linked_task_id = str(args.get("task_id") or raw_metadata.get("task_id") or "").strip()
         linked_task: dict[str, Any] | None = None
-        if linked_task_id:
-            try:
-                from universal_agent import task_hub
-                from universal_agent.durable.db import (
-                    connect_runtime_db,
-                    get_activity_db_path,
-                )
+        th_conn = None
+        try:
+            from universal_agent import task_hub  # noqa: F401 (used implicitly via resolve_cody_mode)
+            from universal_agent.durable.db import (
+                connect_runtime_db,
+                get_activity_db_path,
+            )
 
-                th_conn = connect_runtime_db(get_activity_db_path())
+            th_conn = connect_runtime_db(get_activity_db_path())
+            if linked_task_id:
                 try:
-                    linked_task = task_hub.get_item(th_conn, linked_task_id)
-                finally:
+                    from universal_agent import task_hub as _th
+                    linked_task = _th.get_item(th_conn, linked_task_id)
+                except Exception:
+                    linked_task = None
+            resolved_cody_mode = resolve_cody_mode(linked_task, conn=th_conn)
+        except Exception:
+            # Resolver couldn't reach the DB; fall through to env/hardcoded.
+            resolved_cody_mode = resolve_cody_mode(linked_task)
+        finally:
+            if th_conn is not None:
+                try:
                     th_conn.close()
-            except Exception:
-                linked_task = None
-        resolved_cody_mode = resolve_cody_mode(linked_task)
+                except Exception:
+                    pass
 
     mission_metadata = dict(raw_metadata)
     mission_metadata["cody_mode"] = resolved_cody_mode
+
+    # Hermes Phase E.2 routing rule: when the resolved mode is
+    # "anthropic", auto-route through execution_mode="cli" so the
+    # spawned `claude` subprocess uses workspace-local OAuth (Anthropic
+    # Max) instead of the gateway's ZAI-routed env. SDK in-process mode
+    # cannot easily flip ANTHROPIC_* per-call without races; CLI mode
+    # gives Cody true environmental autonomy (own PID/env/workspace).
+    # Explicit args["execution_mode"] still wins so an operator can
+    # override (e.g. force "dag" for deterministic flows).
+    explicit_exec_mode = str(args.get("execution_mode") or "").strip().lower()
+    if explicit_exec_mode:
+        resolved_execution_mode = explicit_exec_mode
+    elif resolved_cody_mode == "anthropic":
+        resolved_execution_mode = "cli"
+    else:
+        resolved_execution_mode = "sdk"
 
     conn = _connect_vp_db()
     try:
@@ -302,8 +329,7 @@ async def _vp_dispatch_mission_impl(args: dict[str, Any]) -> dict[str, Any]:
                 reply_mode=reply_mode,
                 priority=priority,
                 run_id=run_id or None,
-                execution_mode=str(args.get("execution_mode") or "sdk").strip()
-                or "sdk",
+                execution_mode=resolved_execution_mode,
                 metadata=mission_metadata,
             ),
         )

--- a/tests/unit/test_cody_mode.py
+++ b/tests/unit/test_cody_mode.py
@@ -1,11 +1,14 @@
-"""Hermes Phase E.1 + E.2.a — Cody execution-mode toggle unit tests.
+"""Hermes Phase E.1 + E.2 — Cody execution-mode toggle unit tests.
 
 Verifies the resolver, schema persistence, and CLI env-scrub behavior.
 
-* E.1 — `resolve_cody_mode` returns "zai" by default, "anthropic" only
-  when a valid task override or env var asks for it.
+* E.1 — `resolve_cody_mode` returns "anthropic" by default (hardcoded
+  fallback flipped 2026-05-11 PM per operator decision). DB setting
+  takes precedence over env, env over hardcoded.
 * E.1 — `task_hub_items.cody_mode` column round-trips through
   `upsert_item` / `get_item`.
+* E.2 — `set_default_mode` persists the operator UI choice; resolver
+  picks it up via the conn parameter.
 * E.2.a — `_build_cli_env(cody_mode="anthropic")` strips every
   ANTHROPIC_* env var and forces CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1.
 * E.2.a — `_build_cli_env(cody_mode="zai")` inherits ANTHROPIC_* from
@@ -21,8 +24,10 @@ import pytest
 
 from universal_agent import task_hub
 from universal_agent.services.cody_mode import (
+    get_default_mode_state,
     resolve_cody_mode,
     resolve_from_payload,
+    set_default_mode,
 )
 from universal_agent.vp.clients.claude_cli_client import _build_cli_env
 
@@ -39,42 +44,101 @@ def conn() -> sqlite3.Connection:
     c.close()
 
 
-# ── E.1: resolve_cody_mode ─────────────────────────────────────────────────
+# ── E.1: resolve_cody_mode (new "anthropic" default) ───────────────────────
 
 
-def test_resolve_defaults_to_zai_with_no_task_no_env(monkeypatch) -> None:
+def test_resolve_defaults_to_anthropic_with_no_task_no_env_no_db(monkeypatch) -> None:
+    """2026-05-11 PM operator decision: hardcoded default is "anthropic"."""
     monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
-    assert resolve_cody_mode(None) == "zai"
-    assert resolve_cody_mode({}) == "zai"
-
-
-def test_resolve_honors_env_override(monkeypatch) -> None:
-    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "anthropic")
     assert resolve_cody_mode(None) == "anthropic"
     assert resolve_cody_mode({}) == "anthropic"
 
 
+def test_resolve_honors_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "zai")
+    assert resolve_cody_mode(None) == "zai"
+    assert resolve_cody_mode({}) == "zai"
+
+
 def test_resolve_task_override_wins_over_env(monkeypatch) -> None:
-    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "anthropic")
-    assert resolve_cody_mode({"cody_mode": "zai"}) == "zai"
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "zai")
+    assert resolve_cody_mode({"cody_mode": "anthropic"}) == "anthropic"
 
 
 def test_resolve_invalid_task_value_falls_through(monkeypatch) -> None:
-    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "anthropic")
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "zai")
     # garbage value should be ignored, env wins
-    assert resolve_cody_mode({"cody_mode": "garbage"}) == "anthropic"
+    assert resolve_cody_mode({"cody_mode": "garbage"}) == "zai"
 
 
 def test_resolve_invalid_env_falls_through_to_default(monkeypatch) -> None:
+    monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
     monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "not-a-mode")
-    assert resolve_cody_mode(None) == "zai"
+    assert resolve_cody_mode(None) == "anthropic"
 
 
 def test_resolve_from_payload_reads_payload(monkeypatch) -> None:
     monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
     assert resolve_from_payload({"cody_mode": "anthropic"}) == "anthropic"
     assert resolve_from_payload({"cody_mode": "zai"}) == "zai"
-    assert resolve_from_payload(None) == "zai"
+    # None falls through to hardcoded default (now anthropic)
+    assert resolve_from_payload(None) == "anthropic"
+
+
+def test_resolve_from_payload_reads_metadata_nested(monkeypatch) -> None:
+    """vp_orchestration plumbs cody_mode under metadata.cody_mode."""
+    monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
+    payload = {"metadata": {"cody_mode": "zai"}}
+    assert resolve_from_payload(payload) == "zai"
+
+
+# ── E.2: DB setting (operator UI toggle) ──────────────────────────────────
+
+
+def test_set_default_mode_persists_to_settings(conn: sqlite3.Connection, monkeypatch) -> None:
+    monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
+    set_default_mode(conn, "zai", updated_by="operator")
+    # Resolver picks up the DB setting with a conn passed in.
+    assert resolve_cody_mode(None, conn=conn) == "zai"
+    # State endpoint returns the audit fields.
+    state = get_default_mode_state(conn)
+    assert state["mode"] == "zai"
+    assert state["source"] == "db_setting"
+    assert state["updated_by"] == "operator"
+    assert state["updated_at"]  # non-empty ISO timestamp
+
+
+def test_set_default_mode_validates_input(conn: sqlite3.Connection) -> None:
+    with pytest.raises(ValueError) as exc:
+        set_default_mode(conn, "garbage")
+    assert "must be one of" in str(exc.value)
+
+
+def test_get_default_mode_state_falls_through_env(conn: sqlite3.Connection, monkeypatch) -> None:
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "zai")
+    state = get_default_mode_state(conn)
+    assert state["mode"] == "zai"
+    assert state["source"] == "env_var"
+
+
+def test_get_default_mode_state_hardcoded_default(conn: sqlite3.Connection, monkeypatch) -> None:
+    monkeypatch.delenv("UA_CODY_DEFAULT_MODE", raising=False)
+    state = get_default_mode_state(conn)
+    assert state["mode"] == "anthropic"
+    assert state["source"] == "hardcoded_default"
+
+
+def test_db_setting_beats_env(conn: sqlite3.Connection, monkeypatch) -> None:
+    """DB setting (operator UI) takes precedence over env var (deploy override)."""
+    monkeypatch.setenv("UA_CODY_DEFAULT_MODE", "zai")
+    set_default_mode(conn, "anthropic", updated_by="operator")
+    assert resolve_cody_mode(None, conn=conn) == "anthropic"
+
+
+def test_task_override_beats_db_setting(conn: sqlite3.Connection) -> None:
+    """Per-task `cody_mode` field is the highest-priority override."""
+    set_default_mode(conn, "zai", updated_by="operator")
+    assert resolve_cody_mode({"cody_mode": "anthropic"}, conn=conn) == "anthropic"
 
 
 # ── E.1: schema column round-trip ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

Ship 2a of 3 closing out the remaining Hermes work. Three interlocking changes per your decision on Q2:

1. **Hardcoded default flipped: \`zai\` → \`anthropic\`.** Fresh deploy with no overrides routes Cody through real Anthropic Max.
2. **Operator UI toggle backed by \`task_hub_settings.cody_default_mode\`.** \`set_default_mode\` / \`get_default_mode_state\` helpers + \`GET/POST /api/v1/cody/mode-setting\` endpoints. Ship 2b adds the actual dashboard tile that calls these.
3. **Auto-CLI routing**: when resolved \`cody_mode=anthropic\` and the caller didn't pin \`execution_mode\`, dispatch auto-sets \`execution_mode=cli\` so the spawned \`claude\` subprocess uses workspace-local OAuth (the E.2.a env-scrub already in production handles the rest).

New resolution order: \`task.cody_mode → DB setting → UA_CODY_DEFAULT_MODE env → \"anthropic\"\`.

This also implicitly **closes E.2.b** (deferred). The SDK in-process Anthropic-routing path was race-prone; CLI mode gives Cody true environmental autonomy (own PID, own env, workspace-local OAuth, Agent Teams enabled). No separate adapter work needed.

## Migration impact

Existing tasks with \`cody_mode=NULL\` in production will start routing through Anthropic Max as of next deploy. Operator can flip back to \"zai\" via the new endpoint (or the Ship 2b UI toggle) if cost telemetry shows we should.

## Test plan

- [x] 20/20 \`test_cody_mode.py\` pass (7 new for DB-setting layer + 6 schema + 7 CLI env-scrub updated for new default)
- [x] Cross-Hermes sanity 131/131 across task_hub_runs / unstick verbs / failure-context / F foundation / lifecycle / schema_extensions / max_retries
- [x] py_compile + ruff clean
- [ ] CI PR-Validate
- [ ] Post-deploy: \`curl https://app.clearspringcg.com/api/v1/cody/mode-setting\` returns \`{\"mode\":\"anthropic\",\"source\":\"hardcoded_default\",\"available_modes\":[\"zai\",\"anthropic\"],...}\`; \`POST\` with \`{\"mode\":\"zai\"}\` round-trips.

## Next ships

- **Ship 2b**: Token tracking table + CLI capture hook + dashboard tile with refresh button.
- **Ship 3**: F site wiring + F.3 protocol-violation detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)