### PR TITLE
docs(hermes): Ship 4+5+6 implementation plans (compaction-safe)

### DIFF
--- a/docs/reports/hermes-ship-4-task-observability-protocol-plan.md
+++ b/docs/reports/hermes-ship-4-task-observability-protocol-plan.md
@@ -1,0 +1,421 @@
+# Hermes Ship 4 — Task Hub Observability Protocol: Detailed Implementation Plan
+
+**Created:** 2026-05-11 PM
+**Operator approval:** confirmed in session — Ship 4 + doc + CLAUDE.md row; lint guard deferred to future hardening.
+**Purpose:** This is the operational source of truth for completing Phase F observability coverage AND codifying the Task Hub Observability Protocol as the standard for all new tasks in this repo. The plan is intentionally self-contained so a fresh- or compacted-context Claude session can execute it without re-reading prior conversation.
+
+---
+
+## Context anchor — what's already in production as of 2026-05-11 PM
+
+Production SHA: `ca50b563` (PR #240 — cron task_hub linkage backfill).
+
+The following Hermes phases are MERGED and LIVE. Do not re-implement any of this — only build on top:
+
+| Layer | What's live | Key files |
+|---|---|---|
+| Schema | `task_hub_runs` table (per-attempt history); `cody_token_usage` table; `task_hub_assignments.worker_pid`; `task_hub_items.cody_mode / max_runtime_seconds / max_retries`; `task_hub_settings.cody_default_mode`; `task_hub_settings.cody_token_tracking_window` | `src/universal_agent/task_hub.py` § `ensure_schema` |
+| Helpers | `task_hub.record_worker_pid(conn, *, assignment_id, worker_pid)`; `task_hub.resolve_max_runtime_seconds(task)`; `task_hub._open_run(...)`; `task_hub._close_run(...)`; `task_hub.list_runs_for_task(...)`; `task_hub._get_setting / _set_setting` | `src/universal_agent/task_hub.py` |
+| Exit classifier | `classify_worker_exit(...)` returning `WorkerExit(outcome, is_protocol_violation, is_failure)`; `PROTOCOL_VIOLATION_REASONS` dict keyed by site (`cron`, `vp_cli`, `demo`); `park_task_for_protocol_violation(conn, *, task_id, site, summary)`; `find_active_assignment_for_task(conn, task_id)`; `task_was_closed_normally(conn, task_id)` | `src/universal_agent/services/worker_exit_classifier.py` |
+| Cron auto-link | `ensure_cron_task_link(conn, *, system_job)` → returns `task_id="cron:<system_job>"`; `close_cron_task_link(conn, *, task_id, outcome, error)` | `src/universal_agent/services/cron_task_hub_link.py` |
+| Cron site wiring | The `!script` spawn branch in `cron_service.py` already calls `ensure_cron_task_link` (when `metadata.skip_task_hub_link` is falsy), records `worker_pid`, classifies exit, routes F.3 protocol violations | `src/universal_agent/cron_service.py` around line 1200 |
+| VP CLI site wiring | `_classify_and_route_cli_exit` helper; `run_mission` calls it; F.3 routing when linked task is in_progress | `src/universal_agent/vp/clients/claude_cli_client.py` |
+| Demo workspace site wiring | `run_in_workspace` uses `Popen`; new kwargs `assignment_id` + `task_id`; `RunResult.exit_classification` + `RunResult.worker_pid` | `src/universal_agent/services/cody_implementation.py` |
+| Simone-callable verb tools | `task_re_evaluate / task_redirect_to / task_request_revision` registered in `internal_registry.get_core_internal_tools()` | `src/universal_agent/tools/task_hub_simone_verbs.py` |
+| Cody anthropic-by-default + UI toggle | `resolve_cody_mode(task, conn=...)`, `set_default_mode`, `get_default_mode_state`; resolution order: per-task → DB setting → env → hardcoded `"anthropic"` | `src/universal_agent/services/cody_mode.py` |
+| Cody token tracking | `record_token_usage`, `get_window_state`, `reset_window`, `summarize_window` | `src/universal_agent/services/cody_token_tracking.py` |
+| Endpoints | `GET/POST /api/v1/cody/mode-setting`, `GET /api/v1/cody/anthropic-token-tracking?mode=...`, `POST /api/v1/cody/anthropic-token-tracking/reset` | `src/universal_agent/gateway_server.py` |
+| Dashboard tile | `/dashboard/cody` page with mode toggle + token usage tile + refresh button | `web-ui/app/dashboard/cody/page.tsx` |
+| Auto-merge → deploy chain | `pr-auto-merge.yml` uses `secrets.AUTO_MERGE_PAT` so squash-merge `push` events fire `deploy.yml` automatically; `deploy.yml` has `concurrency: { group: deploy-production, cancel-in-progress: false }` | `.github/workflows/pr-auto-merge.yml`, `.github/workflows/deploy.yml` |
+
+**What's NOT wired yet (Ship 4's scope):**
+- 4 housekeeping crons currently opted out via `skip_task_hub_link=True`: `codie_proactive_cleanup`, `vp_coder_workspace_pruning`, `atlas_direct_dispatch`, `csi_demo_triage_rank`.
+- 2 LLM crons that use the non-`!script` execution path: `autonomous_daily_briefing`, `paper_to_podcast_daily`. Their cron execution branch in `cron_service.py` (the `else` after the `!script` branch, around line 1287) has no F observability wiring.
+- No canonical doc exists yet that codifies the "Task Hub Observability Protocol" as a repository-wide standard for new task types.
+
+---
+
+## The Task Hub Observability Protocol (the standard)
+
+This is the protocol that Ship 4 codifies. It is the **standard for every new asynchronous unit of work added to this repository going forward.**
+
+### The six rules
+
+1. **Identity** — Have a `task_hub_items` row. The unit of work has an identity in the system.
+2. **Claim ledger** — Create a `task_hub_assignments` row when claimed (or auto-link via `ensure_cron_task_link(conn, system_job=...)` for cron-style perpetual tasks).
+3. **Run history** — Open a `task_hub_runs` row at attempt start with `task_hub._open_run(...)`; close it at attempt end with `task_hub._close_run(...)` carrying one of the five outcomes from `classify_worker_exit`.
+4. **Subprocess identity (if applicable)** — If the work spawns a subprocess: record `worker_pid` via `task_hub.record_worker_pid(...)` immediately after spawn; resolve `max_runtime_seconds` via `task_hub.resolve_max_runtime_seconds(task)` for the timeout.
+5. **Protocol violation routing** — If the worker exits cleanly (`rc=0` or coroutine completes normally) but the linked task is still `in_progress`: route to `needs_review` via `park_task_for_protocol_violation(conn, task_id=..., site=...)` with the site-specific reason from `PROTOCOL_VIOLATION_REASONS`.
+6. **Standard recovery verbs** — Use the canonical recovery verbs for stuck tasks: `rehydrate / re_evaluate / request_revision / redirect_to` (operator dashboard buttons or Simone-callable tools). NO per-site recovery logic.
+
+### Helper API reference (already shipped)
+
+```python
+from universal_agent import task_hub
+from universal_agent.services.worker_exit_classifier import (
+    classify_worker_exit,
+    park_task_for_protocol_violation,
+    PROTOCOL_VIOLATION_REASONS,  # {"cron", "vp_cli", "demo"} → reason strings
+    find_active_assignment_for_task,
+    task_was_closed_normally,
+)
+from universal_agent.services.cron_task_hub_link import (
+    ensure_cron_task_link,
+    close_cron_task_link,
+)
+
+# At work start (cron pattern):
+task_id = ensure_cron_task_link(conn, system_job=cron_name)
+# OR (general pattern when the task already exists):
+assignment = task_hub.claim_next_dispatch_tasks(...)
+run_id = task_hub._open_run(conn, task_id=task_id, assignment_id=assignment_id, agent_id=agent_id)
+
+# If subprocess:
+proc = await asyncio.create_subprocess_exec(...)
+task_hub.record_worker_pid(conn, assignment_id=assignment_id, worker_pid=proc.pid)
+timeout_seconds = task_hub.resolve_max_runtime_seconds(task_row)
+
+# At work end:
+exit_class = classify_worker_exit(
+    return_code=rc,
+    was_signaled=signaled,
+    was_timeout_killed=timed_out,
+    task_closed_normally=task_was_closed_normally(conn, task_id),
+)
+task_hub._close_run(
+    conn,
+    assignment_id=assignment_id,
+    outcome=exit_class.outcome,
+    summary=summary_text,
+    error=error_text,
+)
+
+# F.3 protocol violation routing:
+if exit_class.is_protocol_violation:
+    park_task_for_protocol_violation(
+        conn,
+        task_id=task_id,
+        site="cron" | "vp_cli" | "demo" | <new_site>,
+        summary="clean exit but task not closed",
+    )
+```
+
+### When to use which pattern
+
+| Task shape | Pattern |
+|---|---|
+| Cron job spawning a `!script` subprocess | Auto-link via `ensure_cron_task_link`; subprocess flow records PID + classifies exit |
+| Cron job running an in-process LLM call | Auto-link via `ensure_cron_task_link`; in-process flow records run with `worker_pid=NULL` + classifies exit (rc derived from coroutine success/exception) |
+| VP mission via CLI subprocess | Existing wiring in `claude_cli_client.run_mission` — caller passes `task_id` in `payload.metadata.task_id` to enable F.3 |
+| VP mission via SDK in-process | Same as VP CLI but `worker_pid=NULL`; exit classification derived from `MissionOutcome.status` |
+| Demo workspace subprocess | Caller passes `assignment_id` to `run_in_workspace`; PID recorded; classification on `RunResult` |
+| Webhook handler / on-demand operator action / scheduled GitHub Actions task / any new async unit | Apply the six rules. Open `task_hub_items` row, open run, classify exit, close run, F.3 on protocol violation. |
+
+---
+
+## Ship 4 implementation plan
+
+### Branch and identifiers
+
+- **Branch name:** `claude/hermes-f-task-observability-protocol`
+- **PR title:** `feat(hermes-f-final): LLM crons + housekeeping opt-in + Task Hub Observability Protocol doc`
+- **Commit message:** see template at the bottom of this plan.
+
+### Part A — Flip 4 housekeeping crons to opt-in
+
+**File:** `src/universal_agent/gateway_server.py`
+
+Find each of these four `_register_system_cron_job` calls and remove the `skip_task_hub_link=True` kwarg (or set it to `False` explicitly — the default is `False` post-PR #240):
+
+1. `codie_proactive_cleanup` — at the `_ensure_codie_proactive_cleanup_cron_job` function (or similar — grep for `"codie_proactive_cleanup"` in `gateway_server.py`)
+2. `vp_coder_workspace_pruning` — `_ensure_vp_coder_workspace_pruning_cron_job`
+3. `atlas_direct_dispatch` — `_ensure_atlas_direct_dispatch_cron_job`
+4. `csi_demo_triage_rank` — `_ensure_csi_demo_triage_rank_cron_job`
+
+**Verification per cron:** after the flip, `_register_system_cron_job(system_job=<name>, ...)` should have either no `skip_task_hub_link` kwarg OR `skip_task_hub_link=False`. The cron service's `!script` spawn path will then auto-link via `ensure_cron_task_link` on each tick.
+
+**Why this is safe:** the auto-link is idempotent (uses `task_id=f"cron:{system_job}"` as the dedupe key), so flipping mid-flight just starts populating observability rows on the next tick. No backfill needed.
+
+### Part B — Wire the LLM cron path
+
+**File:** `src/universal_agent/cron_service.py`
+
+**Anchor:** the `else:` branch around line 1287 that runs LLM crons via `asyncio.wait_for(run_coro, timeout=timeout_seconds)`. Read the area `1180–1320` to understand both branches and what state the `!script` branch records.
+
+**Changes required:**
+
+1. **Before** `asyncio.wait_for(run_coro, ...)`:
+   - Resolve whether the job opted out (`job.metadata.get("skip_task_hub_link")` — bool). Skip the entire wiring if `True`.
+   - If opted in: call `ensure_cron_task_link(conn, system_job=job.system_job_name)` to ensure the `cron:<name>` task exists, get `task_id`.
+   - Open an assignment + run: `assignment_id = uuid4().hex` (or however the !script branch does it — match that pattern); `_open_run(conn, task_id=task_id, assignment_id=assignment_id, agent_id="cron_runner")`.
+   - **Do NOT** call `record_worker_pid` — this is in-process, no separate PID. The schema already accepts NULL for `worker_pid`.
+   - Set up local vars `was_timeout = False`, `error_text = ""`, `summary_text = ""`.
+
+2. **Inside the try/except around `asyncio.wait_for`:**
+   - On success: capture `summary_text` from the result (or use a generic "LLM cron run completed").
+   - On `asyncio.TimeoutError`: `was_timeout = True`; `error_text = f"cron timed out after {timeout_seconds}s"`.
+   - On other exceptions: `error_text = str(exc)[:1000]`.
+
+3. **After the LLM call:**
+   - Determine return-code equivalent: `rc_equiv = 0 if (not was_timeout and not error_text) else 1`.
+   - Determine `task_closed_normally`: call `task_was_closed_normally(conn, task_id)`. For LLM crons that mark their own work, this will be False if the task is still `in_progress` after the LLM returns.
+   - Call `classify_worker_exit(return_code=rc_equiv, was_signaled=False, was_timeout_killed=was_timeout, task_closed_normally=task_closed_normally)`.
+   - Call `_close_run(conn, assignment_id=assignment_id, outcome=classification.outcome, summary=summary_text, error=error_text)`.
+   - Call `close_cron_task_link(conn, task_id=task_id, outcome=classification.outcome, error=error_text)`.
+   - If `classification.is_protocol_violation`: call `park_task_for_protocol_violation(conn, task_id=task_id, site="cron", summary="LLM cron clean exit no disposition")`.
+
+4. **Wrap everything in try/except**: F observability must not break LLM cron execution. Mirror the defensive style from the `!script` branch — log on failure, continue.
+
+**Code style:** match the existing branch's variable names, log prefixes, and error-handling discipline. Look at how the `!script` branch wraps its F wiring (probably in helper functions in the same file) and reuse those helpers where possible. Do not duplicate logic.
+
+### Part C — Tests
+
+#### New test file: `tests/unit/test_cron_llm_path_f_observability.py`
+
+Mirror the style of `tests/unit/test_hermes_phase_f_site_wiring.py` (existing). Tests:
+
+1. `test_llm_cron_success_records_clean_exit_zero` — Mock the LLM coroutine to succeed; verify `task_hub_runs` row has `outcome="clean_exit_zero"`; verify cron task closed.
+2. `test_llm_cron_timeout_records_timeout_killed` — Mock the coroutine to take longer than `timeout_seconds`; verify outcome is `"timeout_killed"`; verify `_close_run` is called with the right error.
+3. `test_llm_cron_exception_records_nonzero_exit` — Mock the coroutine to raise; verify outcome is `"nonzero_exit"`; verify error text captured.
+4. `test_llm_cron_clean_exit_no_disposition_triggers_protocol_violation` — Mock the coroutine to succeed but leave the task in_progress; verify `park_task_for_protocol_violation` is called.
+5. `test_llm_cron_opt_out_skips_wiring` — Set `metadata.skip_task_hub_link=True`; verify no `task_hub_runs` row appears and no F.3 routing fires.
+6. `test_llm_cron_observability_failure_does_not_break_execution` — Mock `_open_run` to raise; verify the LLM cron still runs and returns.
+
+Use `pytest.fixture` for the SQLite conn and the cron service instance. Mock at the coroutine level (don't actually invoke real LLM calls).
+
+#### Extend existing test file: `tests/unit/test_cron_task_hub_linkage.py`
+
+Add 4 tests, one per flipped housekeeping cron, that verify the registration call no longer carries `skip_task_hub_link=True`. Pattern:
+
+```python
+def test_codie_proactive_cleanup_is_observed(monkeypatch):
+    """Post-Ship-4: codie_proactive_cleanup auto-links via ensure_cron_task_link."""
+    from universal_agent.gateway_server import _ensure_codie_proactive_cleanup_cron_job
+    # Inspect the call args by mocking _register_system_cron_job and capturing them.
+    ...
+    assert "skip_task_hub_link" not in captured_kwargs or captured_kwargs["skip_task_hub_link"] is False
+```
+
+(If `_register_system_cron_job` is hard to mock at this layer, an alternative is to grep the source of the registration helper for `skip_task_hub_link=True` and assert it's not present. Choose whichever is cleaner.)
+
+### Part D — Canonical doc + index updates
+
+#### New file: `docs/03_Operations/108_Task_Hub_Observability_Protocol.md`
+
+Structure:
+
+1. **Title + last-updated stamp** — `# Task Hub Observability Protocol` ; `**Last updated:** 2026-05-11 PM`.
+2. **Purpose** — Why this protocol exists; the centralization principle ("every task is the same, all managed by Task Hub"); links to the centralization rationale in CLAUDE.md.
+3. **Scope** — Applies to: any new async unit of work in `src/universal_agent/`. Includes: crons, VP missions, demo workspaces, webhook handlers, scheduled GHA workflows that produce a task_hub item, manual operator actions that fire async work. Excludes: pure event handlers that produce no persistent state.
+4. **The six rules** — Verbatim from above. Each rule with the WHY.
+5. **Helper API reference** — The code block from above with all imports and helper signatures.
+6. **Per-task-shape patterns table** — From above.
+7. **Worked examples**:
+   - Adding a new cron job (full code with the wiring)
+   - Adding a new VP mission consumer
+   - Adding a webhook handler (hypothetical — illustrates the general case)
+8. **Checklist for adding a new task type** — copy/paste checklist (10 items max).
+9. **What this protocol does NOT do** — Doesn't enforce business logic; doesn't replace per-site retry semantics (those are in `task_hub` already); doesn't auto-instrument existing code (must be explicitly wired).
+10. **Cross-refs**:
+    - `docs/03_Operations/107_Task_Hub_And_Multi_Channel_Execution_Master_Reference_2026-03-31.md` (Task Hub master reference)
+    - `docs/03_Operations/cron_job_registration.md` (cron job registration patterns)
+    - `docs/reports/hermes-adaptation-phased-plan-2026-05-10.md` (Hermes plan that produced this)
+11. **Future hardening** — Mention the deferred lint guard (CI check that flags new `subprocess.run / Popen / asyncio.create_subprocess_exec` calls in `src/universal_agent/` that don't import from `worker_exit_classifier`).
+
+Length target: 500-800 lines. Detailed enough to be a real reference; not so verbose that it gets ignored.
+
+#### CLAUDE.md update
+
+In the "Pre-Implementation Reading — DO NOT SKIP" table (current location: `CLAUDE.md` § "Pre-Implementation Reading"), add a new row:
+
+| If you're about to propose | Read first |
+|---|---|
+| ... existing rows ... | ... |
+| **A new cron job, scheduled task, webhook handler, or any new async unit of work** | **`docs/03_Operations/108_Task_Hub_Observability_Protocol.md` — the protocol is mandatory for new tasks. Use the helper API; don't bypass.** |
+
+Place it logically near the other "task hub" rows.
+
+#### `docs/Documentation_Status.md` update
+
+Prepend a new entry to the rolling "Last updated" block following the existing pattern (2-3 paragraphs covering: Ship 4 LLM cron wiring, 4 housekeeping crons flipped, new 108 canonical doc + checklist + worked examples, CLAUDE.md row addition, test counts).
+
+#### `docs/README.md` update
+
+Find the "3. Operations" or "03_Operations" section and add a link to the new doc:
+- `**[Task Hub Observability Protocol](03_Operations/108_Task_Hub_Observability_Protocol.md)**: Canonical standard for the observability + recovery wiring that every async unit of work must follow.`
+
+### Part E — Verification + ship
+
+1. **Local tests:**
+   ```
+   uv run pytest tests/unit/test_cron_llm_path_f_observability.py tests/unit/test_cron_task_hub_linkage.py tests/unit/test_hermes_phase_f_site_wiring.py tests/unit/test_hermes_phase_f_foundation.py -x -q --no-header
+   ```
+   All must pass. Then broader sanity:
+   ```
+   uv run pytest tests/unit/test_task_hub_runs.py tests/unit/test_task_hub_unstick_verbs.py tests/unit/test_dashboard_failure_context_endpoint.py tests/unit/test_cody_mode.py tests/unit/test_cody_token_tracking.py tests/unit/test_task_hub_simone_verbs.py tests/unit/test_task_hub_lifecycle.py tests/unit/test_task_hub_schema_extensions.py tests/unit/test_task_hub_max_retries_override.py -q --no-header
+   ```
+
+2. **Static checks:**
+   ```
+   python -m py_compile src/universal_agent/cron_service.py src/universal_agent/gateway_server.py tests/unit/test_cron_llm_path_f_observability.py
+   uv run ruff check --select E9,F --ignore E402,F401,F541,F811,F841 --no-cache src/universal_agent/cron_service.py src/universal_agent/gateway_server.py tests/unit/test_cron_llm_path_f_observability.py
+   ```
+
+3. **Commit:**
+   ```
+   git add src/universal_agent/cron_service.py src/universal_agent/gateway_server.py \
+           tests/unit/test_cron_llm_path_f_observability.py tests/unit/test_cron_task_hub_linkage.py \
+           docs/03_Operations/108_Task_Hub_Observability_Protocol.md \
+           docs/Documentation_Status.md docs/README.md CLAUDE.md
+   git commit -m "feat(hermes-f-final): LLM crons + housekeeping opt-in + Task Hub Observability Protocol doc"
+   ```
+   Use the detailed commit template at the bottom of this plan.
+
+4. **Push + PR:**
+   ```
+   git push -u origin claude/hermes-f-task-observability-protocol
+   gh pr create --base main --head claude/hermes-f-task-observability-protocol --title "..." --body "..."
+   ```
+   The PAT-based auto-merge chain will handle the rest.
+
+5. **Post-deploy verification on `ua@uaonvps`:**
+   ```
+   # Wait ~2 minutes for deploy, then:
+   ssh ua@uaonvps "curl -s http://127.0.0.1:8002/api/v1/version" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d['short_sha'], '-', d['commit_subject'])"
+   # Should show the new SHA.
+   
+   # After a cron tick has fired (worst case 30 min for hackernews_snapshot):
+   ssh ua@uaonvps 'sqlite3 /opt/universal_agent/AGENT_RUN_WORKSPACES/activity_state.db "SELECT task_id, source_kind, status, COUNT(*) FROM task_hub_items WHERE source_kind = '\''cron_run'\'' GROUP BY task_id ORDER BY task_id"'
+   # Should show rows for the auto-linked crons (8 work-producing + 4 newly-opted-in = 12 expected).
+   ```
+
+---
+
+## Commit / PR template
+
+### Commit message
+
+```
+feat(hermes-f-final): LLM crons + housekeeping opt-in + Task Hub Observability Protocol doc
+
+Closes Phase F observability coverage and codifies the Task Hub
+Observability Protocol as the repository-wide standard for any new
+async unit of work.
+
+Three pieces:
+
+1. **LLM cron path wiring** — `cron_service.py` LLM execution branch
+   (the non-`!script` path around line 1287) now creates a cron task
+   link, opens a `task_hub_runs` row, classifies the outcome of the
+   coroutine via `classify_worker_exit`, closes the run + cron task
+   link, and routes protocol violations via
+   `park_task_for_protocol_violation`. `worker_pid` stays NULL — these
+   are in-process LLM calls and don't have separate PIDs. Mirrors the
+   `!script` branch wiring from PR #238.
+
+2. **4 housekeeping crons flipped to opt-in** — removed
+   `skip_task_hub_link=True` from `codie_proactive_cleanup`,
+   `vp_coder_workspace_pruning`, `atlas_direct_dispatch`, and
+   `csi_demo_triage_rank`. These are dispatcher/GC crons; the
+   "they don't produce work product" rationale was the wrong frame —
+   meta-observability ("is the dispatcher itself alive?") matters too.
+
+3. **Canonical doc**: `docs/03_Operations/108_Task_Hub_Observability_Protocol.md`
+   — formalizes the six-rule standard for ALL new async work in this
+   repo: identity, claim ledger, run history, subprocess identity,
+   protocol violation routing, standard recovery verbs. Includes
+   helper API reference, per-task-shape patterns table, worked
+   examples (cron / VP mission / webhook), checklist for adding a
+   new task type, and cross-refs to existing canonical docs.
+
+   `CLAUDE.md` Pre-Implementation Reading table gains a row pointing
+   at the new 108 doc as MANDATORY reading before proposing any new
+   async unit. Indexes updated in `docs/README.md` and
+   `docs/Documentation_Status.md`.
+
+Tests: 6 new in `test_cron_llm_path_f_observability.py` + 4 extending
+`test_cron_task_hub_linkage.py`. Cross-Hermes sanity: 200+ Hermes-
+related tests still pass.
+
+After this PR the 4 standalone cron sources audit results from PR #240
+become:
+* Auto-linked: 8 work-producing + 4 newly-opted-in = 12 cron sources
+* N/A: 2 LLM crons → now wired via the LLM-path observability
+* Total: 14/14 cron sources covered by Phase F observability
+
+Future hardening (deferred): a CI lint guard that flags new
+`asyncio.create_subprocess_exec / subprocess.run / Popen` calls in
+`src/universal_agent/` not importing from `worker_exit_classifier`,
+to enforce the protocol at PR time.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+### PR body
+
+```
+## Summary
+
+Closes Phase F observability coverage AND codifies the Task Hub Observability Protocol as the standard for all new async work in this repo.
+
+Three pieces — see commit message for full detail:
+1. LLM cron path wiring (mirrors `!script` branch from PR #238)
+2. 4 housekeeping crons flipped to opt-in
+3. New canonical doc `108_Task_Hub_Observability_Protocol.md` + CLAUDE.md row + index updates
+
+## Why this matters
+
+The user's existing principle is "centralize everything through Task Hub." Phase F shipped the observability layer but only wired 3 spawn sites + 8 cron sources. This PR closes that gap (14/14 cron sources covered) AND documents the protocol so future contributors apply it by default.
+
+## Test plan
+
+- [x] 6 new LLM-path observability tests pass locally
+- [x] 4 new housekeeping-cron opt-in tests pass
+- [x] Cross-Hermes sanity 200+ tests still pass
+- [x] py_compile + ruff clean
+- [ ] CI PR-Validate
+- [ ] Post-deploy: confirm new SHA via `/api/v1/version`; observe `cron_run` rows in production after first tick of a newly-opted-in cron
+
+## Future hardening (deferred)
+
+Lint guard that flags new subprocess spawns not importing from `worker_exit_classifier`. Tracked in commit message.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+---
+
+## Critical context for compaction-resilience
+
+If the context window has been compacted before execution, the following identifiers are LIVE on `main` as of SHA `ca50b563`. Do not assume they need re-creation:
+
+- **Module path:** `src/universal_agent/services/worker_exit_classifier.py` exists and exports `classify_worker_exit`, `WorkerExit`, `PROTOCOL_VIOLATION_REASONS` (dict with keys `cron`, `vp_cli`, `demo`), `park_task_for_protocol_violation(conn, *, task_id, site, summary="")`, `find_active_assignment_for_task(conn, task_id)`, `task_was_closed_normally(conn, task_id)`.
+- **Module path:** `src/universal_agent/services/cron_task_hub_link.py` exists and exports `ensure_cron_task_link(conn, *, system_job)` returning `task_id="cron:<system_job>"`, and `close_cron_task_link(conn, *, task_id, outcome, error)`.
+- **Schema:** `task_hub_assignments.worker_pid INTEGER NULL`; `task_hub_items.max_runtime_seconds INTEGER NULL`; `task_hub_items.cody_mode TEXT`; `task_hub_runs` table with `(run_id, task_id, assignment_id, agent_id, started_at, ended_at, outcome, summary, metadata_json, error)`; `cody_token_usage` table.
+- **PR auto-merge chain:** branch name `claude/<anything>` → PR open → `pr-auto-merge.yml` enables auto-merge via PAT → `pr-validate.yml` runs → squash-merge to main → `deploy.yml` fires on push → production deploy → SHA visible on `/api/v1/version`. Concurrency guard ensures simultaneous merges queue.
+- **Verification command:** `ssh ua@uaonvps "curl -s http://127.0.0.1:8002/api/v1/version" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d['short_sha'])"` returns the live production SHA.
+- **DB path on production:** `/opt/universal_agent/AGENT_RUN_WORKSPACES/activity_state.db`.
+
+If any of these have drifted (e.g. a subsequent PR moved files), grep before assuming. Most likely they have not — the deployed SHA at plan-creation time is `ca50b563` and the next PR built on this plan should ideally branch off `ca50b563` or its descendant.
+
+---
+
+## Open questions / decisions baked in
+
+| Decision | Why |
+|---|---|
+| Lint guard deferred to future PR | User explicit: "Skip the lint guard for now." High value but needs allowlist design. |
+| LLM cron path gets observability with NULL `worker_pid` | The schema explicitly allows NULL for in-process work. Don't try to synthesize a fake PID. |
+| 4 housekeeping crons get flipped, not redesigned | Meta-observability principle: even dispatchers and GC tasks benefit from "did they run?" visibility. Simpler than restructuring them. |
+| LLM-cron protocol violation routing matches `!script` branch | Same `PROTOCOL_VIOLATION_REASONS["cron"]` reason; treat all crons uniformly regardless of execution mode. |
+| Six-rule standard is the canonical framing | Concise; covers identity, claim, history, subprocess identity, protocol violation, recovery. Maps 1:1 to the helpers shipped in PRs #230 / #238 / #239 / #240. |
+
+---
+
+## Execution sequence (when resuming after compaction)
+
+1. Open this plan document (`docs/reports/hermes-ship-4-task-observability-protocol-plan.md`) — it's the operational source of truth.
+2. Branch off latest `origin/main` (verify SHA via `git log origin/main --oneline -1`).
+3. Execute Part A → Part D → Part C tests → Part E ship in order.
+4. Each step has a verification gate; don't skip.
+5. Report back to operator only at ship completion (PR URL, test counts, production verification result).

--- a/docs/reports/hermes-ship-5-lint-guard-plan.md
+++ b/docs/reports/hermes-ship-5-lint-guard-plan.md
@@ -1,0 +1,338 @@
+# Hermes Ship 5 — Subprocess Lint Guard: Detailed Implementation Plan
+
+**Created:** 2026-05-11 PM
+**Sequencing:** Ships AFTER Ship 4 (Task Hub Observability Protocol doc must exist as the reference target).
+**Purpose:** Enforce the Task Hub Observability Protocol at CI time. New subprocess spawns in `src/universal_agent/` that don't import from `worker_exit_classifier` or `task_hub`'s observability helpers fail PR-validate. Existing unwired spawns are grandfathered via an allowlist; the test acts as a ratchet so coverage only ever increases.
+
+This plan is self-contained for compaction-resilience.
+
+---
+
+## Why this guard exists
+
+The Task Hub Observability Protocol (`docs/03_Operations/108_Task_Hub_Observability_Protocol.md`, shipped in Ship 4) requires that every new async unit of work in `src/universal_agent/` uses the six-rule observability + recovery pattern. Without enforcement, a future contributor (Claude or human) can write a new cron job, webhook handler, or subprocess spawn that skips the protocol — and the operator won't see the gap until something goes silently wrong in production.
+
+The lint guard is a CI-time check that:
+
+1. AST-walks `src/universal_agent/` for subprocess-spawning call sites.
+2. For each file with such a call, verifies it imports from `worker_exit_classifier` (the observability module) or is on a documented allowlist.
+3. Fails PR-validate with a pointer to the 108 doc when a new violation appears.
+
+Existing-but-unwired spawn sites are grandfathered via the allowlist so the guard can ship without requiring a giant backfill PR. The allowlist is a regular text file; shrinking it (i.e., wiring an existing site) is the natural path forward.
+
+---
+
+## Detection scope
+
+The guard flags these call patterns:
+
+```python
+asyncio.create_subprocess_exec(...)
+asyncio.create_subprocess_shell(...)
+subprocess.run(...)
+subprocess.call(...)
+subprocess.check_call(...)
+subprocess.check_output(...)
+subprocess.Popen(...)
+os.system(...)               # crude but catches sloppy spawns
+os.popen(...)                # ditto
+```
+
+These can be aliased (`sp.run`, `asyncio.create_subprocess_exec`, etc.). The AST walker must match by call attribute, not name string, so aliases are detected correctly via the import binding.
+
+### Compliant import patterns
+
+A file is considered compliant if it imports any of:
+
+```python
+from universal_agent.services.worker_exit_classifier import classify_worker_exit
+from universal_agent.services.worker_exit_classifier import WorkerExit
+from universal_agent.services.worker_exit_classifier import park_task_for_protocol_violation
+from universal_agent.task_hub import record_worker_pid
+from universal_agent.task_hub import resolve_max_runtime_seconds
+```
+
+Any one of the above is sufficient to consider the file "wired into the protocol" (the check doesn't try to prove every spawn site within the file uses the helper — that's beyond AST scope). Files that have multiple spawns where SOME are wired and SOME aren't are still considered compliant; the protocol assumes per-file ownership.
+
+### Out-of-scope (always excluded)
+
+- `tests/` — test code routinely spawns subprocesses for fixtures; not async work units.
+- `scripts/` — operator-tier installation / setup scripts; not async work units.
+- `.venv/`, `node_modules/`, vendored libs.
+- Generated code (none currently in `src/universal_agent/` but defensive exclusion).
+
+Only `src/universal_agent/` is walked.
+
+---
+
+## Allowlist design
+
+**File:** `tests/unit/task_observability_coverage_allowlist.txt`
+
+**Format:** one relative file path per line, with optional `#` comments. Example:
+
+```
+# Files that spawn subprocesses but predate the Task Hub Observability Protocol.
+# Adding a new entry here requires explicit operator approval — the protocol
+# is the long-term standard; the allowlist exists only to make adoption
+# incremental, not to permit drift.
+#
+# Format: <repo-relative path>     # <reason>
+
+src/universal_agent/services/some_legacy_runner.py  # subprocess used for one-off CLI; not part of task lifecycle
+src/universal_agent/some_other_file.py              # health-check fork, no task semantics
+```
+
+**Ratchet semantics:** the test loads the allowlist, computes the actual set of violating files in the current tree, and:
+
+- Fails if any violating file is NOT in the allowlist.
+- Warns (but does not fail) if any allowlisted file is no longer a violation (so the allowlist can be tightened).
+
+The "warn don't fail" on dead allowlist entries is deliberate — we don't want a passing-then-failing CI flake when someone wires a legacy site.
+
+### Initial allowlist contents
+
+Computed at Ship 5 implementation time by running the AST walker against the current tree and snapshotting the violations. Each entry must be reviewed: is this file actually a task unit that should be wired (defer to follow-up PR), or is it infrastructure that legitimately doesn't fit the protocol (permanent allowlist)?
+
+Likely allowlist candidates (to be verified during implementation):
+
+- Cron service itself (`src/universal_agent/cron_service.py`) — spawns the work; IS the wiring; importing `classify_worker_exit` for use elsewhere in the file should remove this from the allowlist
+- VP CLI client (`src/universal_agent/vp/clients/claude_cli_client.py`) — already wired, should pass without allowlist entry
+- Demo workspace (`src/universal_agent/services/cody_implementation.py`) — already wired, should pass
+
+For any spawn site where the file is NOT in the allowlist AND does NOT import the helpers, the test must fail. That's the whole point.
+
+---
+
+## Implementation details
+
+### Test file: `tests/unit/test_task_observability_coverage.py`
+
+Structure:
+
+```python
+"""Hermes Ship 5 — Task Hub Observability Protocol enforcement test.
+
+Ratchets coverage of the observability protocol across src/universal_agent/.
+New spawn-call sites must either import from worker_exit_classifier (and
+implicitly call its helpers) OR be explicitly listed in
+tests/unit/task_observability_coverage_allowlist.txt.
+
+This is the long-term gate for the protocol; see
+docs/03_Operations/108_Task_Hub_Observability_Protocol.md for the rules
+this test enforces.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from typing import Iterable
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src" / "universal_agent"
+ALLOWLIST_FILE = REPO_ROOT / "tests" / "unit" / "task_observability_coverage_allowlist.txt"
+
+# Call expressions that count as "spawning a subprocess."
+SUBPROCESS_CALLS = {
+    "subprocess": {"run", "call", "check_call", "check_output", "Popen"},
+    "sp": {"run", "call", "check_call", "check_output", "Popen"},  # common alias
+    "asyncio": {"create_subprocess_exec", "create_subprocess_shell"},
+    "os": {"system", "popen"},
+}
+
+# Imports that signal "this file is wired into the observability protocol."
+COMPLIANT_IMPORTS = {
+    ("universal_agent.services.worker_exit_classifier", "classify_worker_exit"),
+    ("universal_agent.services.worker_exit_classifier", "WorkerExit"),
+    ("universal_agent.services.worker_exit_classifier", "park_task_for_protocol_violation"),
+    ("universal_agent.task_hub", "record_worker_pid"),
+    ("universal_agent.task_hub", "resolve_max_runtime_seconds"),
+}
+
+
+def _iter_src_files() -> Iterable[pathlib.Path]:
+    for path in SRC_ROOT.rglob("*.py"):
+        # Skip __pycache__ etc.
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def _file_has_subprocess_call(tree: ast.AST) -> bool:
+    """Walk the AST for any Call node whose attribute chain matches SUBPROCESS_CALLS."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+                module = func.value.id
+                attr = func.attr
+                if module in SUBPROCESS_CALLS and attr in SUBPROCESS_CALLS[module]:
+                    return True
+            # Also catch directly-imported names like `Popen(...)` after
+            # `from subprocess import Popen`.
+            if isinstance(func, ast.Name):
+                if func.id in {"run", "Popen", "call", "check_call", "check_output", "create_subprocess_exec", "create_subprocess_shell"}:
+                    # Could be a false-positive (different `run` function in scope).
+                    # Conservative: include for now; allowlist absorbs noise.
+                    return True
+    return False
+
+
+def _file_imports_compliant_helper(tree: ast.AST) -> bool:
+    """Detect imports from worker_exit_classifier or the task_hub observability helpers."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                if (module, alias.name) in COMPLIANT_IMPORTS:
+                    return True
+    return False
+
+
+def _load_allowlist() -> set[str]:
+    if not ALLOWLIST_FILE.exists():
+        return set()
+    out: set[str] = set()
+    for line in ALLOWLIST_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            out.add(line)
+    return out
+
+
+def test_subprocess_spawns_use_observability_protocol():
+    """Every file in src/universal_agent/ that spawns a subprocess must
+    either import from worker_exit_classifier (implicit protocol use) or
+    be listed in the allowlist. New violations should fix the spawn site
+    rather than add to the allowlist."""
+    allowlist = _load_allowlist()
+    violations: list[str] = []
+    stale_allowlist: list[str] = []
+
+    actual_violating: set[str] = set()
+    for path in _iter_src_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        if not _file_has_subprocess_call(tree):
+            continue
+        if _file_imports_compliant_helper(tree):
+            continue
+        rel = str(path.relative_to(REPO_ROOT))
+        actual_violating.add(rel)
+        if rel not in allowlist:
+            violations.append(rel)
+
+    for rel in sorted(allowlist):
+        if rel not in actual_violating:
+            stale_allowlist.append(rel)
+
+    # Stale entries are a soft warning (printed for visibility) but don't fail.
+    if stale_allowlist:
+        print("\nAllowlist entries no longer needed (file is now compliant):")
+        for entry in stale_allowlist:
+            print(f"  - {entry}")
+
+    assert not violations, (
+        "The following files spawn subprocesses without importing the Task Hub "
+        "Observability Protocol helpers. Wire them via "
+        "`services.worker_exit_classifier` or add them to "
+        f"{ALLOWLIST_FILE.relative_to(REPO_ROOT)} with justification.\n"
+        "See docs/03_Operations/108_Task_Hub_Observability_Protocol.md for "
+        "the protocol rules.\n\n"
+        + "\n".join(f"  - {v}" for v in sorted(violations))
+    )
+```
+
+### Allowlist file: `tests/unit/task_observability_coverage_allowlist.txt`
+
+Initial contents — computed at implementation time by running the AST walker once and inspecting the output. The plan target is **as few entries as possible** — every entry is a known coverage gap.
+
+### Verification
+
+Two-stage local verification:
+
+1. **Baseline:** with the allowlist set to the empty set, run the test and capture every file it flags. Inspect each one — for each:
+   - If the file is actually wired (imports the helpers) but a different name shadowed the AST detection: investigate; fix the detection (likely a missed alias) and re-run.
+   - If the file is genuinely a coverage gap: add it to the allowlist with a comment explaining why it's allowed today.
+2. **Re-run:** with the final allowlist, the test must pass.
+
+Then `uv run pytest tests/unit/test_task_observability_coverage.py -x -q --no-header` should pass cleanly.
+
+---
+
+## Files touched
+
+- `tests/unit/test_task_observability_coverage.py` — new file, ~150 LOC including the AST walker + assertion.
+- `tests/unit/task_observability_coverage_allowlist.txt` — new file, initial allowlist + header comment.
+- `docs/03_Operations/108_Task_Hub_Observability_Protocol.md` — add a section "Enforcement" referencing the new test + allowlist.
+- `docs/Documentation_Status.md` — append Ship 5 entry to rolling log.
+
+Estimated total LOC: ~200 (test + allowlist + doc additions).
+
+---
+
+## Branch / commit / ship
+
+- **Branch:** `claude/hermes-ship-5-observability-lint-guard`
+- **Commit message:**
+
+```
+feat(hermes-f-enforce): Task Hub Observability Protocol lint guard
+
+Ratchets enforcement of the protocol shipped in Ship 4. CI now fails
+on any new subprocess spawn in src/universal_agent/ that doesn't
+import from worker_exit_classifier or appear on an explicit allowlist.
+
+* New tests/unit/test_task_observability_coverage.py — AST-walks
+  src/universal_agent/ for asyncio.create_subprocess_exec /
+  subprocess.run|call|check_call|check_output|Popen / os.system / os.popen
+  calls; for each file with such a call, verifies it imports
+  classify_worker_exit / WorkerExit / park_task_for_protocol_violation
+  from services.worker_exit_classifier OR record_worker_pid /
+  resolve_max_runtime_seconds from task_hub. Files violating both
+  conditions must be on the allowlist.
+* New tests/unit/task_observability_coverage_allowlist.txt — initial
+  set of known coverage gaps. Each entry justified inline. Entries
+  should shrink over time as gaps are wired.
+* docs/03_Operations/108_Task_Hub_Observability_Protocol.md gains
+  an "Enforcement" section.
+
+Ratchet semantics: new violations fail; stale allowlist entries warn
+but don't fail (avoids CI flake when a legacy site gets wired).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+- **PR:** standard PAT-based auto-merge chain.
+- **Post-merge verification:** none beyond CI green — the guard runs as part of PR-Validate, so once it ships, every subsequent PR is checked.
+
+---
+
+## Open questions / decisions baked in
+
+| Decision | Why |
+|---|---|
+| Ratchet (allowlist of existing violations) vs strict (everything must comply on day 1) | Strict requires a backfill PR for every existing subprocess site; ratchet ships immediately and improves over time. Lower friction, same long-run outcome. |
+| AST walk vs grep | AST is more precise; grep would have false positives (e.g. comments mentioning `subprocess.run`). Slight implementation cost worth it. |
+| Run as part of pytest tests/unit | Already part of pr-validate gate. No extra workflow needed. |
+| Stale allowlist entries warn, don't fail | If a contributor wires a site and the file becomes compliant, we don't want CI to fail on the same PR demanding allowlist removal. Warn → operator can clean up in a follow-up. |
+| Check imports at file level, not call-site level | Too noisy to demand every spawn call within a file proves it uses the helper. File-level check is the right granularity. |
+| Don't lint `tests/` or `scripts/` | Test fixtures legitimately spawn subprocesses; scripts are not async task units. |
+| Detect direct imports like `from subprocess import Popen` | Yes — false positives caught by allowlist. |
+
+---
+
+## Execution sequence (when resuming after compaction)
+
+1. Verify Ship 4 has shipped: `gh pr list --state merged --search "feat(hermes-f-final)" --limit 5` should show the protocol-doc PR merged. If not, ship Ship 4 first.
+2. Branch off latest `origin/main`.
+3. Implement the test file. Run it with an empty allowlist to compute the initial violation set.
+4. Inspect each violation — wire it (preferred) OR add it to the allowlist with explicit comment justification.
+5. Re-run test → must pass.
+6. Run `uv run pytest tests/unit/test_task_observability_coverage.py -x -q --no-header` and the broader observability test suite (same suite from Ship 4 plan) — all must pass.
+7. Update `108_Task_Hub_Observability_Protocol.md` with the Enforcement section.
+8. Commit with the message template above; PR; PAT-merge chain handles deploy.
+9. After merge: confirm next un-related PR validates against the new guard (look for the test in the PR-Validate output of any subsequent PR).

--- a/docs/reports/hermes-ship-6-simone-prompt-addendum-plan.md
+++ b/docs/reports/hermes-ship-6-simone-prompt-addendum-plan.md
@@ -1,0 +1,249 @@
+# Hermes Ship 6 — Simone Prompt Addendum for Verb Tools: Detailed Implementation Plan
+
+**Created:** 2026-05-11 PM
+**Sequencing:** Can ship in parallel with Ship 4 or 5; no code dependencies. Pure prompt content + minimal test.
+**Purpose:** Give Simone explicit, structured guidance on when to call `task_re_evaluate` vs `task_request_revision` vs `task_redirect_to` vs simply signing off. The verb tools shipped in PR #234 are registered and discoverable, but Simone's heartbeat directive doesn't currently teach her _how to choose_ between them. Result: she likely uses one consistently (probably `re_evaluate`) instead of the right one for the situation.
+
+This plan is self-contained for compaction-resilience.
+
+---
+
+## The problem
+
+PR #234 (merged) registered three Simone-callable verb tools:
+- `task_re_evaluate(task_id, reason)`
+- `task_redirect_to(task_id, target_vp, reason)`
+- `task_request_revision(task_id, feedback, max_extra_retries=1)`
+
+Each tool has a `description` string in its `@tool` decorator that explains what it does. The Claude Agent SDK passes those descriptions to Simone as part of tool discovery. So technically she has the information.
+
+But: tool descriptions are reference docs, not decision guidance. Simone needs the equivalent of a "playbook" — when looking at a completed Cody mission, _which path should she pick?_
+
+Today she doesn't have that playbook in her system prompt / heartbeat directive. She'll figure something out, but it'll be inconsistent and probably miss the budget-bump semantics of `request_revision` vs `re_evaluate`.
+
+---
+
+## What to add
+
+A new section in Simone's heartbeat directive that contains:
+
+1. A short framing: "When you review a Cody mission outcome, decide which follow-up applies."
+2. A decision table mapping situation → verb.
+3. Concrete examples (the four scenarios from the conversation explanation).
+4. The operator-baked invariant: `re_evaluate` never bumps retry budget; `request_revision` does (by design).
+5. A note that the natural-language `objective` passed to `vp_dispatch_mission` is for INITIAL work; the verbs are for AFTER Cody finishes.
+
+### The exact prompt content
+
+Here's the exact text block to insert. It's tuned for Simone (her tone is operator-style, terse, action-oriented).
+
+```markdown
+## Reviewing Cody's completed missions
+
+When Cody (vp.coder.primary) completes a mission, your job is to judge the
+work product and decide if it's done or if it needs follow-up. Use this
+decision tree:
+
+**Did Cody nail it?**
+→ No action. Task stays `completed`. Move on.
+
+**Wrong output, but you can articulate exactly what to fix?**
+→ Call `task_request_revision(task_id, feedback="...", max_extra_retries=1)`.
+   The `feedback` is operator-style guidance Cody reads verbatim on his
+   next claim. Bumps retry budget by 1 so he can actually attempt the
+   revision without immediately hitting the consecutive-failure limit.
+   Example: feedback="The column is there but the header should be
+   'Output' with a capital O. Also add a footer row with the column total."
+
+**Wrong output, but you can't pinpoint what's wrong?**
+→ Call `task_re_evaluate(task_id, reason="...")`.
+   This attaches the full prior-run history (errors, summaries, side
+   effects) to the task so Cody sees the evidence on his next attempt
+   and can figure it out. Does NOT bump retry budget — operates within
+   his existing failure-count limit. Use when output looks off but
+   you're not sure why (numbers don't add up, completion claim looks
+   unverified, file written but content suspicious).
+   Example: reason="The output column shows 0 for several days I know
+   had transactions. Possibly reading from the wrong sheet?"
+
+**Wrong agent, someone else should try?**
+→ Call `task_redirect_to(task_id, target_vp="vp.general.primary", reason="...")`.
+   Clears Cody-specific retry counters; sets `metadata.preferred_vp` so
+   the next dispatch routes to Atlas (or other named VP). Use when the
+   task isn't a coding problem in the first place, or when Cody's
+   toolchain is the wrong shape (e.g. needs database access he doesn't
+   have configured, or requires a generalist research lane that fits
+   Atlas better).
+   Example: target_vp="vp.general.primary", reason="This needs a
+   research summary of the regulatory landscape, not code changes."
+
+### Key invariants you should know
+
+- `re_evaluate` does NOT bump retry budget. If a task has already hit
+  its `max_retries` ceiling, `re_evaluate` will reset state but the
+  next attempt-failure may immediately re-park. Use `request_revision`
+  when you need to extend the budget.
+- The natural-language `objective` you pass to `vp_dispatch_mission` is
+  how you communicate the INITIAL work to Cody. The three verbs above
+  are exclusively for after-the-fact follow-up.
+- Sign-off is the default. Only invoke a follow-up verb when you've
+  actually identified a problem with the work product. Don't reflexively
+  re-evaluate every completed task.
+```
+
+Total: ~50 lines of markdown.
+
+---
+
+## Where to put it
+
+### Discovery: where is Simone's heartbeat directive assembled?
+
+The system has multiple prompts. Simone's primary directive lives in `memory/HEARTBEAT.md` (referenced in CLAUDE.md and other docs as the source of her cycle directive).
+
+Verification path during implementation:
+1. `grep -rn "memory/HEARTBEAT" src/universal_agent/ --include="*.py"` to find where it's read.
+2. Inspect the heartbeat assembly path — likely `src/universal_agent/heartbeat_service.py` or `src/universal_agent/services/heartbeat_*` — to confirm where `HEARTBEAT.md` is loaded and whether any other prompt files are concatenated alongside.
+3. If `HEARTBEAT.md` is the canonical Simone directive, insert the addendum there.
+4. If the directive is split across multiple files, find the one that contains task-action guidance and add the section there.
+
+The user's existing reference: CLAUDE.md says "Simone's directive file is `memory/HEARTBEAT.md`." Trust that until proven otherwise.
+
+### Placement within HEARTBEAT.md
+
+Find an existing section about task handling or Cody coordination. Insert the new "Reviewing Cody's completed missions" section there. If no logical place exists, add it as a new top-level section near the end of the file, before any closing notes.
+
+---
+
+## Files touched
+
+- `memory/HEARTBEAT.md` — primary target, ~50 lines added.
+- `tests/unit/test_simone_prompt_addendum.py` — new test file, ~30 LOC. Verifies the assembled heartbeat directive contains the addendum text. (Cheap regression guard against accidental deletion.)
+- `docs/Documentation_Status.md` — append entry.
+
+Estimated total LOC: ~85 (50 prompt text + 30 test + 5 doc).
+
+---
+
+## Tests
+
+### `tests/unit/test_simone_prompt_addendum.py`
+
+Minimal regression guard:
+
+```python
+"""Hermes Ship 6 — Simone prompt addendum regression guard.
+
+Verifies the verb-tool decision guidance is present in the assembled
+Simone heartbeat directive. Without this guidance Simone has no way to
+choose between task_re_evaluate / task_request_revision / task_redirect_to
+beyond the tool descriptions, and tends to use one inconsistently.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+HEARTBEAT_PATH = REPO_ROOT / "memory" / "HEARTBEAT.md"
+
+
+def test_heartbeat_directive_contains_verb_decision_tree():
+    """The Cody-mission review decision tree must be present in HEARTBEAT.md."""
+    assert HEARTBEAT_PATH.exists(), f"missing: {HEARTBEAT_PATH}"
+    text = HEARTBEAT_PATH.read_text(encoding="utf-8")
+    # Sentinel markers that must be present (text changes are fine; semantic
+    # markers stay).
+    required_markers = [
+        "Reviewing Cody's completed missions",  # section heading
+        "task_request_revision",                # all three verbs referenced
+        "task_re_evaluate",
+        "task_redirect_to",
+        "does NOT bump retry budget",          # the operator-baked invariant
+    ]
+    missing = [m for m in required_markers if m not in text]
+    assert not missing, (
+        "Simone heartbeat directive is missing required verb-tool guidance markers: "
+        f"{missing}. See docs/reports/hermes-ship-6-simone-prompt-addendum-plan.md"
+    )
+```
+
+This test is intentionally minimal — it doesn't validate prompt _quality_, just that the guidance hasn't been accidentally deleted.
+
+---
+
+## Branch / commit / ship
+
+- **Branch:** `claude/hermes-ship-6-simone-prompt-addendum`
+- **Commit message:**
+
+```
+docs(simone): verb-tool decision guidance for Cody mission follow-up
+
+Adds explicit playbook content to Simone's heartbeat directive that
+teaches her when to call which of the three follow-up verb tools
+(task_re_evaluate / task_request_revision / task_redirect_to) shipped
+in PR #234.
+
+Before: Simone had the tool descriptions from @tool decorators but no
+decision-tree guidance. She'd figure out which verb to use case-by-case
+and inconsistently (probably defaulting to re_evaluate for everything).
+
+After: ~50 lines in memory/HEARTBEAT.md covering:
+- Sign-off is the default (only invoke a follow-up when there's a
+  real identified problem).
+- request_revision: specific feedback + budget bump.
+- re_evaluate: vague suspicion + prior-run evidence, no budget bump.
+- redirect_to: wrong agent, give it to someone else.
+- The operator-baked invariant: only request_revision bumps budget.
+- The natural-language `objective` vs verb-tool distinction.
+
+Includes a small regression guard test
+(tests/unit/test_simone_prompt_addendum.py) that asserts the section
+heading and three verb names + the budget invariant are present in
+HEARTBEAT.md. Doesn't validate prompt quality — just protects against
+accidental deletion.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+- **PR:** standard PAT-based auto-merge chain.
+- **Post-merge verification:** open a wedged task in production, watch Simone's next heartbeat decision. She should pick the right verb (or sign off) based on the specific failure mode. Qualitative observation; no hard metric.
+
+---
+
+## Open questions / decisions baked in
+
+| Decision | Why |
+|---|---|
+| Insert directly into `memory/HEARTBEAT.md` rather than a separate file | Single-source-of-truth for Simone's directives. Multiple files would fragment her context. |
+| 50 lines of guidance, not 500 | Operator tone is terse. More prompt content = more tokens = slower / more expensive heartbeats. The decision tree is the load-bearing part. |
+| Regression test guards markers, not full text | Allows future refinement of prompt phrasing without breaking the test. We just want to catch accidental deletion. |
+| No new docs for this — the prompt is the artifact | Adding doc files for prompt content creates drift between doc and prompt. The HEARTBEAT.md IS the documentation. |
+| Don't add guidance for `task_hub_task_action` (the older lifecycle-verb tool) | That tool has different semantics (claim/complete/block/etc.) and its guidance is separate. Don't bundle. |
+
+---
+
+## Coverage gap this does NOT close
+
+This addendum gives Simone guidance for the THREE verb tools registered in PR #234. It does NOT teach her:
+
+- When to use `vp_dispatch_mission` to send a NEW task to Cody (the initial-dispatch path). That guidance, if missing, would be a separate follow-up.
+- How to evaluate Cody's natural-language output quality (subjective, hard to encode in a prompt). Today she relies on her own judgment + the `task_hub_runs` evidence.
+- Cody-mode toggle decisions (anthropic vs zai). The default is now anthropic (PR #235); operator toggles via dashboard if cost is a concern. Simone doesn't need to think about this normally.
+
+If those gaps surface in production observation, they're separate follow-up plans, not bundled here.
+
+---
+
+## Execution sequence (when resuming after compaction)
+
+1. Confirm PR #234 (Simone-callable verb tools) is merged: `gh pr view 234 --json state` → MERGED.
+2. Locate `memory/HEARTBEAT.md` — confirm it exists at `/home/kjdragan/lrepos/universal_agent/memory/HEARTBEAT.md`.
+3. Read the file to understand its current structure and where to insert the new section.
+4. Branch off `origin/main`: `git checkout -b claude/hermes-ship-6-simone-prompt-addendum`.
+5. Insert the prompt content from this plan into `memory/HEARTBEAT.md` (the exact text block above is the source of truth — paste it in).
+6. Create `tests/unit/test_simone_prompt_addendum.py` with the regression-guard content.
+7. Run: `uv run pytest tests/unit/test_simone_prompt_addendum.py -x -q --no-header` — must pass.
+8. Commit with the template above; PR; PAT-merge chain handles deploy.
+9. Post-merge: heartbeat picks up the new directive on next tick (no service restart needed since `HEARTBEAT.md` is read every cycle). Operator observation over the next few days will confirm whether Simone is picking better verbs.


### PR DESCRIPTION
## Summary

Three self-contained plan documents for the remaining Hermes work. Locking them in source control before context window compaction so the next session can resume from the plans as the operational source of truth.

| Plan | Scope |
|---|---|
| **Ship 4** — `docs/reports/hermes-ship-4-task-observability-protocol-plan.md` | Wire 6 remaining cron sources (4 housekeeping flipped + 2 LLM-path wired) + new canonical \`docs/03_Operations/108_Task_Hub_Observability_Protocol.md\` doc + CLAUDE.md row + indexes |
| **Ship 5** — \`docs/reports/hermes-ship-5-lint-guard-plan.md\` | CI lint guard (AST walker + allowlist ratchet) enforcing the protocol on every new PR |
| **Ship 6** — \`docs/reports/hermes-ship-6-simone-prompt-addendum-plan.md\` | Verb-tool decision-tree guidance in \`memory/HEARTBEAT.md\` + regression-guard test |

## Why this PR

Operator is about to compact the context window. The plans need to survive in source control so the next session can execute from them without re-reading the whole conversation.

Each plan is self-contained:
- File paths and exact identifiers (table names, helper signatures, branch names, commit-message templates)
- Production state snapshot (SHA \`ca50b563\` + everything already live)
- Test patterns + verification gates
- Open decisions baked in with rationale
- Execution sequence for compaction-resilient resume

## Sequencing

- Ship 4 must precede Ship 5 (Ship 5's lint guard references the 108 doc Ship 4 creates).
- Ship 6 has no dependencies; can ship in parallel with Ship 4 or 5.

## Test plan

- [x] py_compile clean (markdown only, no Python)
- [x] Plan files render correctly
- [ ] CI PR-Validate (markdown lint will trip if any)

🤖 Generated with [Claude Code](https://claude.com/claude-code)