### PR TITLE
feat(hermes-e2b): Cody token-usage tracking + dashboard endpoints

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -22737,6 +22737,82 @@ async def cody_mode_setting_post(payload: dict):
     return state
 
 
+# ── Cody Token Tracking (Hermes Phase E.2b — dashboard tile) ─────────
+
+
+@app.get("/api/v1/cody/anthropic-token-tracking")
+async def cody_anthropic_token_tracking_get(mode: str = "anthropic"):
+    """Return cumulative Cody token usage since the last operator refresh.
+
+    Query params:
+        mode: "anthropic" (default) | "zai" | "all" — filter the totals.
+
+    Response shape:
+        {
+            "reset_at": ISO string (cursor lower bound),
+            "reset_by": str,
+            "days_in_window": float,
+            "mission_count": int,
+            "input_tokens": int,
+            "output_tokens": int,
+            "cache_creation_input_tokens": int,
+            "cache_read_input_tokens": int,
+            "total_cost_usd": float,
+            "model_breakdown": [{"model", "missions", "input_tokens",
+                                  "output_tokens", "total_cost_usd"}, ...],
+            "cody_mode_filter": "anthropic" | "zai" | null
+        }
+    """
+    from universal_agent.services.cody_token_tracking import summarize_window
+
+    mode_norm = str(mode or "").strip().lower()
+    cody_mode_filter: Optional[str]
+    if mode_norm == "all":
+        cody_mode_filter = None
+    elif mode_norm in {"zai", "anthropic"}:
+        cody_mode_filter = mode_norm
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="mode must be one of: 'anthropic', 'zai', 'all'",
+        )
+
+    with _activity_store_lock:
+        conn = _task_hub_open_conn()
+        try:
+            return summarize_window(conn, cody_mode=cody_mode_filter)
+        finally:
+            conn.close()
+
+
+@app.post("/api/v1/cody/anthropic-token-tracking/reset")
+async def cody_anthropic_token_tracking_reset(payload: dict = None):
+    """Bump the tracking window cursor to now.
+
+    History rows are preserved; the dashboard tile will show zero
+    totals on the next poll and start accumulating again. Body is
+    optional: ``{"reset_by": "operator"}``.
+    """
+    from universal_agent.services.cody_token_tracking import (
+        reset_window,
+        summarize_window,
+    )
+
+    reset_by = "operator"
+    if isinstance(payload, dict):
+        raw = str(payload.get("reset_by") or "").strip()
+        if raw:
+            reset_by = raw
+
+    with _activity_store_lock:
+        conn = _task_hub_open_conn()
+        try:
+            reset_window(conn, reset_by=reset_by)
+            return summarize_window(conn, cody_mode="anthropic")
+        finally:
+            conn.close()
+
+
 # ── Brainstorm Refinement Endpoints ───────────────────────────────────
 
 @app.post("/api/v1/dashboard/todolist/tasks/{task_id}/refine")

--- a/src/universal_agent/services/cody_token_tracking.py
+++ b/src/universal_agent/services/cody_token_tracking.py
@@ -1,0 +1,270 @@
+"""Hermes Phase E.2b — Cody token-usage tracking.
+
+Records per-mission token usage emitted by the Claude Code CLI's
+``stream-json`` ``result`` event into ``cody_token_usage``, and serves
+the dashboard's "Cody Anthropic Token Usage" tile via a window-based
+accumulator pattern:
+
+* Capture: ``record_token_usage(...)`` writes one row per completed
+  mission. Hooked from ``vp/clients/claude_cli_client.py`` after the
+  CLI subprocess closes.
+* Aggregate: ``summarize_window(...)`` sums every row where
+  ``recorded_at >= reset_at``. The dashboard tile calls this on each
+  poll and renders the totals.
+* Reset: ``reset_window(...)`` bumps the ``reset_at`` cursor in
+  ``task_hub_settings.cody_token_tracking_window``. History under the
+  cursor is preserved for forensics — the tile just shows the new
+  window.
+
+The capture function is best-effort and never raises; if the DB write
+fails (lock, schema drift, etc.) we log and move on. Token tracking is
+operator telemetry, not a correctness gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_WINDOW_SETTING_KEY = "cody_token_tracking_window"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return default
+
+
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value or 0.0)
+    except (TypeError, ValueError):
+        return default
+
+
+def record_token_usage(
+    conn: sqlite3.Connection,
+    *,
+    cody_mode: str,
+    mission_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    model: Optional[str] = None,
+    cost_info: Optional[dict[str, Any]] = None,
+) -> Optional[int]:
+    """Persist one row of token usage for a completed mission.
+
+    Best-effort: returns the new row id on success, ``None`` on any
+    failure (logged at WARNING). Never raises — callers in the CLI
+    client should not have their happy path coupled to telemetry.
+
+    Args:
+        conn: SQLite connection with task_hub schema applied.
+        cody_mode: "zai" or "anthropic" — required so the tile can
+            filter to Anthropic-only totals.
+        mission_id / task_id: provenance for audit / per-mission drill-in.
+        model: model identifier from the CLI's result event (e.g.
+            ``"claude-opus-4-7"``, ``"glm-5.1"``).
+        cost_info: the dict captured from the CLI's ``result`` event.
+            Expected keys (any subset; missing => 0):
+                * ``input_tokens``
+                * ``output_tokens``
+                * ``cache_creation_input_tokens``
+                * ``cache_read_input_tokens``
+                * ``cost_usd`` / ``total_cost_usd``
+                * ``duration_ms``
+    """
+    try:
+        normalized_mode = str(cody_mode or "").strip().lower()
+        if normalized_mode not in {"zai", "anthropic"}:
+            # Defensive — schema doesn't constrain it but tile depends on
+            # this being one of the two known values for filtering.
+            logger.warning(
+                "record_token_usage: unrecognized cody_mode=%r — skipping",
+                cody_mode,
+            )
+            return None
+        ci = dict(cost_info or {})
+        cost_usd = _safe_float(ci.get("total_cost_usd") or ci.get("cost_usd"))
+
+        cursor = conn.execute(
+            """
+            INSERT INTO cody_token_usage (
+                mission_id, task_id, cody_mode, model,
+                input_tokens, output_tokens,
+                cache_creation_input_tokens, cache_read_input_tokens,
+                total_cost_usd, duration_ms, recorded_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(mission_id or "").strip() or None,
+                str(task_id or "").strip() or None,
+                normalized_mode,
+                str(model or "").strip() or None,
+                _safe_int(ci.get("input_tokens")),
+                _safe_int(ci.get("output_tokens")),
+                _safe_int(ci.get("cache_creation_input_tokens")),
+                _safe_int(ci.get("cache_read_input_tokens")),
+                cost_usd,
+                _safe_int(ci.get("duration_ms")),
+                _now_iso(),
+            ),
+        )
+        conn.commit()
+        return cursor.lastrowid
+    except Exception as exc:
+        logger.warning("record_token_usage failed: %s", exc, exc_info=False)
+        return None
+
+
+def get_window_state(conn: sqlite3.Connection) -> dict[str, Any]:
+    """Return the operator-configured tracking window cursor + audit.
+
+    The ``reset_at`` ISO string is the lower bound; rows with
+    ``recorded_at >= reset_at`` are counted in the current window.
+    When no window has been initialized, returns a zero-cursor record
+    so the dashboard tile shows the all-time totals as the current
+    window (operator can hit Refresh to reset).
+    """
+    from universal_agent.task_hub import _get_setting
+
+    record = _get_setting(conn, _WINDOW_SETTING_KEY, default={})
+    if not isinstance(record, dict):
+        record = {}
+    reset_at = str(record.get("reset_at") or "").strip()
+    if not reset_at:
+        reset_at = "1970-01-01T00:00:00+00:00"
+    return {
+        "reset_at": reset_at,
+        "reset_by": record.get("reset_by") or "",
+    }
+
+
+def reset_window(
+    conn: sqlite3.Connection, *, reset_by: str = "operator"
+) -> dict[str, Any]:
+    """Bump the tracking window to start fresh from now.
+
+    History rows are preserved; only the cursor moves. The dashboard
+    tile will then show zero totals on the next poll, and the
+    accumulator starts counting again as new missions complete.
+    """
+    from universal_agent.task_hub import _set_setting
+
+    now_iso = _now_iso()
+    record = {
+        "reset_at": now_iso,
+        "reset_by": str(reset_by or "operator"),
+    }
+    _set_setting(conn, _WINDOW_SETTING_KEY, record)
+    return record
+
+
+def summarize_window(
+    conn: sqlite3.Connection, *, cody_mode: Optional[str] = "anthropic"
+) -> dict[str, Any]:
+    """Aggregate token usage in the current tracking window.
+
+    Args:
+        cody_mode: filter to this mode. Default "anthropic" so the
+            primary dashboard tile shows Anthropic Max cost. Pass
+            ``None`` to aggregate across all modes.
+
+    Returns a dict shaped for direct JSON return to the dashboard:
+        {
+            "reset_at": ISO,
+            "reset_by": str,
+            "days_in_window": float (days since reset_at),
+            "mission_count": int,
+            "input_tokens": int,
+            "output_tokens": int,
+            "cache_creation_input_tokens": int,
+            "cache_read_input_tokens": int,
+            "total_cost_usd": float,
+            "model_breakdown": [{"model": str, "missions": int,
+                                  "input_tokens": int, "output_tokens": int,
+                                  "total_cost_usd": float}, ...],
+            "cody_mode_filter": str | None,
+        }
+    """
+    window = get_window_state(conn)
+    reset_at = window["reset_at"]
+
+    params: tuple = (reset_at,)
+    where_clause = "WHERE recorded_at >= ?"
+    if cody_mode:
+        where_clause += " AND cody_mode = ?"
+        params = (reset_at, cody_mode)
+
+    totals_row = conn.execute(
+        f"""
+        SELECT
+            COUNT(*)                                AS mission_count,
+            COALESCE(SUM(input_tokens), 0)          AS input_tokens,
+            COALESCE(SUM(output_tokens), 0)         AS output_tokens,
+            COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+            COALESCE(SUM(cache_read_input_tokens), 0)     AS cache_read_input_tokens,
+            COALESCE(SUM(total_cost_usd), 0.0)      AS total_cost_usd
+        FROM cody_token_usage
+        {where_clause}
+        """,
+        params,
+    ).fetchone()
+    totals = dict(totals_row) if totals_row else {}
+
+    model_rows = conn.execute(
+        f"""
+        SELECT
+            COALESCE(model, '(unknown)') AS model,
+            COUNT(*) AS missions,
+            COALESCE(SUM(input_tokens), 0) AS input_tokens,
+            COALESCE(SUM(output_tokens), 0) AS output_tokens,
+            COALESCE(SUM(total_cost_usd), 0.0) AS total_cost_usd
+        FROM cody_token_usage
+        {where_clause}
+        GROUP BY COALESCE(model, '(unknown)')
+        ORDER BY missions DESC
+        """,
+        params,
+    ).fetchall()
+    model_breakdown = [dict(r) for r in model_rows]
+
+    # Compute days_in_window for the tile label.
+    try:
+        reset_dt = datetime.fromisoformat(reset_at.replace("Z", "+00:00"))
+        if reset_dt.tzinfo is None:
+            reset_dt = reset_dt.replace(tzinfo=timezone.utc)
+        delta = datetime.now(timezone.utc) - reset_dt
+        days_in_window = max(0.0, delta.total_seconds() / 86400.0)
+    except Exception:
+        days_in_window = 0.0
+
+    return {
+        "reset_at": reset_at,
+        "reset_by": window.get("reset_by") or "",
+        "days_in_window": round(days_in_window, 2),
+        "mission_count": int(totals.get("mission_count") or 0),
+        "input_tokens": int(totals.get("input_tokens") or 0),
+        "output_tokens": int(totals.get("output_tokens") or 0),
+        "cache_creation_input_tokens": int(totals.get("cache_creation_input_tokens") or 0),
+        "cache_read_input_tokens": int(totals.get("cache_read_input_tokens") or 0),
+        "total_cost_usd": float(totals.get("total_cost_usd") or 0.0),
+        "model_breakdown": model_breakdown,
+        "cody_mode_filter": cody_mode,
+    }
+
+
+__all__ = [
+    "record_token_usage",
+    "get_window_state",
+    "reset_window",
+    "summarize_window",
+]

--- a/src/universal_agent/task_hub.py
+++ b/src/universal_agent/task_hub.py
@@ -309,6 +309,32 @@ def ensure_schema(conn: sqlite3.Connection) -> None:
         CREATE INDEX IF NOT EXISTS idx_task_hub_assign_task_state ON task_hub_assignments(task_id, state, started_at DESC);
         CREATE INDEX IF NOT EXISTS idx_task_hub_assign_agent_state ON task_hub_assignments(agent_id, state, started_at DESC);
 
+        -- Hermes Phase E.2b: per-mission Cody token-usage telemetry.
+        -- Rows are written by claude_cli_client at mission close (one
+        -- row per mission). The dashboard tile sums rows where
+        -- recorded_at >= the `cody_token_tracking_window.reset_at`
+        -- cursor stored in task_hub_settings, so the operator can hit
+        -- "Refresh" to start a new accumulator window without losing
+        -- history. `cody_mode` lets the tile filter to "anthropic" usage
+        -- when surfacing cost on the Anthropic-mode card specifically.
+        CREATE TABLE IF NOT EXISTS cody_token_usage (
+            id                          INTEGER PRIMARY KEY AUTOINCREMENT,
+            mission_id                  TEXT,
+            task_id                     TEXT,
+            cody_mode                   TEXT NOT NULL,
+            model                       TEXT,
+            input_tokens                INTEGER NOT NULL DEFAULT 0,
+            output_tokens               INTEGER NOT NULL DEFAULT 0,
+            cache_creation_input_tokens INTEGER NOT NULL DEFAULT 0,
+            cache_read_input_tokens     INTEGER NOT NULL DEFAULT 0,
+            total_cost_usd              REAL NOT NULL DEFAULT 0.0,
+            duration_ms                 INTEGER NOT NULL DEFAULT 0,
+            recorded_at                 TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_cody_token_mode_recorded ON cody_token_usage(cody_mode, recorded_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_cody_token_mission ON cody_token_usage(mission_id);
+        CREATE INDEX IF NOT EXISTS idx_cody_token_task ON cody_token_usage(task_id);
+
         -- Hermes Phase D: per-attempt durable history alongside task_hub_assignments.
         -- task_hub_assignments is the claim-ledger (started/ended/state) while
         -- task_hub_runs holds the closing outcome/summary/metadata/error so

--- a/src/universal_agent/vp/clients/claude_cli_client.py
+++ b/src/universal_agent/vp/clients/claude_cli_client.py
@@ -161,6 +161,16 @@ class ClaudeCodeCLIClient(VpClient):
                 )
 
                 if outcome.status == "completed":
+                    # Hermes Phase E.2b — record token usage for the dashboard
+                    # tile. Best-effort, never raises. Captures every
+                    # completed mission regardless of cody_mode so the
+                    # operator can compare costs across modes.
+                    _record_mission_token_usage(
+                        outcome=outcome,
+                        mission_id=mission_id,
+                        task_id=str(payload.get("task_id") or "").strip() or None,
+                        cody_mode=cody_mode,
+                    )
                     return outcome
 
                 last_outcome = outcome
@@ -403,6 +413,57 @@ async def _monitor_cli_output(
             "stream_lines": len(stream_lines),
         },
     )
+
+
+def _record_mission_token_usage(
+    *,
+    outcome: MissionOutcome,
+    mission_id: str,
+    task_id: Optional[str],
+    cody_mode: str,
+) -> None:
+    """Hermes Phase E.2b — persist token usage for the dashboard tile.
+
+    Best-effort: never raises, never blocks the happy path. The CLI's
+    ``result`` event populated ``outcome.payload["cost"]`` with the
+    usage breakdown (``input_tokens`` etc.) and the model identifier
+    sometimes lives in the same dict. Forwards everything we have to
+    ``cody_token_tracking.record_token_usage``.
+    """
+    try:
+        cost_info = (outcome.payload or {}).get("cost") if outcome.payload else None
+        if not isinstance(cost_info, dict):
+            cost_info = {}
+        # Some Claude CLI stream-json variants put the model on the
+        # result event directly; some nest it under usage. Best-effort.
+        model = cost_info.get("model") or cost_info.get("model_id") or None
+
+        from universal_agent.durable.db import (
+            connect_runtime_db,
+            get_activity_db_path,
+        )
+        from universal_agent.services.cody_token_tracking import (
+            record_token_usage,
+        )
+
+        conn = connect_runtime_db(get_activity_db_path())
+        try:
+            record_token_usage(
+                conn,
+                cody_mode=cody_mode,
+                mission_id=mission_id or None,
+                task_id=task_id,
+                model=str(model) if model else None,
+                cost_info=cost_info,
+            )
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.warning(
+            "Token usage capture failed for mission %s (cody_mode=%s): %s",
+            mission_id, cody_mode, exc,
+            exc_info=False,
+        )
 
 
 def _build_cli_env(

--- a/tests/unit/test_cody_token_tracking.py
+++ b/tests/unit/test_cody_token_tracking.py
@@ -1,0 +1,269 @@
+"""Hermes Phase E.2b — Cody token tracking unit tests.
+
+Covers the schema + accumulator service + endpoint shape used by the
+dashboard tile:
+
+* `cody_token_usage` table round-trips.
+* `record_token_usage` extracts each known cost_info field correctly
+  and is best-effort (never raises on bad input).
+* `summarize_window` filters by `recorded_at >= reset_at` cursor and
+  by `cody_mode`, and rolls up `model_breakdown`.
+* `reset_window` bumps the cursor; new rows under the cursor are
+  excluded from totals; pre-reset rows remain in the DB for forensics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services.cody_token_tracking import (
+    get_window_state,
+    record_token_usage,
+    reset_window,
+    summarize_window,
+)
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    task_hub.ensure_schema(c)
+    yield c
+    c.close()
+
+
+def _backdate_last_row(conn: sqlite3.Connection, iso: str) -> None:
+    """Helper: rewrite the most-recent row's recorded_at for window tests."""
+    conn.execute(
+        "UPDATE cody_token_usage SET recorded_at = ? WHERE id = (SELECT MAX(id) FROM cody_token_usage)",
+        (iso,),
+    )
+    conn.commit()
+
+
+# ── Schema ────────────────────────────────────────────────────────────────
+
+
+def test_cody_token_usage_table_exists(conn: sqlite3.Connection) -> None:
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(cody_token_usage)")}
+    assert {
+        "id",
+        "mission_id",
+        "task_id",
+        "cody_mode",
+        "model",
+        "input_tokens",
+        "output_tokens",
+        "cache_creation_input_tokens",
+        "cache_read_input_tokens",
+        "total_cost_usd",
+        "duration_ms",
+        "recorded_at",
+    } <= cols
+
+
+# ── record_token_usage ────────────────────────────────────────────────────
+
+
+def test_record_token_usage_persists_all_fields(conn: sqlite3.Connection) -> None:
+    row_id = record_token_usage(
+        conn,
+        cody_mode="anthropic",
+        mission_id="vp-mission-abc",
+        task_id="task:x",
+        model="claude-opus-4-7",
+        cost_info={
+            "input_tokens": 100,
+            "output_tokens": 250,
+            "cache_creation_input_tokens": 20,
+            "cache_read_input_tokens": 30,
+            "total_cost_usd": 0.0512,
+            "duration_ms": 1234,
+        },
+    )
+    assert isinstance(row_id, int)
+    row = conn.execute("SELECT * FROM cody_token_usage WHERE id = ?", (row_id,)).fetchone()
+    assert row["cody_mode"] == "anthropic"
+    assert row["mission_id"] == "vp-mission-abc"
+    assert row["task_id"] == "task:x"
+    assert row["model"] == "claude-opus-4-7"
+    assert row["input_tokens"] == 100
+    assert row["output_tokens"] == 250
+    assert row["cache_creation_input_tokens"] == 20
+    assert row["cache_read_input_tokens"] == 30
+    assert row["total_cost_usd"] == pytest.approx(0.0512)
+    assert row["duration_ms"] == 1234
+    assert row["recorded_at"]  # non-empty
+
+
+def test_record_token_usage_accepts_cost_usd_alias(conn: sqlite3.Connection) -> None:
+    """Some stream-json variants use `cost_usd` instead of `total_cost_usd`."""
+    record_token_usage(
+        conn,
+        cody_mode="anthropic",
+        cost_info={"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.001},
+    )
+    row = conn.execute("SELECT total_cost_usd FROM cody_token_usage LIMIT 1").fetchone()
+    assert row["total_cost_usd"] == pytest.approx(0.001)
+
+
+def test_record_token_usage_rejects_unknown_mode(conn: sqlite3.Connection) -> None:
+    out = record_token_usage(conn, cody_mode="bogus", cost_info={"input_tokens": 5})
+    assert out is None
+    count = conn.execute("SELECT COUNT(*) FROM cody_token_usage").fetchone()[0]
+    assert count == 0
+
+
+def test_record_token_usage_handles_missing_cost_info(conn: sqlite3.Connection) -> None:
+    """Empty cost_info should record a zero-token row, not raise."""
+    row_id = record_token_usage(conn, cody_mode="zai", cost_info=None)
+    assert isinstance(row_id, int)
+    row = conn.execute("SELECT * FROM cody_token_usage WHERE id = ?", (row_id,)).fetchone()
+    assert row["input_tokens"] == 0
+    assert row["output_tokens"] == 0
+    assert row["total_cost_usd"] == 0.0
+
+
+def test_record_token_usage_handles_garbage_values(conn: sqlite3.Connection) -> None:
+    """Non-numeric values fall through to zeros."""
+    row_id = record_token_usage(
+        conn,
+        cody_mode="anthropic",
+        cost_info={"input_tokens": "not-a-number", "output_tokens": None, "total_cost_usd": "garbage"},
+    )
+    assert isinstance(row_id, int)
+    row = conn.execute("SELECT * FROM cody_token_usage WHERE id = ?", (row_id,)).fetchone()
+    assert row["input_tokens"] == 0
+    assert row["output_tokens"] == 0
+    assert row["total_cost_usd"] == 0.0
+
+
+# ── window + summarize ────────────────────────────────────────────────────
+
+
+def test_summarize_window_with_no_reset_uses_epoch_cursor(conn: sqlite3.Connection) -> None:
+    """No prior reset → cursor is 1970, so all rows are in-window."""
+    record_token_usage(
+        conn,
+        cody_mode="anthropic",
+        cost_info={"input_tokens": 100, "output_tokens": 200, "total_cost_usd": 0.05},
+    )
+    summary = summarize_window(conn, cody_mode="anthropic")
+    assert summary["mission_count"] == 1
+    assert summary["input_tokens"] == 100
+    assert summary["output_tokens"] == 200
+    assert summary["total_cost_usd"] == pytest.approx(0.05)
+    assert summary["cody_mode_filter"] == "anthropic"
+    assert summary["reset_at"].startswith("1970-")
+
+
+def test_summarize_window_filters_by_cody_mode(conn: sqlite3.Connection) -> None:
+    """Anthropic-only filter excludes ZAI rows."""
+    record_token_usage(conn, cody_mode="anthropic", cost_info={"input_tokens": 100})
+    record_token_usage(conn, cody_mode="zai", cost_info={"input_tokens": 999})
+    anth = summarize_window(conn, cody_mode="anthropic")
+    zai = summarize_window(conn, cody_mode="zai")
+    all_mode = summarize_window(conn, cody_mode=None)
+    assert anth["input_tokens"] == 100
+    assert zai["input_tokens"] == 999
+    assert all_mode["input_tokens"] == 1099
+
+
+def test_reset_window_excludes_pre_reset_rows(conn: sqlite3.Connection) -> None:
+    """Rows recorded before reset_at are excluded from totals (history kept)."""
+    record_token_usage(conn, cody_mode="anthropic", cost_info={"input_tokens": 500})
+    # Backdate it so the upcoming reset puts it pre-cursor.
+    old = (datetime.now(timezone.utc) - timedelta(days=2)).isoformat()
+    _backdate_last_row(conn, old)
+    # Reset cursor to a time after the backdated row.
+    reset_window(conn, reset_by="test-operator")
+    # New post-reset row.
+    record_token_usage(conn, cody_mode="anthropic", cost_info={"input_tokens": 7})
+    summary = summarize_window(conn, cody_mode="anthropic")
+    assert summary["mission_count"] == 1
+    assert summary["input_tokens"] == 7
+    # But raw history is preserved.
+    total_rows = conn.execute("SELECT COUNT(*) FROM cody_token_usage").fetchone()[0]
+    assert total_rows == 2
+    state = get_window_state(conn)
+    assert state["reset_by"] == "test-operator"
+
+
+def test_summarize_window_model_breakdown(conn: sqlite3.Connection) -> None:
+    """Model breakdown groups by model name with per-model totals."""
+    record_token_usage(
+        conn,
+        cody_mode="anthropic",
+        model="claude-opus-4-7",
+        cost_info={"input_tokens": 100, "output_tokens": 50, "total_cost_usd": 0.02},
+    )
+    record_token_usage(
+        conn,
+        cody_mode="anthropic",
+        model="claude-opus-4-7",
+        cost_info={"input_tokens": 100, "output_tokens": 50, "total_cost_usd": 0.02},
+    )
+    record_token_usage(
+        conn,
+        cody_mode="anthropic",
+        model="claude-sonnet-4-6",
+        cost_info={"input_tokens": 200, "output_tokens": 100, "total_cost_usd": 0.01},
+    )
+    summary = summarize_window(conn, cody_mode="anthropic")
+    bd = {r["model"]: r for r in summary["model_breakdown"]}
+    assert bd["claude-opus-4-7"]["missions"] == 2
+    assert bd["claude-opus-4-7"]["input_tokens"] == 200
+    assert bd["claude-sonnet-4-6"]["missions"] == 1
+    assert bd["claude-sonnet-4-6"]["input_tokens"] == 200
+
+
+def test_summarize_window_days_in_window(conn: sqlite3.Connection) -> None:
+    """days_in_window is a float number of days since reset_at."""
+    summary = summarize_window(conn, cody_mode="anthropic")
+    # With no reset, cursor is epoch → many years.
+    assert summary["days_in_window"] > 365 * 30
+
+
+# ── Endpoint smoke ────────────────────────────────────────────────────────
+
+
+def test_get_endpoint_returns_summary(monkeypatch, tmp_path) -> None:
+    """Smoke test the API handler shape (no full FastAPI lifespan)."""
+    db_path = str(tmp_path / "activity.db")
+    monkeypatch.setenv("UA_ACTIVITY_DB_PATH", db_path)
+    # Schema seed.
+    c = sqlite3.connect(db_path)
+    c.row_factory = sqlite3.Row
+    task_hub.ensure_schema(c)
+    record_token_usage(c, cody_mode="anthropic", cost_info={"input_tokens": 42, "output_tokens": 12, "total_cost_usd": 0.005})
+    c.close()
+
+    from universal_agent.gateway_server import cody_anthropic_token_tracking_get
+
+    out = asyncio.run(cody_anthropic_token_tracking_get(mode="anthropic"))
+    assert out["mission_count"] == 1
+    assert out["input_tokens"] == 42
+    assert out["output_tokens"] == 12
+    assert out["cody_mode_filter"] == "anthropic"
+
+
+def test_get_endpoint_invalid_mode(monkeypatch, tmp_path) -> None:
+    db_path = str(tmp_path / "activity.db")
+    monkeypatch.setenv("UA_ACTIVITY_DB_PATH", db_path)
+    c = sqlite3.connect(db_path)
+    task_hub.ensure_schema(c)
+    c.close()
+
+    from fastapi import HTTPException
+
+    from universal_agent.gateway_server import cody_anthropic_token_tracking_get
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(cody_anthropic_token_tracking_get(mode="garbage"))
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary

Ship 2b — backend half of the operator-requested token-usage tile. Captures Claude CLI \`result\` events into a new \`cody_token_usage\` table, exposes window-based accumulator endpoints, supports operator refresh that bumps the cursor (history preserved).

Pairs with Ship 2a (PR #235 — \`cody_mode\` default flipped to \`anthropic\`). Frontend tile in a follow-up PR.

## What ships

- **Schema**: \`cody_token_usage\` table + 3 indexes.
- **Service**: \`services/cody_token_tracking.py\` with \`record_token_usage / get_window_state / reset_window / summarize_window\`.
- **Capture hook**: \`claude_cli_client.run_mission\` writes a row per completed mission (best-effort, never blocks).
- **Endpoints**:
  - \`GET /api/v1/cody/anthropic-token-tracking?mode=anthropic|zai|all\`
  - \`POST /api/v1/cody/anthropic-token-tracking/reset\`

## Why the cursor pattern

You asked for "tokens build up over time until refresh button — date is then refreshed as well." The cursor model preserves every mission's row in the DB for forensics but the operator-facing tile shows only rows with \`recorded_at >= reset_at\`. Pressing Refresh bumps the cursor to now → tile zeros out → accumulator restarts. The \`reset_at\` ISO is returned alongside totals so the tile renders "Last reset: 2026-05-11 (3.4 days ago)".

## Test plan

- [x] 13/13 \`test_cody_token_tracking.py\` pass
- [x] Cross-Hermes sanity 137/137 across token tracking + cody_mode + runs + unstick + failure-context + F foundation + lifecycle + schema_extensions + max_retries
- [x] py_compile + ruff clean
- [ ] CI PR-Validate
- [ ] Post-deploy: trigger any Cody CLI mission, confirm a \`cody_token_usage\` row appears, hit GET endpoint, confirm summary returns it; hit POST /reset; confirm subsequent GET returns zero totals.

## Next ship

- **Ship 2c** (small): Web UI tile that calls these endpoints.
- **Ship 3**: F site wiring + F.3 protocol-violation detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)