### PR TITLE
docs(simone): verb-tool decision guidance for Cody mission follow-up

### DIFF
--- a/memory/HEARTBEAT.md
+++ b/memory/HEARTBEAT.md
@@ -88,6 +88,57 @@ This file controls proactive heartbeat behavior. Keep items concrete and actiona
   - **If entity exists**: invoke the `cody-scaffold-builder` skill with the matched entity slug. Then refine the generated `BRIEF.md` / `ACCEPTANCE.md` / `business_relevance.md` placeholders with real prose synthesis (do NOT just delete `_(Simone: ...)_` markers — substitute substantive content). Then invoke `cody-task-dispatcher` to enqueue the `cody_demo_task`. Finally, mark the original `cody_scaffold_request` row `status=completed` with a Task Hub comment linking to the workspace and the new `cody_demo_task:<id>`.
   - **If entity is missing**: do NOT speculate or invent a stub. Mark the `cody_scaffold_request` row `status=blocked` with reason `vault_entity_missing:<expected_slug>` and surface a one-line note in the heartbeat response so Kevin can decide whether to backfill the entity or defer the demo. Do not loop on it.
   - **Safety**: only use the deterministic `cody-scaffold-builder` Python entry point. Never bypass it to write workspace files directly. The skill enforces the vanilla-settings safety net (`/opt/ua_demos/<id>/.claude/settings.json` integrity).
+## Reviewing Cody's completed missions
+
+When Cody (vp.coder.primary) completes a mission, your job is to judge the
+work product and decide if it's done or if it needs follow-up. Use this
+decision tree:
+
+**Did Cody nail it?**
+→ No action. Task stays `completed`. Move on.
+
+**Wrong output, but you can articulate exactly what to fix?**
+→ Call `task_request_revision(task_id, feedback="...", max_extra_retries=1)`.
+   The `feedback` is operator-style guidance Cody reads verbatim on his
+   next claim. Bumps retry budget by 1 so he can actually attempt the
+   revision without immediately hitting the consecutive-failure limit.
+   Example: feedback="The column is there but the header should be
+   'Output' with a capital O. Also add a footer row with the column total."
+
+**Wrong output, but you can't pinpoint what's wrong?**
+→ Call `task_re_evaluate(task_id, reason="...")`.
+   This attaches the full prior-run history (errors, summaries, side
+   effects) to the task so Cody sees the evidence on his next attempt
+   and can figure it out. Does NOT bump retry budget — operates within
+   his existing failure-count limit. Use when output looks off but
+   you're not sure why (numbers don't add up, completion claim looks
+   unverified, file written but content suspicious).
+   Example: reason="The output column shows 0 for several days I know
+   had transactions. Possibly reading from the wrong sheet?"
+
+**Wrong agent, someone else should try?**
+→ Call `task_redirect_to(task_id, target_vp="vp.general.primary", reason="...")`.
+   Clears Cody-specific retry counters; sets `metadata.preferred_vp` so
+   the next dispatch routes to Atlas (or other named VP). Use when the
+   task isn't a coding problem in the first place, or when Cody's
+   toolchain is the wrong shape (e.g. needs database access he doesn't
+   have configured, or requires a generalist research lane that fits
+   Atlas better).
+   Example: target_vp="vp.general.primary", reason="This needs a
+   research summary of the regulatory landscape, not code changes."
+
+### Key invariants you should know
+
+- `task_re_evaluate` does NOT bump retry budget. If a task has already hit
+  its `max_retries` ceiling, `re_evaluate` will reset state but the
+  next attempt-failure may immediately re-park. Use `task_request_revision`
+  when you need to extend the budget.
+- The natural-language `objective` you pass to `vp_dispatch_mission` is
+  how you communicate the INITIAL work to Cody. The three verbs above
+  are exclusively for after-the-fact follow-up.
+- Sign-off is the default. Only invoke a follow-up verb when you've
+  actually identified a problem with the work product. Don't reflexively
+  re-evaluate every completed task.
 ## Novelty Policy
 - Do NOT repeat an investigation topic that appears in the RECENT INVESTIGATIONS list provided in the prompt.
 - Each heartbeat cycle should advance a DIFFERENT item from the Active Monitors list or explore a genuinely new angle.

--- a/tests/unit/test_simone_prompt_addendum.py
+++ b/tests/unit/test_simone_prompt_addendum.py
@@ -1,0 +1,85 @@
+"""Hermes Ship 6 — Simone prompt addendum regression guard.
+
+Verifies the verb-tool decision guidance is present in the assembled
+Simone heartbeat directive at ``memory/HEARTBEAT.md``.
+
+Without this guidance Simone has no decision-tree for choosing between
+``task_re_evaluate`` / ``task_request_revision`` / ``task_redirect_to``
+(beyond the tool descriptions on the ``@tool`` decorators), and tends
+to use one verb inconsistently across mission outcomes.
+
+This test is intentionally minimal — it pins SEMANTIC markers, not
+exact phrasing, so future refinement of the prompt language won't
+require updating the test. Its sole purpose is to catch accidental
+deletion of the guidance section.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+HEARTBEAT_PATH = REPO_ROOT / "memory" / "HEARTBEAT.md"
+
+
+def test_heartbeat_directive_contains_verb_decision_tree() -> None:
+    """The Cody-mission review decision tree must be present in HEARTBEAT.md.
+
+    Markers asserted:
+      * Section heading exists.
+      * All three verb names are referenced.
+      * The operator-baked budget invariant is present (re_evaluate
+        does not bump retry budget; request_revision does).
+    """
+    assert HEARTBEAT_PATH.exists(), f"missing: {HEARTBEAT_PATH}"
+    text = HEARTBEAT_PATH.read_text(encoding="utf-8")
+    required_markers = [
+        "Reviewing Cody's completed missions",
+        "task_request_revision",
+        "task_re_evaluate",
+        "task_redirect_to",
+        "does NOT bump retry budget",
+    ]
+    missing = [m for m in required_markers if m not in text]
+    assert not missing, (
+        "Simone heartbeat directive is missing required verb-tool guidance "
+        f"markers: {missing}. See "
+        "docs/reports/hermes-ship-6-simone-prompt-addendum-plan.md"
+    )
+
+
+def test_heartbeat_directive_distinguishes_initial_dispatch_from_followup() -> None:
+    """Beyond just naming the three verbs, Simone must understand the
+    distinction between ``vp_dispatch_mission`` (initial work) and the
+    three follow-up verbs (after Cody finishes).  Pin that explicit
+    distinction so a future edit doesn't collapse them."""
+    text = HEARTBEAT_PATH.read_text(encoding="utf-8")
+    # Both names should appear together (in the same paragraph or
+    # neighborhood). We check both present + that the distinction
+    # phrase ("INITIAL" / "after-the-fact" / similar) is there too.
+    assert "vp_dispatch_mission" in text, (
+        "HEARTBEAT.md no longer references vp_dispatch_mission alongside "
+        "the follow-up verbs — Simone needs the initial-vs-followup "
+        "distinction to choose correctly."
+    )
+    assert "INITIAL" in text or "after-the-fact" in text or "follow-up" in text, (
+        "HEARTBEAT.md no longer makes the initial-dispatch vs follow-up "
+        "distinction explicit; without it Simone may treat verbs as "
+        "interchangeable with vp_dispatch_mission."
+    )
+
+
+def test_heartbeat_directive_marks_sign_off_as_default() -> None:
+    """Catch: Simone must understand that doing NOTHING is the default
+    when Cody nails it. Without this, she may reflexively invoke a
+    follow-up verb on every completed task and burn budget on noise."""
+    text = HEARTBEAT_PATH.read_text(encoding="utf-8")
+    # The exact phrase isn't load-bearing; either "No action" or
+    # "Sign-off is the default" works. Pin one marker.
+    markers = ["Sign-off is the default", "No action", "stays `completed`"]
+    found = [m for m in markers if m in text]
+    assert found, (
+        "HEARTBEAT.md no longer marks 'no follow-up needed' as the "
+        "default Cody-review outcome. Simone needs this to avoid "
+        f"reflexively invoking verbs. Expected one of: {markers}"
+    )


### PR DESCRIPTION
## Summary

Teaches Simone when to call which of the three follow-up verb tools (`task_re_evaluate` / `task_request_revision` / `task_redirect_to`) shipped in PR #234. Before this PR she had the tool descriptions from `@tool` decorators but no decision-tree guidance, so she'd default to one verb (probably `re_evaluate`) for every situation.

## What lands in `memory/HEARTBEAT.md`

~50 lines of decision tree:

- **Did Cody nail it?** No action — task stays `completed`. Move on.
- **Wrong output, but can articulate the fix?** `task_request_revision` (specific feedback, bumps retry budget).
- **Wrong output, can't pinpoint why?** `task_re_evaluate` (prior-run evidence, no budget bump).
- **Wrong agent?** `task_redirect_to` (clears Cody counters, sets `metadata.preferred_vp`).

Plus the operator-baked invariant (`re_evaluate` does NOT bump budget; only `request_revision` does) and the initial-dispatch (`vp_dispatch_mission`) vs follow-up-verb distinction so Simone doesn't conflate them.

## Tests

3 regression guards in `tests/unit/test_simone_prompt_addendum.py`. They pin semantic markers (section heading, all three verb names, budget invariant, dispatch-vs-followup distinction, sign-off-is-default) without validating prompt phrasing — future prompt refinement is unblocked.

## Sequencing

No code dependencies. Can merge in parallel with #244 / #245.

## Post-merge

Heartbeat reads `HEARTBEAT.md` every cycle, no service restart needed. Operator observation over the next few days will confirm Simone is picking different verbs based on the specific failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)