### PR TITLE
feat(hermes-f-followup): backfill task_hub linkage for cron sources

### DIFF
--- a/src/universal_agent/cron_service.py
+++ b/src/universal_agent/cron_service.py
@@ -1198,17 +1198,66 @@ class CronService:
                                 env["PYTHONPATH"] = f"{project_src}:{env.get('PYTHONPATH', '')}"
 
                                 # Hermes Phase F site-wiring (cron `!script`).
-                                # Resolve the linked Task Hub task / assignment
-                                # (if any) BEFORE spawning so we can stamp the
-                                # subprocess PID onto the assignment row right
-                                # after spawn.  Cron jobs without a linked
-                                # task_id (the majority) skip F.1/F.3 silently
-                                # — observability is best-effort for the
-                                # subset that DO carry the linkage.
+                                # Resolve / auto-ensure the linked Task Hub
+                                # task + assignment BEFORE spawning so we can
+                                # stamp the subprocess PID onto the assignment
+                                # row right after spawn.
+                                #
+                                # Post-PR #238 (Hermes-F cron task-link
+                                # backfill, 2026-05-11): every cron `!script`
+                                # job gets a stable `cron:<system_job>` task
+                                # row auto-ensured by
+                                # ``ensure_cron_task_link`` unless its
+                                # metadata carries ``skip_task_hub_link =
+                                # True`` (housekeeping crons opt out).  The
+                                # email scheduler path (which already
+                                # populates ``metadata.task_id``) is honored
+                                # verbatim — the helper returns the explicit
+                                # task_id and lets the existing
+                                # ``find_active_assignment_for_task`` lookup
+                                # run below to discover its assignment.
                                 _f_job_metadata = job.metadata or {}
-                                _f_task_id = str(_f_job_metadata.get("task_id") or "").strip()
+                                _f_task_id = ""
                                 _f_assignment_id: Optional[str] = None
+                                _f_auto_linked = False
                                 _f_was_timeout_killed = False
+
+                                try:
+                                    from universal_agent.gateway_server import (
+                                        _task_hub_open_conn as _f_link_open_conn,
+                                    )
+                                    from universal_agent.services.cron_task_hub_link import (
+                                        ensure_cron_task_link as _f_ensure_link,
+                                    )
+                                    _f_link_conn = _f_link_open_conn()
+                                    try:
+                                        _f_linkage = _f_ensure_link(
+                                            _f_link_conn,
+                                            job_id=job.job_id,
+                                            job_metadata=_f_job_metadata,
+                                            description=(job.description or job.command)[:500],
+                                        )
+                                    finally:
+                                        _f_link_conn.close()
+                                    if _f_linkage:
+                                        _f_task_id = str(_f_linkage.get("task_id") or "").strip()
+                                        _f_assignment_id = str(_f_linkage.get("assignment_id") or "").strip() or None
+                                        # `_f_auto_linked` distinguishes the
+                                        # auto-ensured stable cron task from
+                                        # an externally-supplied task_id
+                                        # (email scheduler).  Only auto-linked
+                                        # tasks get their status flipped back
+                                        # to `open` after a clean run; the
+                                        # email path manages its own
+                                        # lifecycle.
+                                        _f_auto_linked = not str(
+                                            _f_job_metadata.get("task_id") or ""
+                                        ).strip()
+                                except Exception as _f_link_exc:
+                                    logger.debug(
+                                        "Phase F cron task-link skipped for job %s: %s",
+                                        job.job_id, _f_link_exc,
+                                    )
 
                                 proc = await asyncio.create_subprocess_exec(
                                     sys.executable, "-m", script_path.replace("/", ".").replace(".py", ""),
@@ -1218,8 +1267,13 @@ class CronService:
                                     env=env,
                                 )
                                 # Phase F.1 — record worker_pid on the linked
-                                # assignment (if any).  Best-effort; never
-                                # blocks the happy path.
+                                # assignment.  When auto-linked, the helper
+                                # already created the assignment row and
+                                # populated `_f_assignment_id`; for the
+                                # email-scheduler path we still need to look
+                                # it up via the classifier helper.  Best-
+                                # effort throughout; never blocks the happy
+                                # path.
                                 if _f_task_id:
                                     try:
                                         from universal_agent import (
@@ -1233,9 +1287,10 @@ class CronService:
                                         )
                                         _f_conn = _f_open_conn()
                                         try:
-                                            _f_assignment_id = _f_find_aid(
-                                                _f_conn, task_id=_f_task_id,
-                                            )
+                                            if not _f_assignment_id:
+                                                _f_assignment_id = _f_find_aid(
+                                                    _f_conn, task_id=_f_task_id,
+                                                )
                                             if _f_assignment_id and proc.pid:
                                                 _f_th.record_worker_pid(
                                                     _f_conn,
@@ -1281,6 +1336,22 @@ class CronService:
                                 # still in_progress), route the task into
                                 # needs_review for Phase B.1 unstick verbs to
                                 # act on.
+                                #
+                                # Auto-linked cron tasks: the cron script
+                                # itself doesn't know about the Task Hub row,
+                                # so a clean rc=0 exit is the normal happy
+                                # path — not a protocol violation.  Before
+                                # the classifier runs we flip the auto-
+                                # linked task to ``completed`` so
+                                # ``task_was_closed_normally`` returns True
+                                # and the classifier picks
+                                # ``clean_exit_zero``.  After the close-run
+                                # records the assignment outcome,
+                                # ``close_cron_task_link`` flips the
+                                # perpetual task back to ``open`` so the
+                                # next cron tick can reuse it.  Email-
+                                # scheduler crons (``_f_auto_linked = False``)
+                                # keep the pre-existing semantics.
                                 if _f_task_id:
                                     try:
                                         from universal_agent import (
@@ -1289,6 +1360,9 @@ class CronService:
                                         from universal_agent.gateway_server import (
                                             _task_hub_open_conn as _f_open_conn2,
                                         )
+                                        from universal_agent.services.cron_task_hub_link import (
+                                            close_cron_task_link as _f_close_link,
+                                        )
                                         from universal_agent.services.worker_exit_classifier import (
                                             classify_worker_exit as _f_classify,
                                             park_task_for_protocol_violation as _f_park,
@@ -1296,6 +1370,42 @@ class CronService:
                                         )
                                         _f_conn2 = _f_open_conn2()
                                         try:
+                                            # Pre-close the auto-linked task
+                                            # on a clean exit so F.3 doesn't
+                                            # treat the normal cron lifecycle
+                                            # as a protocol violation.  We
+                                            # flip the status directly via
+                                            # SQL rather than calling
+                                            # ``perform_task_action`` —
+                                            # auto-linked cron tasks are
+                                            # never email-bound, so the
+                                            # verified-delivery gate that
+                                            # ``perform_task_action`` runs
+                                            # would just add noise.
+                                            if (
+                                                _f_auto_linked
+                                                and exit_code == 0
+                                                and not _f_was_timeout_killed
+                                            ):
+                                                try:
+                                                    _f_conn2.execute(
+                                                        "UPDATE task_hub_items "
+                                                        "SET status = ?, seizure_state = ?, updated_at = ? "
+                                                        "WHERE task_id = ?",
+                                                        (
+                                                            _f_th2.TASK_STATUS_COMPLETED,
+                                                            "unseized",
+                                                            _f_th2._now_iso(),
+                                                            _f_task_id,
+                                                        ),
+                                                    )
+                                                    _f_conn2.commit()
+                                                except Exception as _f_complete_exc:
+                                                    logger.debug(
+                                                        "Phase F auto-link pre-close skipped for cron job %s: %s",
+                                                        job.job_id, _f_complete_exc,
+                                                    )
+
                                             _f_was_signaled = bool(
                                                 exit_code is not None
                                                 and exit_code < 0
@@ -1312,10 +1422,10 @@ class CronService:
                                             )
                                             logger.info(
                                                 "Phase F.1 cron job %s exit classified as %s "
-                                                "(task=%s, assignment=%s, rc=%s)",
+                                                "(task=%s, assignment=%s, rc=%s, auto_linked=%s)",
                                                 job.job_id, _f_classification.outcome,
                                                 _f_task_id, _f_assignment_id or "<none>",
-                                                exit_code,
+                                                exit_code, _f_auto_linked,
                                             )
                                             if _f_assignment_id:
                                                 try:
@@ -1332,7 +1442,24 @@ class CronService:
                                                         metadata={
                                                             "worker_exit": _f_classification.to_dict(),
                                                             "site": "cron",
+                                                            "auto_linked": _f_auto_linked,
                                                         },
+                                                    )
+                                                    # Also mark the
+                                                    # assignment itself as
+                                                    # ended so subsequent
+                                                    # ``find_active_assignment_for_task``
+                                                    # lookups don't keep
+                                                    # returning this row.
+                                                    _f_conn2.execute(
+                                                        "UPDATE task_hub_assignments "
+                                                        "SET state = ?, ended_at = ? "
+                                                        "WHERE assignment_id = ? AND ended_at IS NULL",
+                                                        (
+                                                            "completed" if exit_code == 0 else "failed",
+                                                            _f_th2._now_iso(),
+                                                            _f_assignment_id,
+                                                        ),
                                                     )
                                                     _f_conn2.commit()
                                                 except Exception as _f_close_exc:
@@ -1347,6 +1474,21 @@ class CronService:
                                                     site="cron",
                                                     summary=f"cron !script {script_path} job={job.job_id}",
                                                     agent_id="cron_scheduler",
+                                                )
+
+                                            # Auto-linked tasks: flip
+                                            # perpetual task back to
+                                            # ``open`` so the next cron
+                                            # tick can re-claim it.
+                                            # ``close_cron_task_link``
+                                            # checks status to avoid
+                                            # stomping needs_review left
+                                            # by F.3.
+                                            if _f_auto_linked:
+                                                _f_close_link(
+                                                    _f_conn2,
+                                                    task_id=_f_task_id,
+                                                    success=(exit_code == 0),
                                                 )
                                         finally:
                                             _f_conn2.close()

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -17984,6 +17984,12 @@ def _ensure_codie_proactive_cleanup_cron_job() -> Optional[dict[str, Any]]:
         "source": "system",
         "session_id": "cron_codie_cleanup",
         "proactive_producer": "codie_cleanup",
+        # Housekeeping: this cron enqueues OTHER Task Hub tasks; it
+        # doesn't itself produce a tracked work-product, so we skip
+        # the Hermes-F auto-link to avoid surfacing a useless
+        # ``cron:codie_proactive_cleanup`` row in the dashboard.
+        # See `services/cron_task_hub_link.py`.
+        "skip_task_hub_link": True,
     }
     updates = {
         "user_id": "system",
@@ -18036,6 +18042,8 @@ def _ensure_vp_coder_workspace_pruning_cron_job() -> Optional[dict[str, Any]]:
         enabled=_proactive_cron_enabled("UA_VP_CODER_WORKSPACE_PRUNING_ENABLED"),
         cron_env_var="UA_VP_CODER_WORKSPACE_PRUNING_CRON",
         timezone_env_var="UA_VP_CODER_WORKSPACE_PRUNING_TIMEZONE",
+        # Housekeeping: GC sweep, no tracked work-product.
+        skip_task_hub_link=True,
     )
 
 
@@ -18259,12 +18267,20 @@ def _register_system_cron_job(
     cron_env_var: str | None = None,
     timezone_env_var: str | None = None,
     required_secrets: list[str] | None = None,
+    skip_task_hub_link: bool = False,
 ) -> Optional[dict[str, Any]]:
     """Idempotent boot-time helper for proactive cron jobs.
 
     Looks up an existing job by `metadata.system_job`; updates if found,
     adds if not.  Always sets `catch_up_on_restart=True` so missed runs
     are backfilled on next gateway start instead of silently skipped.
+
+    `skip_task_hub_link=True` opts the job out of the Hermes Phase F
+    auto-link path (`services/cron_task_hub_link.py`).  Use this for
+    housekeeping crons (dispatcher sweeps, GC, re-rank passes) that
+    don't themselves produce a tracked work-product.  Crons that
+    produce artifacts (briefings, snapshots, digests) should leave
+    this False — the auto-link gives them F.1/F.3 observability.
 
     Returns the job dict on success, or `None` when disabled or the
     cron service is unavailable.
@@ -18290,6 +18306,8 @@ def _register_system_cron_job(
     }
     if required_secrets:
         metadata["required_secrets"] = list(required_secrets)
+    if skip_task_hub_link:
+        metadata["skip_task_hub_link"] = True
     updates = {
         "user_id": "cron_system",
         "workspace_dir": workspace_dir,
@@ -18409,6 +18427,9 @@ def _ensure_atlas_direct_dispatch_cron_job() -> Optional[dict[str, Any]]:
         enabled=_proactive_cron_enabled("UA_ATLAS_DIRECT_DISPATCH_ENABLED"),
         cron_env_var="UA_ATLAS_DIRECT_DISPATCH_CRON",
         timezone_env_var="UA_ATLAS_DIRECT_DISPATCH_TIMEZONE",
+        # Housekeeping: dispatcher sweep, no tracked work-product.
+        # The tasks it dispatches have their own task_hub linkage.
+        skip_task_hub_link=True,
     )
 
 
@@ -18638,6 +18659,9 @@ def _ensure_csi_demo_triage_rank_cron_job() -> Optional[dict[str, Any]]:
         cron_env_var="UA_CSI_DEMO_TRIAGE_RANK_CRON_EXPR",
         timezone_env_var="UA_CSI_DEMO_TRIAGE_RANK_CRON_TIMEZONE",
         required_secrets=["ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"],
+        # Housekeeping: re-ranking sweep over existing candidates; the
+        # candidates themselves carry their own task_hub linkage.
+        skip_task_hub_link=True,
     )
 
 

--- a/src/universal_agent/services/cron_task_hub_link.py
+++ b/src/universal_agent/services/cron_task_hub_link.py
@@ -1,0 +1,277 @@
+"""Hermes Phase F follow-up — auto-ensure Task Hub linkage for cron jobs.
+
+Background
+----------
+The Hermes Phase F site-wiring in :mod:`cron_service` records ``worker_pid``
+and detects protocol violations (rc=0 + task still ``in_progress``) only when
+the cron job's ``metadata.task_id`` is populated.  As shipped in PR #238, the
+only producer that populated that key was the email task scheduler — every
+other ``!script`` cron source skipped the F.1/F.3 hooks silently.
+
+This module closes the gap.  It provides a single helper,
+:func:`ensure_cron_task_link`, which the cron `!script` spawn site calls
+right before forking the subprocess.  The helper:
+
+1. Returns immediately if the job has opted out
+   (``metadata.skip_task_hub_link == True``) — used by housekeeping crons.
+2. If the job already carries an explicit ``metadata.task_id`` (e.g. the
+   email scheduler path), returns that ``task_id`` verbatim — the existing
+   F.1/F.3 wiring needs no further help.
+3. Otherwise, derives a stable ``task_id = "cron:<system_job>"`` (falling
+   back to ``cron:<job_id>`` if ``system_job`` is not set), upserts a
+   ``task_hub_items`` row (idempotent — repeated cron runs reuse the same
+   row), and creates a fresh ``task_hub_assignments`` row plus a
+   ``task_hub_runs`` row so the F.1 PID-stamp / F.3 close-run / protocol
+   violation routing all hook up the same way they do for email-sourced
+   crons.
+
+Design notes
+------------
+* **Stable task per cron source (Pattern A).**  Each cron name maps to a
+  single perpetual ``task_hub_items`` row — re-runs append a new
+  assignment / run row but reuse the task.  This keeps the task list
+  manageable while ``task_hub_runs`` still preserves a per-run audit
+  trail (which is exactly what Hermes Phase D was built for).
+
+* **agent_ready = False.**  Cron drives itself; we must not let the
+  dispatch sweep claim a ``cron:<name>`` task from underneath the
+  scheduler.
+
+* **status lifecycle for auto-linked cron tasks.**
+
+  1. :func:`ensure_cron_task_link` upserts the task as ``in_progress``
+     at spawn time so each run has a clear "active" signal.
+  2. Just before the F.3 classifier runs, the cron site wiring flips
+     the task to ``completed`` on a clean rc=0 exit (auto-linked cron
+     scripts don't manage their own task lifecycle, so a clean exit
+     IS the "done" signal).  This makes ``task_was_closed_normally``
+     return True and the classifier picks ``clean_exit_zero`` rather
+     than ``protocol_violation``.
+  3. :func:`close_cron_task_link` then flips ``completed`` back to
+     ``open`` so the next cron tick can re-claim the perpetual task
+     without creating a new row.
+
+* **Best-effort.**  Every code path swallows DB errors and logs at
+  ``debug`` — the cron run must never break because Task Hub linkage
+  failed.  ``ensure_cron_task_link`` returning ``None`` is a valid
+  ``no linkage`` signal that the spawn site interprets as "skip F.1/F.3
+  silently" (the pre-PR behavior).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import uuid
+from typing import Any, Optional
+
+from universal_agent import task_hub
+
+logger = logging.getLogger(__name__)
+
+
+_CRON_AGENT_ID = "cron_scheduler"
+
+# Source kind used for auto-linked cron task rows.  Stable across the
+# codebase — close_cron_task_link uses this as a guard so it only
+# resets cron-owned rows, never accidental email-scheduler rows that
+# happen to be in completed status.
+CRON_TASK_SOURCE_KIND = "cron_run"
+
+
+def derive_cron_task_id(*, system_job: str | None, job_id: str | None) -> Optional[str]:
+    """Derive the canonical ``cron:<name>`` task_id for a cron job.
+
+    Prefers ``system_job`` (the canonical key registered via
+    ``_register_system_cron_job``); falls back to ``job_id`` for ad-hoc
+    crons that don't go through the system-job helper.  Returns ``None``
+    if neither value is usable — the caller should treat that as
+    "no linkage available, skip F.1/F.3".
+    """
+    sj = str(system_job or "").strip()
+    if sj:
+        return f"cron:{sj}"
+    jid = str(job_id or "").strip()
+    if jid:
+        return f"cron:{jid}"
+    return None
+
+
+def ensure_cron_task_link(
+    conn: sqlite3.Connection,
+    *,
+    job_id: str,
+    job_metadata: dict[str, Any] | None,
+    description: str = "",
+) -> Optional[dict[str, str]]:
+    """Auto-ensure a stable Task Hub row + fresh assignment for a cron run.
+
+    Returns a dict ``{"task_id": ..., "assignment_id": ...}`` on success
+    so the spawn site can stamp ``worker_pid`` onto the assignment.
+
+    Returns ``None`` if:
+
+    * the job opted out (``metadata.skip_task_hub_link == True``);
+    * the linkage helper failed (best-effort — DB errors return ``None``
+      and log at ``debug`` so the cron run proceeds unblocked);
+    * the job had no derivable ``task_id`` (both ``system_job`` and
+      ``job_id`` were empty / missing — should never happen in practice).
+
+    If the job already carries ``metadata.task_id`` (e.g. email scheduler
+    crons), the function returns a dict with that explicit task_id and
+    ``assignment_id=""`` — the caller's existing ``find_active_assignment_for_task``
+    path handles assignment lookup for those crons.
+    """
+    metadata = dict(job_metadata or {})
+
+    # Opt-out for housekeeping crons.
+    if metadata.get("skip_task_hub_link") is True:
+        return None
+
+    # Caller-supplied task_id (e.g. email scheduler) — pre-existing path.
+    explicit_task_id = str(metadata.get("task_id") or "").strip()
+    if explicit_task_id:
+        return {"task_id": explicit_task_id, "assignment_id": ""}
+
+    system_job = str(metadata.get("system_job") or "").strip()
+    task_id = derive_cron_task_id(system_job=system_job, job_id=job_id)
+    if not task_id:
+        return None
+
+    try:
+        # 1. Idempotent upsert of the perpetual cron task row.
+        title = f"Cron: {system_job or job_id}"
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": task_id,
+                "source_kind": CRON_TASK_SOURCE_KIND,
+                "source_ref": system_job or job_id,
+                "title": title,
+                "description": description or title,
+                # `agent_ready = False` is the load-bearing flag: it tells
+                # the dispatch sweep "do not claim this task — the cron
+                # scheduler owns it".  Without this, a stable cron task
+                # could be grabbed by a heartbeat and processed twice.
+                "agent_ready": False,
+                "status": task_hub.TASK_STATUS_IN_PROGRESS,
+                "metadata": {
+                    "cron_owned": True,
+                    "system_job": system_job,
+                    "job_id": job_id,
+                },
+            },
+        )
+
+        # 2. Fresh assignment row for THIS run.  Each run gets its own
+        # assignment + run so F.1 PID stamping / F.3 close-run can
+        # correlate via assignment_id without colliding with prior runs.
+        assignment_id = f"asg_cron_{uuid.uuid4().hex[:16]}"
+        now_iso = task_hub._now_iso()  # type: ignore[attr-defined]
+        conn.execute(
+            """
+            INSERT INTO task_hub_assignments (
+                assignment_id, task_id, agent_id, state, started_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (assignment_id, task_id, _CRON_AGENT_ID, "running", now_iso),
+        )
+
+        # 3. Phase D run row so the operator dashboard surfaces the
+        # per-attempt outcome alongside any other Task Hub run.
+        try:
+            task_hub._open_run(  # type: ignore[attr-defined]
+                conn,
+                task_id=task_id,
+                assignment_id=assignment_id,
+                agent_id=_CRON_AGENT_ID,
+                metadata={
+                    "claim_source": "cron_auto_link",
+                    "system_job": system_job,
+                    "job_id": job_id,
+                },
+            )
+        except Exception as run_exc:  # pragma: no cover — defensive
+            logger.debug(
+                "ensure_cron_task_link: _open_run failed for job=%s: %s",
+                job_id, run_exc,
+            )
+
+        conn.commit()
+        return {"task_id": task_id, "assignment_id": assignment_id}
+    except Exception as exc:
+        logger.debug(
+            "ensure_cron_task_link failed for job=%s (continuing without linkage): %s",
+            job_id, exc,
+        )
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        return None
+
+
+def close_cron_task_link(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    success: bool,
+) -> None:
+    """Reset a perpetual cron task back to ``open`` after a clean run.
+
+    Lifecycle for auto-linked cron tasks (full picture in module docstring):
+
+    1. ``ensure_cron_task_link`` upserts the task as ``in_progress``.
+    2. Cron site wiring flips it to ``completed`` before F.3 classifier.
+    3. THIS function flips ``completed`` back to ``open``.
+
+    On failure (``success=False``) or if F.3 moved the task to
+    ``needs_review``, the task is left at whatever state the wiring
+    set — those are intentional surfacing signals for the operator.
+
+    Best-effort; never raises.
+    """
+    tid = str(task_id or "").strip()
+    if not tid:
+        return
+    try:
+        item = task_hub.get_item(conn, tid)
+        if not item:
+            return
+        # Guard: only reset rows we own (source_kind == cron_run) AND
+        # only on success AND only when the status is one of the
+        # expected "happy path" states.  This avoids stomping on a
+        # ``needs_review`` left by F.3 (a real protocol violation we
+        # want the operator to see) or a ``blocked`` set manually.
+        current_status = str(item.get("status") or "")
+        if (
+            str(item.get("source_kind") or "") == CRON_TASK_SOURCE_KIND
+            and success
+            and current_status in {
+                task_hub.TASK_STATUS_IN_PROGRESS,
+                task_hub.TASK_STATUS_COMPLETED,
+            }
+        ):
+            conn.execute(
+                "UPDATE task_hub_items SET status = ?, seizure_state = ?, updated_at = ? "
+                "WHERE task_id = ?",
+                (task_hub.TASK_STATUS_OPEN, "unseized", task_hub._now_iso(), tid),  # type: ignore[attr-defined]
+            )
+            conn.commit()
+    except Exception as exc:
+        logger.debug(
+            "close_cron_task_link failed for task=%s (continuing): %s",
+            tid, exc,
+        )
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+
+
+__all__ = [
+    "CRON_TASK_SOURCE_KIND",
+    "derive_cron_task_id",
+    "ensure_cron_task_link",
+    "close_cron_task_link",
+]

--- a/tests/unit/test_cron_task_hub_linkage.py
+++ b/tests/unit/test_cron_task_hub_linkage.py
@@ -1,0 +1,357 @@
+"""Hermes Phase F follow-up — cron task-hub linkage tests.
+
+Covers ``services/cron_task_hub_link.py``:
+
+* :func:`derive_cron_task_id` returns the canonical ``cron:<name>`` key.
+* :func:`ensure_cron_task_link` auto-ensures a stable task per cron
+  source on first call.
+* Re-running the same cron does NOT create duplicate task rows (the
+  ``cron:<name>`` task_id is the dedupe key).
+* ``metadata.skip_task_hub_link = True`` opts a cron out of the linkage.
+* ``metadata.task_id`` (the email-scheduler path) is honored verbatim
+  and short-circuits the auto-link path.
+* :func:`close_cron_task_link` resets a successful run's task back to
+  ``open`` so the next tick can re-claim it.
+* Each ensure call appends a fresh ``task_hub_assignments`` row + a
+  ``task_hub_runs`` row so F.1/F.3 wiring sees per-run granularity.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services.cron_task_hub_link import (
+    CRON_TASK_SOURCE_KIND,
+    close_cron_task_link,
+    derive_cron_task_id,
+    ensure_cron_task_link,
+)
+
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    task_hub.ensure_schema(c)
+    yield c
+    c.close()
+
+
+# ── derive_cron_task_id ────────────────────────────────────────────────────
+
+
+def test_derive_prefers_system_job_over_job_id() -> None:
+    assert (
+        derive_cron_task_id(system_job="morning_briefing", job_id="job-xyz")
+        == "cron:morning_briefing"
+    )
+
+
+def test_derive_falls_back_to_job_id_when_system_job_empty() -> None:
+    assert (
+        derive_cron_task_id(system_job="", job_id="adhoc-123") == "cron:adhoc-123"
+    )
+
+
+def test_derive_returns_none_when_both_empty() -> None:
+    assert derive_cron_task_id(system_job="", job_id="") is None
+    assert derive_cron_task_id(system_job=None, job_id=None) is None
+    assert derive_cron_task_id(system_job="  ", job_id="  ") is None
+
+
+# ── ensure_cron_task_link: opt-out ─────────────────────────────────────────
+
+
+def test_ensure_returns_none_when_skip_flag_set(conn: sqlite3.Connection) -> None:
+    result = ensure_cron_task_link(
+        conn,
+        job_id="job-xyz",
+        job_metadata={
+            "system_job": "csi_demo_triage_rank",
+            "skip_task_hub_link": True,
+        },
+    )
+    assert result is None
+    # No row should have been created.
+    row = conn.execute(
+        "SELECT COUNT(*) AS c FROM task_hub_items WHERE task_id = ?",
+        ("cron:csi_demo_triage_rank",),
+    ).fetchone()
+    assert row["c"] == 0
+
+
+def test_ensure_returns_none_when_no_derivable_task_id(conn: sqlite3.Connection) -> None:
+    result = ensure_cron_task_link(
+        conn,
+        job_id="",
+        job_metadata={"system_job": ""},
+    )
+    assert result is None
+
+
+# ── ensure_cron_task_link: explicit task_id (email scheduler) ──────────────
+
+
+def test_ensure_honors_explicit_task_id_verbatim(conn: sqlite3.Connection) -> None:
+    """The email scheduler path: ``metadata.task_id`` is already set."""
+    result = ensure_cron_task_link(
+        conn,
+        job_id="job-email-1",
+        job_metadata={
+            "source": "email_task_scheduler",
+            "task_id": "email-task:abc123",
+            "system_job": "",
+        },
+    )
+    assert result == {"task_id": "email-task:abc123", "assignment_id": ""}
+    # Should NOT create a `cron:<job-id>` row — the email scheduler
+    # owns the lifecycle of its own task.
+    row = conn.execute(
+        "SELECT COUNT(*) AS c FROM task_hub_items WHERE task_id LIKE 'cron:%'",
+    ).fetchone()
+    assert row["c"] == 0
+
+
+# ── ensure_cron_task_link: auto-link happy path ────────────────────────────
+
+
+def test_ensure_creates_stable_task_per_cron_name(conn: sqlite3.Connection) -> None:
+    result = ensure_cron_task_link(
+        conn,
+        job_id="job-mb-1",
+        job_metadata={"system_job": "morning_briefing"},
+        description="Daily briefing",
+    )
+    assert result is not None
+    assert result["task_id"] == "cron:morning_briefing"
+    assert result["assignment_id"].startswith("asg_cron_")
+
+    item = task_hub.get_item(conn, "cron:morning_briefing")
+    assert item is not None
+    assert item["source_kind"] == CRON_TASK_SOURCE_KIND
+    assert item["status"] == task_hub.TASK_STATUS_IN_PROGRESS
+    # `agent_ready = False` ensures dispatch sweep won't claim this row.
+    assert item["agent_ready"] is False or item["agent_ready"] == 0
+
+
+def test_ensure_dedupes_by_task_id_across_runs(conn: sqlite3.Connection) -> None:
+    """Re-running the same cron name produces ONE task row, multiple assignments."""
+    r1 = ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "nightly_wiki"},
+    )
+    r2 = ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "nightly_wiki"},
+    )
+    r3 = ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "nightly_wiki"},
+    )
+
+    assert r1 is not None and r2 is not None and r3 is not None
+    assert r1["task_id"] == r2["task_id"] == r3["task_id"] == "cron:nightly_wiki"
+    # Distinct assignment_ids per run.
+    assert r1["assignment_id"] != r2["assignment_id"] != r3["assignment_id"]
+
+    # Exactly ONE task row.
+    task_count = conn.execute(
+        "SELECT COUNT(*) AS c FROM task_hub_items WHERE task_id = 'cron:nightly_wiki'",
+    ).fetchone()["c"]
+    assert task_count == 1
+
+    # THREE assignment rows (one per ensure call).
+    assignment_count = conn.execute(
+        "SELECT COUNT(*) AS c FROM task_hub_assignments WHERE task_id = 'cron:nightly_wiki'",
+    ).fetchone()["c"]
+    assert assignment_count == 3
+
+    # THREE run rows (one per ensure call, via _open_run).
+    run_count = conn.execute(
+        "SELECT COUNT(*) AS c FROM task_hub_runs WHERE task_id = 'cron:nightly_wiki'",
+    ).fetchone()["c"]
+    assert run_count == 3
+
+
+def test_ensure_uses_job_id_when_system_job_missing(conn: sqlite3.Connection) -> None:
+    """Ad-hoc crons without a system_job fall back to the job_id."""
+    result = ensure_cron_task_link(
+        conn,
+        job_id="adhoc-xyz",
+        job_metadata={},  # no system_job
+    )
+    assert result is not None
+    assert result["task_id"] == "cron:adhoc-xyz"
+
+
+def test_ensure_records_assignment_with_running_state_and_agent(
+    conn: sqlite3.Connection,
+) -> None:
+    result = ensure_cron_task_link(
+        conn,
+        job_id="job-1",
+        job_metadata={"system_job": "hackernews_snapshot"},
+    )
+    assert result is not None
+    row = conn.execute(
+        "SELECT state, agent_id FROM task_hub_assignments WHERE assignment_id = ?",
+        (result["assignment_id"],),
+    ).fetchone()
+    assert row is not None
+    assert row["state"] == "running"
+    assert row["agent_id"] == "cron_scheduler"
+
+
+# ── close_cron_task_link ───────────────────────────────────────────────────
+
+
+def test_close_resets_in_progress_to_open(conn: sqlite3.Connection) -> None:
+    ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "morning_briefing"},
+    )
+    # Sanity: task is in_progress after ensure.
+    assert (
+        task_hub.get_item(conn, "cron:morning_briefing")["status"]
+        == task_hub.TASK_STATUS_IN_PROGRESS
+    )
+
+    close_cron_task_link(conn, task_id="cron:morning_briefing", success=True)
+
+    item = task_hub.get_item(conn, "cron:morning_briefing")
+    assert item["status"] == task_hub.TASK_STATUS_OPEN
+
+
+def test_close_resets_completed_to_open(conn: sqlite3.Connection) -> None:
+    """The cron site wiring flips the task to ``completed`` before F.3;
+    ``close_cron_task_link`` should then flip it back to ``open``."""
+    ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "morning_briefing"},
+    )
+    # Simulate the pre-F.3 flip to completed.
+    conn.execute(
+        "UPDATE task_hub_items SET status = ? WHERE task_id = ?",
+        (task_hub.TASK_STATUS_COMPLETED, "cron:morning_briefing"),
+    )
+    conn.commit()
+
+    close_cron_task_link(conn, task_id="cron:morning_briefing", success=True)
+
+    assert (
+        task_hub.get_item(conn, "cron:morning_briefing")["status"]
+        == task_hub.TASK_STATUS_OPEN
+    )
+
+
+def test_close_leaves_needs_review_untouched(conn: sqlite3.Connection) -> None:
+    """F.3 may have moved the task to ``needs_review`` (real protocol
+    violation).  ``close_cron_task_link`` must NOT stomp that signal."""
+    ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "morning_briefing"},
+    )
+    # Simulate F.3 routing to needs_review.
+    conn.execute(
+        "UPDATE task_hub_items SET status = ? WHERE task_id = ?",
+        (task_hub.TASK_STATUS_REVIEW, "cron:morning_briefing"),
+    )
+    conn.commit()
+
+    close_cron_task_link(conn, task_id="cron:morning_briefing", success=True)
+
+    assert (
+        task_hub.get_item(conn, "cron:morning_briefing")["status"]
+        == task_hub.TASK_STATUS_REVIEW
+    )
+
+
+def test_close_leaves_task_untouched_on_failure(conn: sqlite3.Connection) -> None:
+    """``success=False`` => leave the task at whatever state it's in."""
+    ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "morning_briefing"},
+    )
+    close_cron_task_link(conn, task_id="cron:morning_briefing", success=False)
+    # Still in_progress (ensure set it that way).
+    assert (
+        task_hub.get_item(conn, "cron:morning_briefing")["status"]
+        == task_hub.TASK_STATUS_IN_PROGRESS
+    )
+
+
+def test_close_skips_non_cron_owned_tasks(conn: sqlite3.Connection) -> None:
+    """Guard: only reset rows with source_kind='cron_run'.  An accidentally
+    matching task_id from another source must NOT be reset."""
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": "not-a-cron",
+            "source_kind": "internal",
+            "title": "manual task",
+            "status": task_hub.TASK_STATUS_IN_PROGRESS,
+        },
+    )
+    conn.commit()
+    close_cron_task_link(conn, task_id="not-a-cron", success=True)
+    # Unchanged.
+    assert (
+        task_hub.get_item(conn, "not-a-cron")["status"]
+        == task_hub.TASK_STATUS_IN_PROGRESS
+    )
+
+
+def test_close_swallows_unknown_task(conn: sqlite3.Connection) -> None:
+    """Best-effort: calling close on a non-existent task is a no-op."""
+    close_cron_task_link(conn, task_id="cron:does-not-exist", success=True)
+    # No exception, no rows.
+
+
+def test_close_empty_task_id_is_noop(conn: sqlite3.Connection) -> None:
+    close_cron_task_link(conn, task_id="", success=True)
+    close_cron_task_link(conn, task_id="   ", success=True)
+
+
+# ── Per-run granularity: each ensure creates a fresh assignment + run ──────
+
+
+def test_each_run_gets_distinct_assignment_and_run_id(
+    conn: sqlite3.Connection,
+) -> None:
+    """The whole point of the auto-link is per-run observability —
+    every cron tick MUST land in its own assignment row + run row."""
+    r1 = ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "morning_briefing"},
+    )
+    r2 = ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "morning_briefing"},
+    )
+    assert r1["assignment_id"] != r2["assignment_id"]
+
+    # Both runs should exist and reference distinct assignments.
+    runs = conn.execute(
+        "SELECT assignment_id FROM task_hub_runs WHERE task_id = 'cron:morning_briefing' "
+        "ORDER BY started_at",
+    ).fetchall()
+    assert len(runs) == 2
+    assert runs[0]["assignment_id"] != runs[1]["assignment_id"]
+
+
+# ── F-wiring contract: auto-linked task is queryable by find_active_assignment_for_task ──
+
+
+def test_ensure_creates_assignment_findable_by_phase_f_helper(
+    conn: sqlite3.Connection,
+) -> None:
+    """The F.1 PID-stamping path uses ``find_active_assignment_for_task``
+    as a fallback.  Even though the auto-link returns the assignment_id
+    directly, this verifies the row is queryable through the canonical
+    classifier helper too (defense in depth)."""
+    from universal_agent.services.worker_exit_classifier import (
+        find_active_assignment_for_task,
+    )
+
+    result = ensure_cron_task_link(
+        conn, job_id="job-1", job_metadata={"system_job": "morning_briefing"},
+    )
+    found = find_active_assignment_for_task(conn, task_id="cron:morning_briefing")
+    assert found == result["assignment_id"]


### PR DESCRIPTION
## Summary

Hermes Phase F (PR #238) site-wiring records `worker_pid` and detects protocol violations only when a cron job's `metadata.task_id` is populated. Today, only the email task scheduler populates that key — every other `!script` cron source skips F.1/F.3 silently.

This PR closes the gap by auto-ensuring a stable Task Hub linkage for every cron `!script` job that hasn't explicitly opted out.

## What changed

- **New `services/cron_task_hub_link.py`** — `ensure_cron_task_link()` upserts a perpetual `cron:<system_job>` task row + fresh assignment + run row per tick. `close_cron_task_link()` resets the task back to `open` so the next tick reuses it.
- **`cron_service.py`** — `!script` spawn site calls `ensure_cron_task_link` before fork, pre-closes auto-linked tasks to `completed` so F.3 classifier picks `clean_exit_zero` not `protocol_violation`, then resets to `open` after F.3 runs. Marks assignments `ended_at` so subsequent ticks see fresh rows.
- **`gateway_server.py`** — adds `skip_task_hub_link: bool = False` kwarg to `_register_system_cron_job` and opts out four housekeeping crons.

## Audit — every `!script` cron classified

**Auto-linked (default, produces tracked work-product):**

| system_job | rationale |
|---|---|
| `morning_briefing` | produces briefing artifact |
| `nightly_wiki` | produces wiki output |
| `proactive_report_morning/midday/afternoon` | produces report |
| `proactive_artifact_digest` | produces digest email |
| `hackernews_snapshot` | produces snapshot artifact |
| `youtube_daily_digest` | produces digest email |
| `claude_code_intel_sync` | produces intel brief |
| `csi_convergence_sync` | produces convergence work |

**Opt-out (`skip_task_hub_link=True`, housekeeping):**

| system_job | rationale |
|---|---|
| `codie_proactive_cleanup` | enqueues other Task Hub tasks; no own work-product |
| `vp_coder_workspace_pruning` | GC sweep |
| `atlas_direct_dispatch` | dispatcher sweep (dispatched tasks carry own linkage) |
| `csi_demo_triage_rank` | re-ranking sweep (candidates carry own linkage) |

**N/A — LLM crons (not `!script`, no F-wiring spawn path):**

- `autonomous_daily_briefing`, `paper_to_podcast_daily`

## Design choice — Pattern A (stable task per cron source)

The spec called out two patterns. Pattern A (one perpetual `cron:<name>` task, multiple assignments + runs per tick) was chosen to keep the task list manageable. Per-run audit trail still lives in `task_hub_runs` (Phase D.1). Pattern B (fresh task per run) would have created N rows per day per cron — noise without benefit since cron runs are intrinsically the same logical work unit.

`agent_ready=False` on the perpetual task prevents the dispatch sweep from claiming it from underneath the scheduler.

## Lifecycle for an auto-linked cron tick

1. `ensure_cron_task_link` upserts the task `in_progress` + fresh assignment `running` + new run row.
2. Subprocess spawned; PID stamped onto the assignment via F.1.
3. On exit: if rc=0 and auto-linked, flip task to `completed` so F.3 classifier sees `task_was_closed_normally=True` → classifies as `clean_exit_zero` (not `protocol_violation`).
4. F.3 close-run records assignment outcome + marks assignment `ended_at`.
5. `close_cron_task_link` flips `completed` → `open` so the next cron tick reuses the row.

If F.3 routes the task to `needs_review` (real protocol violation — should never happen for auto-linked crons in practice, since we pre-close), `close_cron_task_link` leaves it alone.

## Test plan

- [x] `uv run pytest tests/unit/test_cron_task_hub_linkage.py -x -q --no-header` — 19 new tests pass.
- [x] `uv run pytest tests/unit/test_hermes_phase_f_site_wiring.py tests/unit/test_hermes_phase_f_foundation.py -x -q --no-header` — 56 prior tests still pass.
- [x] `uv run ruff check --select E9,F --ignore E402,F401,F541,F811,F841 --no-cache <changed files>` — clean.
- [ ] Post-merge VPS verification (cron tick observed creating `cron_run` task_hub_items):
  ```
  sqlite3 /opt/universal_agent/AGENT_RUN_WORKSPACES/activity_state.db \
    "SELECT task_id, source_kind, COUNT(*) FROM task_hub_items WHERE source_kind = 'cron_run' GROUP BY task_id"
  ```

## Files touched

- `src/universal_agent/services/cron_task_hub_link.py` (new, 263 lines)
- `src/universal_agent/cron_service.py` (auto-link + close wiring in `!script` site)
- `src/universal_agent/gateway_server.py` (skip flag + opt-outs)
- `tests/unit/test_cron_task_hub_linkage.py` (new, 19 tests)

## Out of scope

- `services/cody_implementation.py` and `vp/clients/claude_cli_client.py` — parallel follow-up agent handling demo workspace Popen switch.
- Schema changes — none; uses existing F.1/F.3 columns from PR #238.
- LLM cron paths (`paper_to_podcast_daily`, `autonomous_daily_briefing`) — they don't go through the `!script` spawn site, so F.1/F.3 wiring doesn't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)