### PR TITLE
feat(hermes-f-followup): demo workspace Popen + PID observability

### DIFF
--- a/src/universal_agent/services/cody_implementation.py
+++ b/src/universal_agent/services/cody_implementation.py
@@ -39,7 +39,7 @@ from pathlib import Path
 import re
 import shutil
 import subprocess as sp
-from typing import Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -293,6 +293,14 @@ class RunResult:
     responsibility for the demo path because the demo workspace does
     NOT have a direct ``task_hub_assignments`` linkage at the
     ``subprocess.run`` level.
+
+    Hermes Phase F.1 follow-up (Popen migration) — ``worker_pid`` carries
+    the spawned subprocess PID when the call provided an
+    ``assignment_id`` AND PID recording succeeded.  ``None`` otherwise
+    (no linkage requested, recording skipped, or in-process tests where
+    Popen was mocked).  PID is captured at spawn time via Popen.pid,
+    matching the observability shape of the cron and VP CLI sites that
+    already wire Phase F.1.
     """
 
     return_code: int
@@ -303,6 +311,7 @@ class RunResult:
     cwd: str
     env_scrubbed: bool
     exit_classification: Any = None  # WorkerExit | None — quoted to keep import optional
+    worker_pid: Optional[int] = None  # F.1 follow-up: captured from Popen.pid
 
     @property
     def ok(self) -> bool:
@@ -326,7 +335,50 @@ class RunResult:
                 # Best-effort: if a plain dict was stashed instead of a
                 # WorkerExit, propagate as-is.
                 payload["exit_classification"] = self.exit_classification
+        if self.worker_pid is not None:
+            payload["worker_pid"] = self.worker_pid
         return payload
+
+
+def _record_demo_worker_pid(assignment_id: str, worker_pid: int) -> bool:
+    """Best-effort F.1 demo-site PID record.
+
+    Opens its own runtime DB connection (mirrors the cron/VP CLI site
+    pattern), writes the PID against ``assignment_id`` via
+    :func:`task_hub.record_worker_pid`, commits, and closes.  Never
+    raises — failures are logged at WARNING but do not block the spawn
+    happy path.
+
+    Returns ``True`` on a successful write, ``False`` on any error (or
+    no-op skip for empty assignment_id / non-positive PID).
+    """
+    aid = str(assignment_id or "").strip()
+    if not aid or worker_pid <= 0:
+        return False
+    try:
+        from universal_agent import task_hub
+        from universal_agent.durable.db import connect_runtime_db, get_activity_db_path
+
+        conn = connect_runtime_db(get_activity_db_path())
+        try:
+            task_hub.record_worker_pid(
+                conn,
+                assignment_id=aid,
+                worker_pid=int(worker_pid),
+            )
+            try:
+                conn.commit()
+            except Exception:
+                pass
+        finally:
+            conn.close()
+        return True
+    except Exception as exc:
+        logger.warning(
+            "Phase F.1 demo workspace PID record failed (assignment_id=%s): %s",
+            aid, exc,
+        )
+        return False
 
 
 def run_in_workspace(
@@ -335,6 +387,8 @@ def run_in_workspace(
     *,
     timeout: int = 300,
     scrub_env: bool = True,
+    assignment_id: Optional[str] = None,
+    task_id: Optional[str] = None,
 ) -> RunResult:
     """Run a command from inside the workspace dir with optional env scrubbing.
 
@@ -350,40 +404,98 @@ def run_in_workspace(
     Hermes Phase F.1 site-wiring — the returned ``RunResult`` carries an
     ``exit_classification`` (a :class:`WorkerExit`) so the caller can
     distinguish clean exit / timeout / signaled / nonzero / protocol
-    violation.  PID recording is NOT supported here because
-    ``subprocess.run`` does not expose the PID; switching to ``Popen``
-    would be the upgrade path if PID observability becomes required for
-    the demo workspace.  F.3 (parking into needs_review) is the
-    caller\u2019s responsibility because the demo workspace has no direct
-    ``task_hub_assignments`` linkage at this level.
+    violation.
+
+    Hermes Phase F.1 follow-up (Popen migration) — the spawn now uses
+    :class:`subprocess.Popen` so the PID is observable immediately after
+    spawn rather than only after completion.  When the caller passes
+    ``assignment_id`` (the Task Hub assignment that owns this demo run),
+    the spawned subprocess PID is stamped onto
+    ``task_hub_assignments.worker_pid`` via
+    :func:`task_hub.record_worker_pid`.  Backward-compatible: existing
+    callers that don't pass ``assignment_id`` see identical behavior to
+    the pre-Popen path.
+
+    The ``task_id`` kwarg is accepted (and surfaced on the
+    ``RunResult.command`` audit trail via logger context only) for
+    future F.3 protocol-violation routing from this site.  Today the
+    demo site's caller (cody-task-dispatcher / cody-implements-from-brief)
+    owns disposition; this signature keeps the door open for moving the
+    F.3 park decision into ``run_in_workspace`` itself once a real
+    Task Hub-linked demo path lands.
     """
     cwd = workspace_dir.resolve()
     if not cwd.exists():
         raise FileNotFoundError(f"workspace does not exist: {cwd}")
     env = _scrubbed_env() if scrub_env else dict(os.environ)
+    cwd_str = str(cwd)
+    command_list = list(command)
 
     start = datetime.now(timezone.utc)
     was_timeout_killed = False
+    worker_pid: Optional[int] = None
+    rc: int
+    stdout: str
+    stderr: str
+
     try:
-        completed = sp.run(
-            list(command),
-            cwd=str(cwd),
-            capture_output=True,
+        proc = sp.Popen(
+            command_list,
+            cwd=cwd_str,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
             text=True,
-            timeout=timeout,
-            check=False,
             env=env,
         )
-        rc = completed.returncode
-        stdout = completed.stdout or ""
-        stderr = completed.stderr or ""
     except FileNotFoundError as exc:
         rc, stdout, stderr = 127, "", f"binary_not_found: {exc}"
-    except sp.TimeoutExpired:
-        rc, stdout, stderr = 124, "", f"timeout after {timeout}s"
-        was_timeout_killed = True
     except Exception as exc:
         rc, stdout, stderr = 1, "", f"unexpected_error: {exc}"
+    else:
+        # Capture PID immediately — that's the whole point of switching
+        # to Popen.  Record onto the assignment row before we block on
+        # communicate() so the observability metadata lands even if the
+        # subprocess is long-running.
+        try:
+            worker_pid = int(proc.pid) if proc.pid else None
+        except (TypeError, ValueError):
+            worker_pid = None
+        if assignment_id and worker_pid:
+            _record_demo_worker_pid(assignment_id, worker_pid)
+
+        try:
+            stdout_raw, stderr_raw = proc.communicate(timeout=timeout)
+            rc = proc.returncode if proc.returncode is not None else 1
+            stdout = stdout_raw or ""
+            stderr = stderr_raw or ""
+        except sp.TimeoutExpired:
+            # Preserve existing semantics: kill the process, drain its
+            # pipes, set rc=124, and flag the timeout-killed signal for
+            # the classifier.  communicate() after kill() drains the
+            # remaining buffered output.
+            was_timeout_killed = True
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                drain_stdout, drain_stderr = proc.communicate()
+            except Exception:
+                drain_stdout, drain_stderr = "", ""
+            rc = 124
+            stdout = drain_stdout or ""
+            stderr = (drain_stderr or "") + f"\ntimeout after {timeout}s"
+        except Exception as exc:
+            # Best-effort cleanup of any straggling process.
+            try:
+                proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.communicate()
+            except Exception:
+                pass
+            rc, stdout, stderr = 1, "", f"unexpected_error: {exc}"
     end = datetime.now(timezone.utc)
 
     # Phase F.1 — classify the exit so the caller can route protocol
@@ -411,15 +523,25 @@ def run_in_workspace(
     except Exception as exc:
         logger.debug("Phase F.1 demo classification skipped: %s", exc)
 
+    if task_id:
+        # Quiet breadcrumb so a future F.3 routing decision can be
+        # back-correlated through logs without changing this function's
+        # return shape.
+        logger.debug(
+            "run_in_workspace task_id=%s assignment_id=%s rc=%s pid=%s",
+            task_id, assignment_id, rc, worker_pid,
+        )
+
     return RunResult(
         return_code=rc,
         stdout=stdout,
         stderr=stderr,
         wall_time_seconds=(end - start).total_seconds(),
         command=tuple(command),
-        cwd=str(cwd),
+        cwd=cwd_str,
         env_scrubbed=scrub_env,
         exit_classification=classification,
+        worker_pid=worker_pid,
     )
 
 

--- a/tests/unit/test_hermes_phase_f_site_wiring.py
+++ b/tests/unit/test_hermes_phase_f_site_wiring.py
@@ -475,6 +475,61 @@ def test_classify_and_route_cli_exit_parks_on_protocol_violation(
 
 
 # ── Demo workspace site wiring ──────────────────────────────────────────────
+#
+# Hermes Phase F.1 follow-up: ``run_in_workspace`` now spawns via
+# ``subprocess.Popen`` so the PID is observable immediately after spawn.
+# These tests mock ``sp.Popen`` (NOT ``sp.run``) and exercise:
+#
+#   * ``clean_exit_zero`` classification on rc=0 happy path.
+#   * ``timeout_killed`` classification + ``proc.kill()`` + ``proc.communicate()``
+#     drain when ``communicate(timeout=…)`` raises ``TimeoutExpired``.
+#   * ``nonzero_exit`` and ``signaled`` classifications via mocked
+#     ``returncode``.
+#   * Round-tripping the result through ``to_dict()``.
+#   * PID recording when ``assignment_id`` is supplied + no-op when it
+#     is omitted (backward compat for the existing callers in
+#     ``cody_evaluation`` etc.).
+
+
+def _make_popen_mock(
+    *,
+    returncode: int = 0,
+    stdout: str = "ok",
+    stderr: str = "",
+    pid: int = 4242,
+    raise_timeout: bool = False,
+    raise_exception: Exception | None = None,
+) -> MagicMock:
+    """Build a Popen-compatible mock for ``run_in_workspace`` tests.
+
+    Mimics the post-spawn surface ``run_in_workspace`` touches:
+      * ``proc.pid`` — captured immediately for F.1 PID recording.
+      * ``proc.communicate(timeout=…)`` — returns ``(stdout, stderr)``
+        on success, raises ``sp.TimeoutExpired`` when ``raise_timeout``,
+        or any other ``raise_exception`` for fault-injection.
+      * ``proc.returncode`` — read after communicate() resolves.
+      * ``proc.kill()`` — must be callable; we record it via MagicMock.
+    """
+    proc = MagicMock()
+    proc.pid = pid
+
+    if raise_timeout:
+        # First call raises TimeoutExpired; the drain call (post-kill)
+        # returns empty strings.  Use side_effect with an iterator so
+        # the second invocation succeeds.
+        proc.communicate.side_effect = [
+            sp.TimeoutExpired(cmd="x", timeout=1),
+            ("", ""),
+        ]
+        proc.returncode = None
+    elif raise_exception is not None:
+        proc.communicate.side_effect = raise_exception
+        proc.returncode = None
+    else:
+        proc.communicate.return_value = (stdout, stderr)
+        proc.returncode = returncode
+
+    return proc
 
 
 def test_demo_run_in_workspace_stamps_classification_clean_exit(
@@ -484,12 +539,9 @@ def test_demo_run_in_workspace_stamps_classification_clean_exit(
     workspace = tmp_path / "demo"
     workspace.mkdir()
 
-    fake_completed = MagicMock()
-    fake_completed.returncode = 0
-    fake_completed.stdout = "ok"
-    fake_completed.stderr = ""
+    proc = _make_popen_mock(returncode=0, stdout="ok", stderr="")
 
-    with patch.object(cody_implementation.sp, "run", return_value=fake_completed):
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc):
         result = cody_implementation.run_in_workspace(
             workspace,
             ["echo", "hi"],
@@ -510,10 +562,9 @@ def test_demo_run_in_workspace_stamps_classification_timeout(
     workspace = tmp_path / "demo-tmo"
     workspace.mkdir()
 
-    def _raise_timeout(*a, **kw):
-        raise sp.TimeoutExpired(cmd="claude", timeout=10)
+    proc = _make_popen_mock(raise_timeout=True)
 
-    with patch.object(cody_implementation.sp, "run", side_effect=_raise_timeout):
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc):
         result = cody_implementation.run_in_workspace(
             workspace,
             ["claude"],
@@ -522,6 +573,9 @@ def test_demo_run_in_workspace_stamps_classification_timeout(
     assert result.return_code == 124
     assert result.exit_classification is not None
     assert result.exit_classification.outcome == "timeout_killed"
+    # Timeout path MUST have killed the process and drained its pipes.
+    proc.kill.assert_called_once()
+    assert proc.communicate.call_count == 2
 
 
 def test_demo_run_in_workspace_stamps_classification_nonzero(
@@ -530,12 +584,9 @@ def test_demo_run_in_workspace_stamps_classification_nonzero(
     workspace = tmp_path / "demo-err"
     workspace.mkdir()
 
-    fake = MagicMock()
-    fake.returncode = 2
-    fake.stdout = ""
-    fake.stderr = "boom"
+    proc = _make_popen_mock(returncode=2, stdout="", stderr="boom")
 
-    with patch.object(cody_implementation.sp, "run", return_value=fake):
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc):
         result = cody_implementation.run_in_workspace(
             workspace,
             ["something"],
@@ -554,12 +605,9 @@ def test_demo_run_in_workspace_stamps_classification_signaled(
     workspace = tmp_path / "demo-sig"
     workspace.mkdir()
 
-    fake = MagicMock()
-    fake.returncode = -9
-    fake.stdout = ""
-    fake.stderr = ""
+    proc = _make_popen_mock(returncode=-9, stdout="", stderr="")
 
-    with patch.object(cody_implementation.sp, "run", return_value=fake):
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc):
         result = cody_implementation.run_in_workspace(
             workspace,
             ["something"],
@@ -573,11 +621,8 @@ def test_demo_run_in_workspace_stamps_classification_signaled(
 def test_demo_run_in_workspace_to_dict_round_trip(tmp_path: Path) -> None:
     workspace = tmp_path / "demo-rt"
     workspace.mkdir()
-    fake = MagicMock()
-    fake.returncode = 0
-    fake.stdout = "ok"
-    fake.stderr = ""
-    with patch.object(cody_implementation.sp, "run", return_value=fake):
+    proc = _make_popen_mock(returncode=0, stdout="ok", stderr="")
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc):
         result = cody_implementation.run_in_workspace(
             workspace, ["echo", "ok"], timeout=5,
         )
@@ -587,3 +632,209 @@ def test_demo_run_in_workspace_to_dict_round_trip(tmp_path: Path) -> None:
     assert "exit_classification" in payload
     assert payload["exit_classification"]["outcome"] == "clean_exit_zero"
     assert payload["exit_classification"]["is_failure"] is False
+
+
+# ── F.1 follow-up — Popen + PID observability for demo workspace ───────────
+
+
+def test_demo_run_in_workspace_uses_popen_not_run(tmp_path: Path) -> None:
+    """Regression guard: confirms the spawn path is ``sp.Popen``.
+
+    The whole point of the F.1 follow-up is moving demo-workspace
+    invocations off ``sp.run`` so the spawned PID is observable
+    immediately.  This test ensures the migration sticks.
+    """
+    workspace = tmp_path / "demo-popen"
+    workspace.mkdir()
+
+    proc = _make_popen_mock(returncode=0)
+
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc) as popen:
+        result = cody_implementation.run_in_workspace(
+            workspace,
+            ["echo", "hi"],
+            timeout=5,
+        )
+    popen.assert_called_once()
+    # Popen must be passed PIPE for stdout/stderr (text=True) and cwd
+    # set to the resolved workspace dir.
+    _, kwargs = popen.call_args
+    assert kwargs["cwd"] == str(workspace.resolve())
+    assert kwargs["stdout"] is sp.PIPE
+    assert kwargs["stderr"] is sp.PIPE
+    assert kwargs["text"] is True
+    assert result.return_code == 0
+
+
+def test_demo_run_in_workspace_captures_pid_on_result(tmp_path: Path) -> None:
+    """The Popen PID lands on ``RunResult.worker_pid`` regardless of linkage."""
+    workspace = tmp_path / "demo-pid"
+    workspace.mkdir()
+
+    proc = _make_popen_mock(returncode=0, pid=9876)
+
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc):
+        result = cody_implementation.run_in_workspace(
+            workspace,
+            ["echo", "hi"],
+            timeout=5,
+        )
+    assert result.worker_pid == 9876
+    # ``worker_pid`` should also round-trip through ``to_dict``.
+    assert result.to_dict()["worker_pid"] == 9876
+
+
+def test_demo_run_in_workspace_records_pid_when_assignment_id_provided(
+    tmp_path: Path,
+) -> None:
+    """When ``assignment_id`` is set, the spawned PID is written via
+    ``task_hub.record_worker_pid``.  Connection plumbing is mocked at
+    the ``_record_demo_worker_pid`` boundary to avoid touching the real
+    runtime DB."""
+    workspace = tmp_path / "demo-record"
+    workspace.mkdir()
+    proc = _make_popen_mock(returncode=0, pid=5555)
+
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc), \
+         patch.object(
+             cody_implementation,
+             "_record_demo_worker_pid",
+             return_value=True,
+         ) as recorder:
+        cody_implementation.run_in_workspace(
+            workspace,
+            ["claude"],
+            timeout=5,
+            assignment_id="asg-demo-123",
+        )
+    recorder.assert_called_once_with("asg-demo-123", 5555)
+
+
+def test_demo_run_in_workspace_no_pid_record_when_assignment_id_missing(
+    tmp_path: Path,
+) -> None:
+    """Backward compat: legacy callers (no ``assignment_id``) must NOT
+    trigger any PID-record call."""
+    workspace = tmp_path / "demo-noid"
+    workspace.mkdir()
+    proc = _make_popen_mock(returncode=0)
+
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc), \
+         patch.object(
+             cody_implementation,
+             "_record_demo_worker_pid",
+         ) as recorder:
+        cody_implementation.run_in_workspace(
+            workspace,
+            ["echo", "hi"],
+            timeout=5,
+        )
+    recorder.assert_not_called()
+
+
+def test_demo_run_in_workspace_with_broken_db_completes_normally(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    """The real ``_record_demo_worker_pid`` swallows DB errors, so
+    ``run_in_workspace`` MUST complete normally even when the runtime
+    DB is unreachable.  Uses the real helper (not a mock) so the
+    swallowing logic is exercised end-to-end.
+    """
+    workspace = tmp_path / "demo-recerr"
+    workspace.mkdir()
+    proc = _make_popen_mock(returncode=0, pid=7777)
+
+    # Break the DB connect path so the helper hits the warning + return
+    # False branch internally.
+    monkeypatch.setattr(
+        "universal_agent.durable.db.connect_runtime_db",
+        lambda _path=None: (_ for _ in ()).throw(RuntimeError("db down")),
+    )
+
+    with patch.object(cody_implementation.sp, "Popen", return_value=proc):
+        result = cody_implementation.run_in_workspace(
+            workspace,
+            ["claude"],
+            timeout=5,
+            assignment_id="asg-demo-err",
+        )
+    # Happy path still completes; the failed PID record is observability
+    # noise, not a blocker.
+    assert result.return_code == 0
+    assert result.worker_pid == 7777
+    assert result.exit_classification.outcome == "clean_exit_zero"
+
+
+def test_record_demo_worker_pid_helper_no_op_for_empty_assignment(
+    tmp_path: Path,
+) -> None:
+    """``_record_demo_worker_pid("", pid)`` is a silent no-op."""
+    assert cody_implementation._record_demo_worker_pid("", 1234) is False
+    assert cody_implementation._record_demo_worker_pid("   ", 1234) is False
+
+
+def test_record_demo_worker_pid_helper_no_op_for_non_positive_pid(
+    tmp_path: Path,
+) -> None:
+    assert cody_implementation._record_demo_worker_pid("asg", 0) is False
+    assert cody_implementation._record_demo_worker_pid("asg", -1) is False
+
+
+def test_record_demo_worker_pid_helper_swallows_db_errors(
+    monkeypatch,
+) -> None:
+    """If the runtime DB connect raises, the helper logs and returns False."""
+
+    def _raise(*_a, **_kw):
+        raise RuntimeError("db connect failed")
+
+    monkeypatch.setattr(
+        "universal_agent.durable.db.connect_runtime_db", _raise,
+    )
+    ok = cody_implementation._record_demo_worker_pid("asg-x", 12345)
+    assert ok is False
+
+
+def test_record_demo_worker_pid_helper_writes_and_commits(
+    monkeypatch,
+) -> None:
+    """Happy path: helper opens a conn, writes the PID, commits, closes."""
+
+    class _FakeConn:
+        def __init__(self) -> None:
+            self.commits = 0
+            self.closed = False
+
+        def commit(self) -> None:
+            self.commits += 1
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake_conn = _FakeConn()
+
+    monkeypatch.setattr(
+        "universal_agent.durable.db.connect_runtime_db",
+        lambda _path=None: fake_conn,
+    )
+    monkeypatch.setattr(
+        "universal_agent.durable.db.get_activity_db_path",
+        lambda: "/tmp/fake.db",
+    )
+
+    record_calls: list[tuple[str, int]] = []
+
+    def _record(conn, *, assignment_id, worker_pid):
+        record_calls.append((assignment_id, worker_pid))
+        assert conn is fake_conn
+        return 1
+
+    monkeypatch.setattr(
+        "universal_agent.task_hub.record_worker_pid", _record,
+    )
+
+    ok = cody_implementation._record_demo_worker_pid("asg-real", 4321)
+    assert ok is True
+    assert record_calls == [("asg-real", 4321)]
+    assert fake_conn.commits == 1
+    assert fake_conn.closed is True


### PR DESCRIPTION
## Summary

- Switches `services/cody_implementation.run_in_workspace` from `subprocess.run` to `subprocess.Popen` so the demo workspace site gets PID observability parity with cron/VP CLI (both wired in PR #238).
- Adds optional `assignment_id` / `task_id` kwargs to `run_in_workspace` so Task Hub-linked callers can opt into PID recording via `task_hub.record_worker_pid`. Existing callers (e.g. `services/cody_evaluation`) are unchanged — fully backward compatible.
- New `RunResult.worker_pid` field surfaces the spawned PID on the result dataclass and in `to_dict()` when present.

## Why this matters

`subprocess.run` only exposes the PID after the process exits, which means the demo path could never participate in Hermes Phase F.1's PID tracking. Popen captures `proc.pid` at spawn time, which (a) lets us stamp the PID onto `task_hub_assignments.worker_pid` immediately, and (b) keeps the observability contract uniform across all three owned-subprocess sites (cron `!script`, VP CLI, demo workspace).

Timeout semantics are preserved: on `TimeoutExpired` we `proc.kill()`, drain the pipes via a second `proc.communicate()`, set `rc=124`, and flag `was_timeout_killed=True` for `classify_worker_exit`.

## Coverage gap (documented honestly)

Today, NO real demo workspace caller passes `assignment_id`. The demo task dispatch path (`cody-task-dispatcher` -> `cody-implements-from-brief`) does not yet create a `task_hub_assignments` row that `run_in_workspace` could link against. The new kwargs are therefore **scaffolding for the eventual Task Hub-linked demo path**; downstream wiring (producer side — the dispatcher needs to start emitting an assignment row before the spawn) is a follow-up. The schema + capability are now in place and tested so when the producer side lands, the only change required at this layer is adding `assignment_id=...` to the existing `run_in_workspace` call sites.

## Test plan

- [x] `python -m py_compile` clean on `cody_implementation.py` and the two test files.
- [x] `uv run pytest tests/unit/test_cody_implementation.py tests/unit/test_hermes_phase_f_site_wiring.py tests/unit/test_hermes_phase_f_foundation.py -x -q` -- 89 passed.
- [x] Broader sweep `-k "cody or worker_exit or phase_f"` -- 192 passed, 1 skipped, no regressions.
- [x] `ruff check --select E9,F` on changed source file `cody_implementation.py` -- clean. (Pre-existing unused imports in the test files were not introduced by this PR.)
- [ ] Post-deploy smoke: trigger any demo workspace path and observe whether the PID record appears in `task_hub_assignments.worker_pid` -- gated on the producer-side wiring described above (no real caller passes `assignment_id` yet).

## Files touched

- `src/universal_agent/services/cody_implementation.py` -- Popen migration + `_record_demo_worker_pid` helper + new `worker_pid` field on `RunResult` + new kwargs on `run_in_workspace`.
- `tests/unit/test_hermes_phase_f_site_wiring.py` -- Updated 5 existing demo-site tests to mock `sp.Popen` instead of `sp.run`. Added 9 new tests for the Popen migration regression guard, PID capture, PID recording on `assignment_id`, backward-compat no-op when omitted, broken-DB swallowing, and direct coverage of `_record_demo_worker_pid` (empty assignment, non-positive PID, DB connect failure, happy-path write+commit+close).

## New function signature

```python
def run_in_workspace(
    workspace_dir: Path,
    command: list[str] | tuple[str, ...],
    *,
    timeout: int = 300,
    scrub_env: bool = True,
    assignment_id: Optional[str] = None,   # NEW
    task_id: Optional[str] = None,          # NEW
) -> RunResult:
```

## Don't-touch list (honored)

- `cron_service.py` -- parallel agent's territory (cron task_id backfill); not modified.
- `vp/clients/claude_cli_client.py` -- wired in PR #238; not modified.
- `worker_exit_classifier.py` and `task_hub.record_worker_pid` -- consumed read-only.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)