### PR TITLE
fix(ci): ci-failure-issue.yml — pass --repo so gh stops shelling to git

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -57,6 +57,15 @@ jobs:
       - name: Open issue for failed run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # 2026-05-11 fix: `gh issue list` / `gh issue create` auto-detect
+          # the repo by running `git rev-parse`, which fails on a
+          # checkout-less runner with `fatal: not a git repository`. Pass
+          # --repo explicitly so the CLI doesn't shell out to git. This
+          # workflow has run 64 times and successfully filed 0 issues
+          # because of this bug — every failure since the watcher was
+          # introduced has been silent. Issue creation now works without
+          # an actions/checkout dependency.
+          REPO: ${{ github.repository }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_ID: ${{ github.event.workflow_run.id }}
@@ -70,6 +79,7 @@ jobs:
 
           # Dedup: don't re-file if an issue already exists for this exact run.
           EXISTING=$(gh issue list \
+            --repo "${REPO}" \
             --label ci-failure \
             --state open \
             --search "in:title \"${RUN_ID}\"" \
@@ -91,6 +101,7 @@ jobs:
           } > /tmp/issue-body.md
 
           gh issue create \
+            --repo "${REPO}" \
             --title "${TITLE} — run_id=${RUN_ID}" \
             --body-file /tmp/issue-body.md \
             --label ci-failure


### PR DESCRIPTION
## Summary

The CI Failure Issue Filer has been broken since introduction. It's run **64 times** and successfully filed **0 issues** — every CI failure has been silent.

## Root cause

From the failed run log at https://github.com/Kjdragan/universal_agent/actions/runs/25693460068:

\`\`\`
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1.
\`\`\`

\`gh issue list\` and \`gh issue create\` auto-detect the target repo by running \`git rev-parse\`. The filer workflow has no \`actions/checkout\` step, so there's no .git on the runner. Both gh commands crash. The label-create step (step 2) survives because it has \`--repo\` set; step 3 didn't.

## Today's silenced failures

This PR was prompted by the operator noticing the noise of "skipped" CI Failure Issue Filer runs and asking "are we swallowing errors?" Investigation showed:

- 62 skipped (correct — underlying workflow succeeded)
- 2 failure (these are the bug — couldn't file the issue)
- 0 success — meaning the filer has NEVER filed an issue, ever

Today's 3 concurrent Deploy git-index.lock races (SHA \`a51f1571\`) and 1 Dependabot Updates failure (SHA \`5fe4b5d7\`) all went unobserved by the auto-filer.

## Fix

Two-line edit — add \`REPO: \${{ github.repository }}\` to step 3's env block, and pass \`--repo \"\${REPO}\"\` to both gh commands. No \`actions/checkout\` dependency needed (which would slow the workflow + cost cycles).

## Test plan

- [x] py_compile / ruff N/A (YAML only)
- [ ] CI PR-Validate
- [ ] Live verification: next genuine CI failure on main after merge should auto-file an issue with label \`ci-failure\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)