### PR TITLE
feat(hermes-f): site wiring (cron / VP CLI / demo) + F.3 protocol violation

### DIFF
--- a/src/universal_agent/cron_service.py
+++ b/src/universal_agent/cron_service.py
@@ -1187,16 +1187,29 @@ class CronService:
                             if raw_command.startswith("!script "):
                                 script_path = raw_command.replace("!script ", "", 1).strip()
                                 logger.info(f"Chron job {job.job_id} executing native script: {script_path}")
-                                
+
                                 # Use asyncio.create_subprocess_exec
                                 import subprocess
                                 import sys
-                                
+
                                 env = os.environ.copy()
                                 cwd_str = str(job.workspace_dir_resolved) if hasattr(job, "workspace_dir_resolved") else str(Path(__file__).resolve().parents[2])
                                 project_src = str(Path(__file__).resolve().parents[1])
                                 env["PYTHONPATH"] = f"{project_src}:{env.get('PYTHONPATH', '')}"
-                                
+
+                                # Hermes Phase F site-wiring (cron `!script`).
+                                # Resolve the linked Task Hub task / assignment
+                                # (if any) BEFORE spawning so we can stamp the
+                                # subprocess PID onto the assignment row right
+                                # after spawn.  Cron jobs without a linked
+                                # task_id (the majority) skip F.1/F.3 silently
+                                # — observability is best-effort for the
+                                # subset that DO carry the linkage.
+                                _f_job_metadata = job.metadata or {}
+                                _f_task_id = str(_f_job_metadata.get("task_id") or "").strip()
+                                _f_assignment_id: Optional[str] = None
+                                _f_was_timeout_killed = False
+
                                 proc = await asyncio.create_subprocess_exec(
                                     sys.executable, "-m", script_path.replace("/", ".").replace(".py", ""),
                                     stdout=subprocess.PIPE,
@@ -1204,9 +1217,44 @@ class CronService:
                                     cwd=cwd_str,
                                     env=env,
                                 )
+                                # Phase F.1 — record worker_pid on the linked
+                                # assignment (if any).  Best-effort; never
+                                # blocks the happy path.
+                                if _f_task_id:
+                                    try:
+                                        from universal_agent import (
+                                            task_hub as _f_th,
+                                        )
+                                        from universal_agent.gateway_server import (
+                                            _task_hub_open_conn as _f_open_conn,
+                                        )
+                                        from universal_agent.services.worker_exit_classifier import (
+                                            find_active_assignment_for_task as _f_find_aid,
+                                        )
+                                        _f_conn = _f_open_conn()
+                                        try:
+                                            _f_assignment_id = _f_find_aid(
+                                                _f_conn, task_id=_f_task_id,
+                                            )
+                                            if _f_assignment_id and proc.pid:
+                                                _f_th.record_worker_pid(
+                                                    _f_conn,
+                                                    assignment_id=_f_assignment_id,
+                                                    worker_pid=int(proc.pid),
+                                                )
+                                                _f_conn.commit()
+                                        finally:
+                                            _f_conn.close()
+                                    except Exception as _f_pid_exc:
+                                        logger.debug(
+                                            "Phase F.1 record_worker_pid skipped for cron job %s: %s",
+                                            job.job_id, _f_pid_exc,
+                                        )
+
                                 try:
                                     stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout_seconds)
                                 except asyncio.TimeoutError:
+                                    _f_was_timeout_killed = True
                                     with contextlib.suppress(ProcessLookupError):
                                         proc.kill()
                                     try:
@@ -1216,10 +1264,10 @@ class CronService:
                                     output_text = stdout.decode(errors="replace") + "\n" + stderr.decode(errors="replace")
                                     record.output_preview = output_text[:400]
                                     raise
-                                
+
                                 exit_code = proc.returncode
                                 output_text = stdout.decode(errors="replace") + "\n" + stderr.decode(errors="replace")
-                                
+
                                 if exit_code == 0:
                                     record.status = "success"
                                     record.output_preview = output_text[:400]
@@ -1227,6 +1275,86 @@ class CronService:
                                     record.status = "error"
                                     record.error = f"Script exited with {exit_code}"
                                     record.output_preview = output_text[:400]
+
+                                # Phase F.1 / F.3 — classify exit and, if a
+                                # protocol violation (rc=0 but linked task is
+                                # still in_progress), route the task into
+                                # needs_review for Phase B.1 unstick verbs to
+                                # act on.
+                                if _f_task_id:
+                                    try:
+                                        from universal_agent import (
+                                            task_hub as _f_th2,
+                                        )
+                                        from universal_agent.gateway_server import (
+                                            _task_hub_open_conn as _f_open_conn2,
+                                        )
+                                        from universal_agent.services.worker_exit_classifier import (
+                                            classify_worker_exit as _f_classify,
+                                            park_task_for_protocol_violation as _f_park,
+                                            task_was_closed_normally as _f_closed,
+                                        )
+                                        _f_conn2 = _f_open_conn2()
+                                        try:
+                                            _f_was_signaled = bool(
+                                                exit_code is not None
+                                                and exit_code < 0
+                                                and not _f_was_timeout_killed
+                                            )
+                                            _f_closed_normally = _f_closed(
+                                                _f_conn2, task_id=_f_task_id,
+                                            )
+                                            _f_classification = _f_classify(
+                                                return_code=exit_code,
+                                                was_signaled=_f_was_signaled,
+                                                was_timeout_killed=_f_was_timeout_killed,
+                                                task_closed_normally=_f_closed_normally,
+                                            )
+                                            logger.info(
+                                                "Phase F.1 cron job %s exit classified as %s "
+                                                "(task=%s, assignment=%s, rc=%s)",
+                                                job.job_id, _f_classification.outcome,
+                                                _f_task_id, _f_assignment_id or "<none>",
+                                                exit_code,
+                                            )
+                                            if _f_assignment_id:
+                                                try:
+                                                    _f_th2._close_run(
+                                                        _f_conn2,
+                                                        assignment_id=_f_assignment_id,
+                                                        outcome=(
+                                                            "completed"
+                                                            if exit_code == 0
+                                                            else "failed"
+                                                        ),
+                                                        summary=f"cron !script {script_path}",
+                                                        error=(record.error or "")[:500],
+                                                        metadata={
+                                                            "worker_exit": _f_classification.to_dict(),
+                                                            "site": "cron",
+                                                        },
+                                                    )
+                                                    _f_conn2.commit()
+                                                except Exception as _f_close_exc:
+                                                    logger.debug(
+                                                        "Phase F.1 _close_run skipped for cron job %s: %s",
+                                                        job.job_id, _f_close_exc,
+                                                    )
+                                            if _f_classification.is_protocol_violation:
+                                                _f_park(
+                                                    _f_conn2,
+                                                    task_id=_f_task_id,
+                                                    site="cron",
+                                                    summary=f"cron !script {script_path} job={job.job_id}",
+                                                    agent_id="cron_scheduler",
+                                                )
+                                        finally:
+                                            _f_conn2.close()
+                                    except Exception as _f_exc:
+                                        logger.debug(
+                                            "Phase F.1/F.3 wiring skipped for cron job %s: %s",
+                                            job.job_id, _f_exc,
+                                        )
 
                                 # Manually construct a result object to satisfy _persist_run_output
                                 class _MockResult:

--- a/src/universal_agent/services/cody_implementation.py
+++ b/src/universal_agent/services/cody_implementation.py
@@ -282,7 +282,18 @@ def _scrubbed_env() -> dict[str, str]:
 
 @dataclass(frozen=True)
 class RunResult:
-    """Result of running a command inside a demo workspace."""
+    """Result of running a command inside a demo workspace.
+
+    Hermes Phase F.1 site-wiring — ``exit_classification`` carries the
+    :class:`WorkerExit` classification from
+    :func:`universal_agent.services.worker_exit_classifier.classify_worker_exit`.
+    The caller (Cody\u2019s demo task dispatcher) inspects it to decide
+    whether the run succeeded, timed out, signaled, or was a protocol
+    violation.  F.3 (parking into needs_review) is the caller\u2019s
+    responsibility for the demo path because the demo workspace does
+    NOT have a direct ``task_hub_assignments`` linkage at the
+    ``subprocess.run`` level.
+    """
 
     return_code: int
     stdout: str
@@ -291,13 +302,14 @@ class RunResult:
     command: tuple[str, ...]
     cwd: str
     env_scrubbed: bool
+    exit_classification: Any = None  # WorkerExit | None — quoted to keep import optional
 
     @property
     def ok(self) -> bool:
         return self.return_code == 0
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "return_code": self.return_code,
             "stdout_excerpt": self.stdout[:2000],
             "stderr_excerpt": self.stderr[:2000],
@@ -307,6 +319,14 @@ class RunResult:
             "env_scrubbed": self.env_scrubbed,
             "ok": self.ok,
         }
+        if self.exit_classification is not None:
+            try:
+                payload["exit_classification"] = self.exit_classification.to_dict()
+            except AttributeError:
+                # Best-effort: if a plain dict was stashed instead of a
+                # WorkerExit, propagate as-is.
+                payload["exit_classification"] = self.exit_classification
+        return payload
 
 
 def run_in_workspace(
@@ -326,6 +346,16 @@ def run_in_workspace(
     `scrub_env=True` removes any ANTHROPIC_* env var that would override
     the project-local settings. Default ON because the production VPS
     shell typically has them set.
+
+    Hermes Phase F.1 site-wiring — the returned ``RunResult`` carries an
+    ``exit_classification`` (a :class:`WorkerExit`) so the caller can
+    distinguish clean exit / timeout / signaled / nonzero / protocol
+    violation.  PID recording is NOT supported here because
+    ``subprocess.run`` does not expose the PID; switching to ``Popen``
+    would be the upgrade path if PID observability becomes required for
+    the demo workspace.  F.3 (parking into needs_review) is the
+    caller\u2019s responsibility because the demo workspace has no direct
+    ``task_hub_assignments`` linkage at this level.
     """
     cwd = workspace_dir.resolve()
     if not cwd.exists():
@@ -333,6 +363,7 @@ def run_in_workspace(
     env = _scrubbed_env() if scrub_env else dict(os.environ)
 
     start = datetime.now(timezone.utc)
+    was_timeout_killed = False
     try:
         completed = sp.run(
             list(command),
@@ -350,9 +381,35 @@ def run_in_workspace(
         rc, stdout, stderr = 127, "", f"binary_not_found: {exc}"
     except sp.TimeoutExpired:
         rc, stdout, stderr = 124, "", f"timeout after {timeout}s"
+        was_timeout_killed = True
     except Exception as exc:
         rc, stdout, stderr = 1, "", f"unexpected_error: {exc}"
     end = datetime.now(timezone.utc)
+
+    # Phase F.1 — classify the exit so the caller can route protocol
+    # violations / failures appropriately.  Best-effort; classifier is
+    # pure so failures should never happen, but defensive try just in
+    # case.
+    classification = None
+    try:
+        from universal_agent.services.worker_exit_classifier import (
+            classify_worker_exit as _f_classify,
+        )
+        # Negative rc on POSIX = signaled. Skip when we already classified
+        # as timeout-killed (timeout takes priority).
+        was_signaled = bool(
+            isinstance(rc, int) and rc < 0 and not was_timeout_killed
+        )
+        classification = _f_classify(
+            return_code=rc,
+            was_signaled=was_signaled,
+            was_timeout_killed=was_timeout_killed,
+            # No linked Task Hub assignment at this level — caller owns
+            # disposition; treat rc=0 as the success signal.
+            task_closed_normally=(rc == 0 and not was_timeout_killed),
+        )
+    except Exception as exc:
+        logger.debug("Phase F.1 demo classification skipped: %s", exc)
 
     return RunResult(
         return_code=rc,
@@ -362,6 +419,7 @@ def run_in_workspace(
         command=tuple(command),
         cwd=str(cwd),
         env_scrubbed=scrub_env,
+        exit_classification=classification,
     )
 
 

--- a/src/universal_agent/services/worker_exit_classifier.py
+++ b/src/universal_agent/services/worker_exit_classifier.py
@@ -32,7 +32,11 @@ Outcomes:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+import logging
+import sqlite3
+from typing import Any, Literal, Optional
+
+logger = logging.getLogger(__name__)
 
 WorkerOutcome = Literal[
     "clean_exit_zero",
@@ -62,6 +66,13 @@ class WorkerExit:
     outcome: WorkerOutcome
     is_protocol_violation: bool
     is_failure: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome,
+            "is_protocol_violation": self.is_protocol_violation,
+            "is_failure": self.is_failure,
+        }
 
 
 def classify_worker_exit(
@@ -136,9 +147,193 @@ PROTOCOL_VIOLATION_REASONS: dict[str, str] = {
 }
 
 
+# F.3 sentinel — sites pass the string key into ``park_task_for_protocol_violation``
+# so the helper looks up the canonical reason. Keeps the reason vocabulary
+# centralized in this module.
+_VALID_SITES = frozenset(PROTOCOL_VIOLATION_REASONS.keys())
+
+
+def park_task_for_protocol_violation(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    site: str,
+    summary: str = "",
+    agent_id: str = "worker_exit_classifier",
+) -> bool:
+    """Hermes Phase F.3 — route a protocol-violating task into ``needs_review``.
+
+    Called from each owned-subprocess spawn site (cron / VP CLI) when
+    ``classify_worker_exit`` returns ``is_protocol_violation=True`` — the
+    subprocess exited rc=0 but never closed its task via
+    ``finalize_assignments`` or ``perform_task_action(action="complete")``.
+    Phase B.1's ``rehydrate`` / ``re_evaluate`` verbs then surface the
+    parked task for Simone to act on.
+
+    Args:
+        conn: A live Task Hub connection. The caller owns the
+            transaction — this function commits before returning.
+        task_id: The Task Hub item to route. If empty or unknown the
+            call is a no-op and returns ``False``.
+        site: One of ``"cron"`` | ``"vp_cli"`` | ``"demo"``. Determines
+            which canonical reason string from ``PROTOCOL_VIOLATION_REASONS``
+            is recorded on the task.
+        summary: Optional short text appended to the reason. Surfaces in
+            the task's ``last_disposition_reason`` metadata field so the
+            operator (or Simone, post-Phase D) can see *what* the
+            worker was attempting when it bailed silently.
+        agent_id: The agent attribution string written to the
+            evaluation/action audit trail. Defaults to
+            ``"worker_exit_classifier"`` to make protocol-violation parks
+            grep-able in the audit log.
+
+    Returns:
+        ``True`` if the task was parked, ``False`` if the call was a
+        no-op (missing task_id, unknown task, unknown site, or any
+        ``perform_task_action`` failure). Best-effort by design — F.3
+        is observability + recovery routing; it must never raise into the
+        spawn site's happy path.
+    """
+    tid = str(task_id or "").strip()
+    if not tid:
+        return False
+    site_norm = str(site or "").strip().lower()
+    if site_norm not in _VALID_SITES:
+        logger.warning(
+            "park_task_for_protocol_violation called with unknown site=%r; "
+            "valid: %s",
+            site, sorted(_VALID_SITES),
+        )
+        return False
+
+    reason = PROTOCOL_VIOLATION_REASONS[site_norm]
+    if summary:
+        # Keep the canonical reason key as the leading token so downstream
+        # filters / log scrapers stay simple.
+        combined_reason = f"{reason}: {summary.strip()[:300]}"
+    else:
+        combined_reason = reason
+
+    try:
+        # Lazy import to avoid a hard module-level dependency cycle with
+        # task_hub (task_hub may import from services in the future).
+        from universal_agent import task_hub  # noqa: WPS433 (local import is intentional)
+
+        task_hub.perform_task_action(
+            conn,
+            task_id=tid,
+            action="review",
+            reason=combined_reason,
+            agent_id=agent_id,
+        )
+        try:
+            conn.commit()
+        except Exception:
+            # Some callers wrap us in a larger transaction; don't blow up.
+            pass
+        logger.info(
+            "Phase F.3 parked task %s in needs_review (site=%s, reason=%s)",
+            tid, site_norm, reason,
+        )
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Phase F.3 park failed for task %s (site=%s): %s",
+            tid, site_norm, exc,
+        )
+        return False
+
+
+def find_active_assignment_for_task(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+) -> Optional[str]:
+    """Look up the most recent active assignment_id for a task.
+
+    Active = ``state IN ('seized', 'running')``. Used by spawn sites to
+    correlate their just-spawned subprocess back to a Task Hub assignment
+    row (so ``record_worker_pid`` knows which row to stamp).
+
+    Returns ``None`` if the task has no active assignment (which is the
+    common case for cron-only jobs that don't go through Task Hub).
+    Never raises — wraps DB errors in a warning log and returns ``None``.
+    """
+    tid = str(task_id or "").strip()
+    if not tid:
+        return None
+    try:
+        row = conn.execute(
+            """
+            SELECT assignment_id
+            FROM task_hub_assignments
+            WHERE task_id = ? AND state IN ('seized', 'running')
+            ORDER BY started_at DESC
+            LIMIT 1
+            """,
+            (tid,),
+        ).fetchone()
+        if not row:
+            return None
+        # Support both Row (mapping access) and tuple cursor row_factory.
+        try:
+            return str(row["assignment_id"])
+        except (TypeError, IndexError, KeyError):
+            return str(row[0])
+    except Exception as exc:
+        logger.debug(
+            "find_active_assignment_for_task(%s) failed: %s", tid, exc,
+        )
+        return None
+
+
+def task_was_closed_normally(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+) -> bool:
+    """Return True iff the task is in a terminal-success-ish state.
+
+    Used by spawn sites to feed ``classify_worker_exit``'s
+    ``task_closed_normally`` flag. ``completed`` (the normal success
+    path) is the canonical signal. ``cancelled`` is also acceptable
+    because the operator/Simone explicitly closed the task — it's not a
+    protocol violation if the worker happened to exit rc=0 after the
+    task was cancelled out from under it.
+
+    States that explicitly mean "still in flight" or "needs human
+    follow-up" return ``False`` so F.3 routes them.
+
+    Returns ``False`` on unknown task / DB error (conservative —
+    prevents spurious protocol-violation parks against tasks we can't
+    even read).
+    """
+    tid = str(task_id or "").strip()
+    if not tid:
+        return False
+    try:
+        row = conn.execute(
+            "SELECT status FROM task_hub_items WHERE task_id = ? LIMIT 1",
+            (tid,),
+        ).fetchone()
+        if not row:
+            return False
+        try:
+            status = str(row["status"] or "").strip().lower()
+        except (TypeError, IndexError, KeyError):
+            status = str(row[0] or "").strip().lower()
+        return status in {"completed", "cancelled"}
+    except Exception as exc:
+        logger.debug("task_was_closed_normally(%s) failed: %s", tid, exc)
+        return False
+
+
 __all__ = [
     "WorkerOutcome",
     "WorkerExit",
     "classify_worker_exit",
     "PROTOCOL_VIOLATION_REASONS",
+    "park_task_for_protocol_violation",
+    "find_active_assignment_for_task",
+    "task_was_closed_normally",
 ]

--- a/src/universal_agent/vp/clients/claude_cli_client.py
+++ b/src/universal_agent/vp/clients/claude_cli_client.py
@@ -151,6 +151,7 @@ class ClaudeCodeCLIClient(VpClient):
                         attempt=attempt,
                     )
 
+                _cli_task_id = str(payload.get("task_id") or "").strip()
                 outcome = await _execute_cli_session(
                     prompt=current_prompt,
                     workspace_dir=workspace_dir,
@@ -158,6 +159,18 @@ class ClaudeCodeCLIClient(VpClient):
                     enable_agent_teams=enable_agent_teams,
                     mission_id=mission_id,
                     cody_mode=cody_mode,
+                    task_id=_cli_task_id,
+                )
+
+                # Hermes Phase F.1 / F.3 — classify the CLI exit and, if
+                # this was a protocol violation (rc=0 but linked task
+                # still in_progress), route the task into needs_review.
+                # Also persists the classification onto the run row via
+                # _close_run.  Best-effort: never blocks dispatch.
+                _classify_and_route_cli_exit(
+                    outcome=outcome,
+                    task_id=_cli_task_id,
+                    mission_id=mission_id,
                 )
 
                 if outcome.status == "completed":
@@ -200,8 +213,16 @@ async def _execute_cli_session(
     enable_agent_teams: bool,
     mission_id: str,
     cody_mode: str = "zai",
+    task_id: str = "",
 ) -> MissionOutcome:
-    """Spawn a claude CLI subprocess and monitor its output."""
+    """Spawn a claude CLI subprocess and monitor its output.
+
+    Hermes Phase F site-wiring — if ``task_id`` is provided, the
+    spawned subprocess's PID is recorded on the linked Task Hub
+    assignment (best-effort) and the eventual exit is fed into
+    ``classify_worker_exit`` upstream in :func:`run_mission`. Empty
+    ``task_id`` skips F.1 bookkeeping silently.
+    """
 
     env = _build_cli_env(enable_agent_teams, workspace_dir, cody_mode=cody_mode)
 
@@ -236,6 +257,38 @@ async def _execute_cli_session(
             message=f"Failed to launch claude CLI: {exc}",
         )
 
+    # Hermes Phase F.1 site-wiring — if the mission carries a linked
+    # Task Hub task_id, stamp the spawned subprocess PID onto its
+    # active assignment row.  Best-effort; never blocks the happy
+    # path of the CLI session.
+    cli_assignment_id: Optional[str] = None
+    if task_id and proc.pid:
+        try:
+            from universal_agent import task_hub as _f_th
+            from universal_agent.gateway_server import (
+                _task_hub_open_conn as _f_open_conn,
+            )
+            from universal_agent.services.worker_exit_classifier import (
+                find_active_assignment_for_task as _f_find_aid,
+            )
+            _f_conn = _f_open_conn()
+            try:
+                cli_assignment_id = _f_find_aid(_f_conn, task_id=task_id)
+                if cli_assignment_id:
+                    _f_th.record_worker_pid(
+                        _f_conn,
+                        assignment_id=cli_assignment_id,
+                        worker_pid=int(proc.pid),
+                    )
+                    _f_conn.commit()
+            finally:
+                _f_conn.close()
+        except Exception as _f_exc:
+            logger.debug(
+                "Phase F.1 record_worker_pid skipped for CLI mission %s: %s",
+                mission_id, _f_exc,
+            )
+
     # Send the prompt to stdin
     try:
         proc.stdin.write(prompt.encode("utf-8"))
@@ -258,7 +311,28 @@ async def _execute_cli_session(
         mission_id=mission_id,
     )
 
-    return result
+    # Phase F.1 — enrich the outcome payload with PID + assignment +
+    # timeout-kill signal so run_mission can classify the exit.
+    enriched_payload = dict(result.payload or {})
+    if proc.pid:
+        enriched_payload.setdefault("worker_pid", int(proc.pid))
+    if cli_assignment_id:
+        enriched_payload.setdefault("assignment_id", cli_assignment_id)
+    # Heuristic: a "timed out" message indicates _monitor_cli_output\u2019s
+    # timeout path fired (it calls ``_kill_process`` and returns
+    # status="failed" with a "timed out" message).
+    if (
+        result.status == "failed"
+        and result.message
+        and "timed out" in result.message.lower()
+    ):
+        enriched_payload.setdefault("was_timeout_killed", True)
+    return MissionOutcome(
+        status=result.status,
+        result_ref=result.result_ref,
+        message=result.message,
+        payload=enriched_payload,
+    )
 
 
 async def _monitor_cli_output(
@@ -413,6 +487,158 @@ async def _monitor_cli_output(
             "stream_lines": len(stream_lines),
         },
     )
+
+
+def _classify_and_route_cli_exit(
+    *,
+    outcome: MissionOutcome,
+    task_id: str,
+    mission_id: str,
+) -> None:
+    """Hermes Phase F.1 / F.3 — classify a CLI mission exit and route.
+
+    Called from :meth:`ClaudeCodeCLIClient.run_mission` immediately
+    after ``_execute_cli_session`` returns.  Pulls ``exit_code`` +
+    ``was_timeout_killed`` + ``assignment_id`` out of
+    ``outcome.payload`` (populated in ``_execute_cli_session``\u2019s
+    enriched return path) and feeds them into
+    :func:`classify_worker_exit`.
+
+    Side effects (all best-effort, never raise):
+      * Logs the classified outcome with mission_id + task_id +
+        assignment_id for grep-ability.
+      * If a linked assignment exists, writes the classification onto
+        the open run row via ``task_hub._close_run``.
+      * If the classification is a protocol violation
+        (``clean_exit_zero_no_disposition`` — rc=0 but task is still
+        in_progress), parks the task in ``needs_review`` with the
+        canonical ``protocol_violation_vp_cli_clean_exit_no_disposition``
+        reason so Phase B.1\u2019s ``rehydrate`` / ``re_evaluate`` verbs
+        can act on it.
+
+    No-ops silently if ``task_id`` is empty (the common case — most VP
+    missions don\u2019t carry a direct Task Hub linkage).
+    """
+    tid = str(task_id or "").strip()
+    if not tid:
+        # No linked task — just log the classification at debug for
+        # observability and return.  We still classify so the log
+        # carries the outcome bucket.
+        try:
+            from universal_agent.services.worker_exit_classifier import (
+                classify_worker_exit as _f_classify,
+            )
+            _exit_code = None
+            _was_timeout_killed = False
+            if outcome.payload:
+                _exit_code = outcome.payload.get("exit_code")
+                _was_timeout_killed = bool(outcome.payload.get("was_timeout_killed"))
+            _was_signaled = bool(
+                isinstance(_exit_code, int)
+                and _exit_code < 0
+                and not _was_timeout_killed
+            )
+            _classification = _f_classify(
+                return_code=_exit_code if isinstance(_exit_code, int) else None,
+                was_signaled=_was_signaled,
+                was_timeout_killed=_was_timeout_killed,
+                # No linked task — treat outcome.status as ground truth.
+                task_closed_normally=outcome.status == "completed",
+            )
+            logger.debug(
+                "Phase F.1 CLI mission %s exit classified as %s (no linked task)",
+                mission_id, _classification.outcome,
+            )
+        except Exception as _f_exc:
+            logger.debug(
+                "Phase F.1 classification skipped for mission %s: %s",
+                mission_id, _f_exc,
+            )
+        return
+
+    try:
+        from universal_agent import task_hub as _f_th
+        from universal_agent.gateway_server import (
+            _task_hub_open_conn as _f_open_conn,
+        )
+        from universal_agent.services.worker_exit_classifier import (
+            classify_worker_exit as _f_classify,
+            park_task_for_protocol_violation as _f_park,
+            task_was_closed_normally as _f_closed,
+        )
+
+        _exit_code = None
+        _was_timeout_killed = False
+        _assignment_id = ""
+        if outcome.payload:
+            _exit_code = outcome.payload.get("exit_code")
+            _was_timeout_killed = bool(outcome.payload.get("was_timeout_killed"))
+            _assignment_id = str(outcome.payload.get("assignment_id") or "")
+
+        _was_signaled = bool(
+            isinstance(_exit_code, int)
+            and _exit_code < 0
+            and not _was_timeout_killed
+        )
+
+        _conn = _f_open_conn()
+        try:
+            _closed_normally = _f_closed(_conn, task_id=tid)
+            _classification = _f_classify(
+                return_code=_exit_code if isinstance(_exit_code, int) else None,
+                was_signaled=_was_signaled,
+                was_timeout_killed=_was_timeout_killed,
+                task_closed_normally=_closed_normally,
+            )
+            logger.info(
+                "Phase F.1 CLI mission %s exit classified as %s "
+                "(task=%s, assignment=%s, rc=%s)",
+                mission_id, _classification.outcome, tid,
+                _assignment_id or "<none>", _exit_code,
+            )
+            if _assignment_id:
+                try:
+                    _f_th._close_run(
+                        _conn,
+                        assignment_id=_assignment_id,
+                        outcome=(
+                            "completed"
+                            if outcome.status == "completed"
+                            else "failed"
+                        ),
+                        summary=(outcome.message or "")[:200],
+                        error=(
+                            ""
+                            if outcome.status == "completed"
+                            else (outcome.message or "")[:500]
+                        ),
+                        metadata={
+                            "worker_exit": _classification.to_dict(),
+                            "site": "vp_cli",
+                            "mission_id": mission_id,
+                        },
+                    )
+                    _conn.commit()
+                except Exception as _close_exc:
+                    logger.debug(
+                        "Phase F.1 _close_run skipped for CLI mission %s: %s",
+                        mission_id, _close_exc,
+                    )
+            if _classification.is_protocol_violation:
+                _f_park(
+                    _conn,
+                    task_id=tid,
+                    site="vp_cli",
+                    summary=f"vp cli mission_id={mission_id}",
+                    agent_id="vp_cli_client",
+                )
+        finally:
+            _conn.close()
+    except Exception as exc:
+        logger.debug(
+            "Phase F.1/F.3 wiring skipped for CLI mission %s: %s",
+            mission_id, exc,
+        )
 
 
 def _record_mission_token_usage(

--- a/tests/unit/test_hermes_phase_f_site_wiring.py
+++ b/tests/unit/test_hermes_phase_f_site_wiring.py
@@ -1,0 +1,589 @@
+"""Hermes Phase F.3 site-wiring unit tests.
+
+Covers the three owned-subprocess spawn sites:
+
+* Cron ``!script`` jobs (``cron_service.py``)
+* VP CLI client (``vp/clients/claude_cli_client.py``)
+* Demo workspace (``services/cody_implementation.run_in_workspace``)
+
+…plus the F.3 helper ``park_task_for_protocol_violation``.
+
+Tests are scoped to the post-spawn wiring: they mock at the
+``asyncio.create_subprocess_exec`` / ``subprocess.run`` boundary and
+assert that:
+
+  1. ``record_worker_pid`` is invoked when a linked assignment exists.
+  2. ``classify_worker_exit`` returns the right outcome bucket given
+     the spawn-site's exit signals.
+  3. F.3 routes protocol violations into ``needs_review`` with the
+     correct ``protocol_violation_<site>_*`` reason.
+  4. When there's no linked task / assignment, the wiring is a silent
+     no-op (it must never break dispatch).
+
+The foundation tests live in ``test_hermes_phase_f_foundation.py``
+(classifier purity, schema columns, ``record_worker_pid`` and
+``resolve_max_runtime_seconds`` helpers).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+import sqlite3
+import subprocess as sp
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services import cody_implementation
+from universal_agent.services.worker_exit_classifier import (
+    PROTOCOL_VIOLATION_REASONS,
+    WorkerExit,
+    classify_worker_exit,
+    find_active_assignment_for_task,
+    park_task_for_protocol_violation,
+    task_was_closed_normally,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    task_hub.ensure_schema(c)
+    yield c
+    c.close()
+
+
+def _seed_task_and_assignment(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str = "task:f3",
+    assignment_id: str = "asg-f3",
+    status: str = "in_progress",
+    assignment_state: str = "running",
+) -> None:
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": task_id,
+            "source_kind": "internal",
+            "title": "fixture task",
+            "status": status,
+        },
+    )
+    conn.execute(
+        """
+        INSERT INTO task_hub_assignments
+            (assignment_id, task_id, agent_id, state, started_at)
+        VALUES (?, ?, ?, ?, datetime('now'))
+        """,
+        (assignment_id, task_id, "agent:test", assignment_state),
+    )
+    conn.commit()
+
+
+# ── F.3 helper — park_task_for_protocol_violation ──────────────────────────
+
+
+def test_park_with_unknown_site_returns_false_and_logs(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_task_and_assignment(conn)
+    parked = park_task_for_protocol_violation(
+        conn,
+        task_id="task:f3",
+        site="not_a_real_site",
+    )
+    assert parked is False
+    # Task should still be in_progress (unchanged).
+    row = conn.execute(
+        "SELECT status FROM task_hub_items WHERE task_id = ?",
+        ("task:f3",),
+    ).fetchone()
+    assert row is not None
+    assert row["status"] == "in_progress"
+
+
+def test_park_with_empty_task_id_returns_false() -> None:
+    # Standalone conn — doesn't matter what's in it since the function
+    # short-circuits on the empty task_id.
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    task_hub.ensure_schema(c)
+    try:
+        assert park_task_for_protocol_violation(c, task_id="", site="cron") is False
+        assert park_task_for_protocol_violation(c, task_id="   ", site="cron") is False
+    finally:
+        c.close()
+
+
+def test_park_routes_task_into_needs_review_with_canonical_reason(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_task_and_assignment(conn)
+    parked = park_task_for_protocol_violation(
+        conn,
+        task_id="task:f3",
+        site="cron",
+        summary="cron !script foo.py job=demo-job",
+    )
+    assert parked is True
+    row = conn.execute(
+        "SELECT status FROM task_hub_items WHERE task_id = ?",
+        ("task:f3",),
+    ).fetchone()
+    assert row is not None
+    # `review` action sets status to needs_review.
+    assert row["status"] == task_hub.TASK_STATUS_REVIEW
+
+
+def test_park_records_canonical_reason_per_site(
+    conn: sqlite3.Connection,
+) -> None:
+    """Verify each site key resolves to its canonical reason string.
+
+    The ``review`` action writes the reason into
+    ``task_hub_assignments.result_summary`` on the active assignment(s)
+    via ``_complete_active_assignments_for_task``.  We assert that the
+    canonical site reason string lands there for each site.
+    """
+    _seed_task_and_assignment(conn, task_id="task:cron", assignment_id="asg-c")
+    _seed_task_and_assignment(conn, task_id="task:cli", assignment_id="asg-v")
+    _seed_task_and_assignment(conn, task_id="task:demo", assignment_id="asg-d")
+
+    for site, tid, aid in [
+        ("cron", "task:cron", "asg-c"),
+        ("vp_cli", "task:cli", "asg-v"),
+        ("demo", "task:demo", "asg-d"),
+    ]:
+        parked = park_task_for_protocol_violation(
+            conn, task_id=tid, site=site,
+        )
+        assert parked is True
+        # 1. The task should be in needs_review.
+        item = task_hub.get_item(conn, tid)
+        assert item is not None
+        assert item["status"] == task_hub.TASK_STATUS_REVIEW
+        # 2. The assignment's result_summary should carry the canonical
+        #    site reason string.
+        row = conn.execute(
+            "SELECT result_summary FROM task_hub_assignments "
+            "WHERE assignment_id = ?",
+            (aid,),
+        ).fetchone()
+        assert row is not None
+        assert (row["result_summary"] or "").startswith(
+            PROTOCOL_VIOLATION_REASONS[site]
+        )
+
+
+def test_park_swallows_perform_task_action_failure(
+    conn: sqlite3.Connection,
+) -> None:
+    """If perform_task_action raises, park returns False and doesn't propagate."""
+    _seed_task_and_assignment(conn)
+    with patch(
+        "universal_agent.task_hub.perform_task_action",
+        side_effect=RuntimeError("boom"),
+    ):
+        parked = park_task_for_protocol_violation(
+            conn, task_id="task:f3", site="cron",
+        )
+    assert parked is False
+
+
+# ── F.3 helper — find_active_assignment_for_task ───────────────────────────
+
+
+def test_find_active_assignment_returns_running_assignment(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_task_and_assignment(
+        conn, task_id="task:f3", assignment_id="asg-f3", assignment_state="running",
+    )
+    assert (
+        find_active_assignment_for_task(conn, task_id="task:f3") == "asg-f3"
+    )
+
+
+def test_find_active_assignment_returns_none_for_completed(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_task_and_assignment(
+        conn,
+        task_id="task:done",
+        assignment_id="asg-done",
+        assignment_state="completed",
+    )
+    assert find_active_assignment_for_task(conn, task_id="task:done") is None
+
+
+def test_find_active_assignment_returns_none_for_unknown_task(
+    conn: sqlite3.Connection,
+) -> None:
+    assert find_active_assignment_for_task(conn, task_id="task:nope") is None
+
+
+def test_find_active_assignment_empty_task_id_returns_none(
+    conn: sqlite3.Connection,
+) -> None:
+    assert find_active_assignment_for_task(conn, task_id="") is None
+    assert find_active_assignment_for_task(conn, task_id="   ") is None
+
+
+# ── F.3 helper — task_was_closed_normally ──────────────────────────────────
+
+
+def test_task_closed_normally_true_for_completed(conn: sqlite3.Connection) -> None:
+    _seed_task_and_assignment(conn, status="completed")
+    assert task_was_closed_normally(conn, task_id="task:f3") is True
+
+
+def test_task_closed_normally_false_for_in_progress(
+    conn: sqlite3.Connection,
+) -> None:
+    _seed_task_and_assignment(conn, status="in_progress")
+    assert task_was_closed_normally(conn, task_id="task:f3") is False
+
+
+def test_task_closed_normally_false_for_unknown_task(
+    conn: sqlite3.Connection,
+) -> None:
+    assert task_was_closed_normally(conn, task_id="task:nope") is False
+
+
+# ── Cron `!script` site wiring ──────────────────────────────────────────────
+
+
+def _make_classification_chain(
+    *,
+    return_code: int | None,
+    was_signaled: bool = False,
+    was_timeout_killed: bool = False,
+    task_closed_normally: bool = True,
+) -> WorkerExit:
+    """Helper — exercise the classifier exactly as the wiring does."""
+    return classify_worker_exit(
+        return_code=return_code,
+        was_signaled=was_signaled,
+        was_timeout_killed=was_timeout_killed,
+        task_closed_normally=task_closed_normally,
+    )
+
+
+def test_cron_classification_clean_exit_with_open_task_is_protocol_violation(
+    conn: sqlite3.Connection,
+) -> None:
+    """End-to-end on the F.3 fork: rc=0 + task still in_progress -> review."""
+    _seed_task_and_assignment(
+        conn, task_id="task:cron-open", assignment_id="asg-cron-open",
+    )
+    closed = task_was_closed_normally(conn, task_id="task:cron-open")
+    assert closed is False
+    classification = _make_classification_chain(
+        return_code=0, task_closed_normally=closed,
+    )
+    assert classification.is_protocol_violation is True
+    parked = park_task_for_protocol_violation(
+        conn,
+        task_id="task:cron-open",
+        site="cron",
+        summary="cron !script test job=demo",
+    )
+    assert parked is True
+    row = conn.execute(
+        "SELECT status FROM task_hub_items WHERE task_id = ?",
+        ("task:cron-open",),
+    ).fetchone()
+    assert row["status"] == task_hub.TASK_STATUS_REVIEW
+
+
+def test_cron_classification_nonzero_exit_is_not_a_protocol_violation(
+    conn: sqlite3.Connection,
+) -> None:
+    """rc != 0 is a real failure, not a protocol violation."""
+    _seed_task_and_assignment(conn, task_id="task:cron-err")
+    classification = _make_classification_chain(
+        return_code=137,
+        task_closed_normally=False,
+    )
+    assert classification.outcome == "nonzero_exit"
+    assert classification.is_protocol_violation is False
+    # F.3 wiring should NOT park.  Verify by NOT calling park and
+    # confirming the task remains in_progress.
+    row = conn.execute(
+        "SELECT status FROM task_hub_items WHERE task_id = ?",
+        ("task:cron-err",),
+    ).fetchone()
+    assert row["status"] == "in_progress"
+
+
+def test_cron_classification_timeout_killed_takes_priority(
+    conn: sqlite3.Connection,
+) -> None:
+    classification = _make_classification_chain(
+        return_code=-9,
+        was_signaled=True,
+        was_timeout_killed=True,
+        task_closed_normally=False,
+    )
+    assert classification.outcome == "timeout_killed"
+    assert classification.is_failure is True
+    assert classification.is_protocol_violation is False
+
+
+# ── VP CLI site wiring ──────────────────────────────────────────────────────
+
+
+def test_cli_classification_clean_exit_payload_routes_to_protocol_violation(
+    conn: sqlite3.Connection,
+) -> None:
+    """Simulate VP CLI returning a clean exit_code but task still open."""
+    _seed_task_and_assignment(conn, task_id="task:cli-open")
+    # The classifier args mirror what _classify_and_route_cli_exit feeds:
+    exit_code = 0
+    was_timeout_killed = False
+    was_signaled = bool(exit_code < 0 and not was_timeout_killed)
+    closed = task_was_closed_normally(conn, task_id="task:cli-open")
+    classification = classify_worker_exit(
+        return_code=exit_code,
+        was_signaled=was_signaled,
+        was_timeout_killed=was_timeout_killed,
+        task_closed_normally=closed,
+    )
+    assert classification.is_protocol_violation is True
+    parked = park_task_for_protocol_violation(
+        conn,
+        task_id="task:cli-open",
+        site="vp_cli",
+        summary="vp cli mission_id=mission-abc",
+    )
+    assert parked is True
+    row = conn.execute(
+        "SELECT status FROM task_hub_items WHERE task_id = ?",
+        ("task:cli-open",),
+    ).fetchone()
+    assert row["status"] == task_hub.TASK_STATUS_REVIEW
+
+
+def test_cli_classification_timeout_via_payload_marker(
+    conn: sqlite3.Connection,
+) -> None:
+    """_execute_cli_session populates payload.was_timeout_killed when the
+    timeout path fires; classifier should yield ``timeout_killed``."""
+    payload = {
+        "exit_code": -9,  # signaled via _kill_process
+        "was_timeout_killed": True,
+    }
+    exit_code = payload["exit_code"]
+    was_timeout_killed = bool(payload.get("was_timeout_killed"))
+    was_signaled = bool(
+        isinstance(exit_code, int) and exit_code < 0 and not was_timeout_killed
+    )
+    classification = classify_worker_exit(
+        return_code=exit_code if isinstance(exit_code, int) else None,
+        was_signaled=was_signaled,
+        was_timeout_killed=was_timeout_killed,
+        task_closed_normally=False,
+    )
+    assert classification.outcome == "timeout_killed"
+    assert classification.is_protocol_violation is False
+
+
+def test_classify_and_route_cli_exit_skips_when_no_task_id() -> None:
+    """No linked task_id => no DB calls, no exception."""
+    from universal_agent.vp.clients.claude_cli_client import (
+        _classify_and_route_cli_exit,
+    )
+    from universal_agent.vp.clients.base import MissionOutcome
+
+    outcome = MissionOutcome(
+        status="completed",
+        payload={"exit_code": 0, "tool_calls": 1, "cost": {}},
+    )
+    # Should not raise — the function is best-effort and short-circuits
+    # on empty task_id.
+    _classify_and_route_cli_exit(
+        outcome=outcome,
+        task_id="",
+        mission_id="m-empty",
+    )
+
+
+def test_classify_and_route_cli_exit_parks_on_protocol_violation(
+    conn: sqlite3.Connection,
+    monkeypatch,
+) -> None:
+    """E2E: feed the helper a clean-exit MissionOutcome + a still-open
+    task, and verify F.3 lands the task in needs_review."""
+    from universal_agent.vp.clients.claude_cli_client import (
+        _classify_and_route_cli_exit,
+    )
+    from universal_agent.vp.clients.base import MissionOutcome
+
+    _seed_task_and_assignment(
+        conn, task_id="task:cli-route", assignment_id="asg-cli-route",
+    )
+
+    # Wrap the shared in-memory conn so the helper\u2019s ``finally:
+    # conn.close()`` doesn\u2019t evict our fixture mid-test.  We expose the
+    # exact same Row-factory connection but stub ``close()`` to a no-op.
+    class _NonClosing:
+        def __init__(self, inner: sqlite3.Connection) -> None:
+            self._inner = inner
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._inner, name)
+
+        def close(self) -> None:  # no-op: fixture owns lifecycle
+            pass
+
+    proxy = _NonClosing(conn)
+
+    monkeypatch.setattr(
+        "universal_agent.gateway_server._task_hub_open_conn",
+        lambda: proxy,
+    )
+
+    outcome = MissionOutcome(
+        status="completed",
+        result_ref="workspace://foo",
+        payload={
+            "exit_code": 0,
+            "tool_calls": 3,
+            "assignment_id": "asg-cli-route",
+        },
+    )
+    _classify_and_route_cli_exit(
+        outcome=outcome,
+        task_id="task:cli-route",
+        mission_id="mission-route",
+    )
+
+    row = conn.execute(
+        "SELECT status FROM task_hub_items WHERE task_id = ?",
+        ("task:cli-route",),
+    ).fetchone()
+    assert row["status"] == task_hub.TASK_STATUS_REVIEW
+
+
+# ── Demo workspace site wiring ──────────────────────────────────────────────
+
+
+def test_demo_run_in_workspace_stamps_classification_clean_exit(
+    tmp_path: Path,
+) -> None:
+    """run_in_workspace should stamp a clean_exit_zero classification."""
+    workspace = tmp_path / "demo"
+    workspace.mkdir()
+
+    fake_completed = MagicMock()
+    fake_completed.returncode = 0
+    fake_completed.stdout = "ok"
+    fake_completed.stderr = ""
+
+    with patch.object(cody_implementation.sp, "run", return_value=fake_completed):
+        result = cody_implementation.run_in_workspace(
+            workspace,
+            ["echo", "hi"],
+            timeout=10,
+        )
+    assert result.return_code == 0
+    assert result.exit_classification is not None
+    assert result.exit_classification.outcome == "clean_exit_zero"
+    # Round-trip via to_dict.
+    d = result.to_dict()
+    assert d["exit_classification"]["outcome"] == "clean_exit_zero"
+
+
+def test_demo_run_in_workspace_stamps_classification_timeout(
+    tmp_path: Path,
+) -> None:
+    """TimeoutExpired path should yield ``timeout_killed`` classification."""
+    workspace = tmp_path / "demo-tmo"
+    workspace.mkdir()
+
+    def _raise_timeout(*a, **kw):
+        raise sp.TimeoutExpired(cmd="claude", timeout=10)
+
+    with patch.object(cody_implementation.sp, "run", side_effect=_raise_timeout):
+        result = cody_implementation.run_in_workspace(
+            workspace,
+            ["claude"],
+            timeout=10,
+        )
+    assert result.return_code == 124
+    assert result.exit_classification is not None
+    assert result.exit_classification.outcome == "timeout_killed"
+
+
+def test_demo_run_in_workspace_stamps_classification_nonzero(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "demo-err"
+    workspace.mkdir()
+
+    fake = MagicMock()
+    fake.returncode = 2
+    fake.stdout = ""
+    fake.stderr = "boom"
+
+    with patch.object(cody_implementation.sp, "run", return_value=fake):
+        result = cody_implementation.run_in_workspace(
+            workspace,
+            ["something"],
+            timeout=10,
+        )
+    assert result.return_code == 2
+    assert result.exit_classification is not None
+    assert result.exit_classification.outcome == "nonzero_exit"
+    assert result.exit_classification.is_failure is True
+
+
+def test_demo_run_in_workspace_stamps_classification_signaled(
+    tmp_path: Path,
+) -> None:
+    """Negative returncode (POSIX signaled) => ``signaled``."""
+    workspace = tmp_path / "demo-sig"
+    workspace.mkdir()
+
+    fake = MagicMock()
+    fake.returncode = -9
+    fake.stdout = ""
+    fake.stderr = ""
+
+    with patch.object(cody_implementation.sp, "run", return_value=fake):
+        result = cody_implementation.run_in_workspace(
+            workspace,
+            ["something"],
+            timeout=10,
+        )
+    assert result.return_code == -9
+    assert result.exit_classification is not None
+    assert result.exit_classification.outcome == "signaled"
+
+
+def test_demo_run_in_workspace_to_dict_round_trip(tmp_path: Path) -> None:
+    workspace = tmp_path / "demo-rt"
+    workspace.mkdir()
+    fake = MagicMock()
+    fake.returncode = 0
+    fake.stdout = "ok"
+    fake.stderr = ""
+    with patch.object(cody_implementation.sp, "run", return_value=fake):
+        result = cody_implementation.run_in_workspace(
+            workspace, ["echo", "ok"], timeout=5,
+        )
+    payload = result.to_dict()
+    assert payload["ok"] is True
+    assert payload["return_code"] == 0
+    assert "exit_classification" in payload
+    assert payload["exit_classification"]["outcome"] == "clean_exit_zero"
+    assert payload["exit_classification"]["is_failure"] is False


### PR DESCRIPTION
## Summary

Wires the Phase F foundation (PR #230 — `worker_pid` + `max_runtime_seconds` + `classify_worker_exit` + `PROTOCOL_VIOLATION_REASONS`) into the three owned-subprocess spawn sites and adds F.3 protocol-violation routing.

The foundation shipped in PR #230 was dead code until something called it. This PR makes the three sites call it.

### Sites wired

| Site | Spawn anchor | PID recording | F.3 routing |
|---|---|---|---|
| Cron `!script` jobs | `cron_service.py:1200` (`asyncio.create_subprocess_exec`) | Yes (when linked `task_id` present) | Yes |
| VP CLI client | `vp/clients/claude_cli_client.py:218` (`asyncio.create_subprocess_exec`) | Yes (when `payload.task_id` present) | Yes via new `_classify_and_route_cli_exit` helper |
| Demo workspace | `services/cody_implementation.py:312` (`subprocess.run`) | **Not supported** — `subprocess.run` doesn't expose PID; documented as limitation | **Caller's responsibility** — classification surfaced via new `RunResult.exit_classification` field |

### F.3 routing flow

```
subprocess exits ── classify_worker_exit ── outcome == "clean_exit_zero_no_disposition"?
                                                 │
                                                 ▼ yes
                       park_task_for_protocol_violation(task_id, site=...)
                                                 │
                                                 ▼
                       perform_task_action(action="review", reason=PROTOCOL_VIOLATION_REASONS[site])
                                                 │
                                                 ▼
                       Task status = `needs_review`, reason on assignment.result_summary
                                                 │
                                                 ▼
                       Phase B.1 `rehydrate` / `re_evaluate` verbs surface for Simone
```

### New helpers (`services/worker_exit_classifier.py`)

- `park_task_for_protocol_violation(conn, *, task_id, site, summary, agent_id)` — F.3 routing. Best-effort, never raises.
- `find_active_assignment_for_task(conn, *, task_id)` — resolves `assignment_id` for post-spawn PID stamp.
- `task_was_closed_normally(conn, *, task_id)` — feeds the classifier's `task_closed_normally` flag.
- `WorkerExit.to_dict()` — serializes the classification into `task_hub_runs.metadata_json` via `_close_run`.

### Coverage gaps (honest about what's NOT wired)

- **Cron jobs without a linked `task_id` in metadata** — the vast majority of crons today, only `email_task_scheduler`-sourced crons carry the linkage. They skip F.1/F.3 silently. This is the right behavior: F is observability for the subset that DO have linkage.
- **VP CLI missions without `payload.task_id`** skip F.3 routing but still emit a debug-level classification log for observability.
- **Demo workspace** skips F.3 entirely — Cody's task dispatcher owns the task lifecycle.

## Test plan

- [x] py_compile clean on all changed files
- [x] ruff E9/F clean on all changed files
- [x] New: `tests/unit/test_hermes_phase_f_site_wiring.py` — 21 unit tests covering F.3 helper, cron / VP CLI / demo classification forks, and E2E `_classify_and_route_cli_exit` parking
- [x] Combined Phase F unit surface (foundation + site-wiring) — 47 tests, all green
- [x] Broader sanity: `test_task_hub_runs`, `test_task_hub_unstick_verbs`, `test_dashboard_failure_context_endpoint`, `test_cody_mode`, `test_cody_token_tracking`, `test_task_hub_lifecycle`, `test_task_hub_schema_extensions`, `test_task_hub_max_retries_override` — 168 tests green
- [x] No regressions in `test_claude_cli_client`, `test_cody_implementation`, `test_cron_*` — 66 tests green

## Production verification plan (post-merge)

1. Schema verification (should be no-op — columns landed in PR #230):
   ```
   ssh ua@uaonvps "sqlite3 /opt/universal_agent/AGENT_RUN_WORKSPACES/activity_state.db \
     'PRAGMA table_info(task_hub_assignments)' | grep worker_pid"
   ```
2. Grep production logs after first `!script` cron run for "Phase F.1 cron job".
3. Watch for any `protocol_violation_*` reason strings in `task_hub_assignments.result_summary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)