### PR TITLE
feat(infisical): drop infisical-python SDK, talk to REST directly

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -57,31 +57,23 @@ jobs:
           # to identify only the .py files this PR touches.
           fetch-depth: 0
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.13
         uses: actions/setup-python@v6
         with:
-          # 3.12, not 3.13 — `infisical-python==2.3.5` only ships
-          # cp312 wheels for `manylinux_2_28_x86_64`, no cp313 wheel
-          # exists, and the source build needs PyO3 ≥ 0.22 (it pins
-          # 0.20.3, which doesn't support 3.13). This bit us on
-          # PR #153, the first PR to exercise this workflow end-to-end.
-          # Production runtime is 3.13 (see `.python-version` and
-          # scripts/deploy_validate_runtime.sh) — the deploy host has
-          # the cp313 source-built wheel cached in ~/.cache/uv/sdists-v9/
-          # so it bypasses the cp313 wheel gap. CI runners don't have
-          # that cache, hence we stay on 3.12 here for the lint/syntax
-          # gate only.
-          python-version: '3.12'
+          # Matches `.python-version` and production. The cp313 band-aid
+          # that lived here (cp312 + `--python 3.12` pins on every uv
+          # call) existed only because `infisical-python==2.3.5` had no
+          # cp313 manylinux wheel. That dep was dropped in the same PR
+          # as this bump — UA talks to Infisical via httpx against the
+          # REST API now (see `src/universal_agent/infisical_loader.py`),
+          # so the whole pyproject resolves cleanly on cp313.
+          python-version: '3.13'
 
       - name: Install uv
         run: pip install --quiet uv
 
       - name: Install project dependencies
-        # --python 3.12 overrides `.python-version` (3.13). Without this
-        # uv would try to fetch the cp313 infisical-python wheel (none
-        # exists) and then build from source, which fails on a vanilla
-        # GH runner. See pr-validate Python comment above.
-        run: uv sync --frozen --no-progress --python 3.12 2>&1 | tail -5
+        run: uv sync --frozen --no-progress 2>&1 | tail -5
 
       - name: Identify changed Python files
         id: changed
@@ -109,7 +101,7 @@ jobs:
           set -e
           for f in ${{ steps.changed.outputs.files }}; do
             echo "  py_compile $f"
-            uv run --python 3.12 python -c "compile(open('$f').read(), '$f', 'exec')"
+            uv run python -c "compile(open('$f').read(), '$f', 'exec')"
           done
           echo "All changed .py files compile cleanly."
 
@@ -146,7 +138,7 @@ jobs:
           # globals() patterns and pre-existing F821 bugs in
           # gateway_server.py carry surgical `# noqa: F821` annotations
           # with TODO comments at their sites instead.
-          uv run --python 3.12 ruff check \
+          uv run ruff check \
             --select E9,F \
             --ignore E402,F401,F541,F811,F841 \
             --no-cache \
@@ -156,7 +148,7 @@ jobs:
         run: |
           # tests/unit is the fast subset. Full suite runs nightly.
           if [ -d tests/unit ]; then
-            uv run --python 3.12 pytest tests/unit -x -q --no-header 2>&1 | tail -50
+            uv run pytest tests/unit -x -q --no-header 2>&1 | tail -50
           else
             echo "No tests/unit directory; skipping."
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,12 @@ dependencies = [
     "email-reply-parser>=0.5.12",
     "chardet>=5.2.0,<6",
     "typer>=0.12",
-    "infisical-python==2.3.5",
+    # Removed 2026-05-12: replaced with the pure-Python REST path already
+    # in src/universal_agent/infisical_loader.py. Upstream infisical-python
+    # ships no cp313 manylinux wheel on any version and the PyO3 0.20.3 cap
+    # blocks a clean 3.13 source build; 2.3.6 also regressed (lost cp312
+    # manylinux x86_64). httpx already covers the full universal-auth +
+    # /api/v3/secrets/raw surface we use.
     "pyjwt>=2.12.1",
     "langsmith[claude-agent-sdk,otel]>=0.7.22",
     "crawl4ai-cloud-sdk",

--- a/src/universal_agent/infisical_loader.py
+++ b/src/universal_agent/infisical_loader.py
@@ -182,60 +182,14 @@ def _fetch_infisical_secrets() -> dict[str, str]:
     if missing:
         raise RuntimeError(f"Missing required Infisical settings: {', '.join(missing)}")
 
-    try:
-        from infisical_client import (
-            AuthenticationOptions,
-            ClientSettings,
-            InfisicalClient,
-            ListSecretsOptions,
-            UniversalAuthMethod,
-        )
-    except Exception as exc:
-        logger.warning("Infisical SDK unavailable; falling back to REST bootstrap (%s)", _safe_error(exc))
-        return _fetch_infisical_secrets_via_rest(
-            api_url=api_url,
-            client_id=client_id,
-            client_secret=client_secret,
-            project_id=project_id,
-            environment=environment,
-            secret_path=secret_path,
-        )
-
-    try:
-        client = InfisicalClient(
-            ClientSettings(
-                auth=AuthenticationOptions(
-                    universal_auth=UniversalAuthMethod(
-                        client_id=client_id,
-                        client_secret=client_secret,
-                    )
-                )
-            )
-        )
-        secrets = client.listSecrets(
-            options=ListSecretsOptions(
-                environment=environment,
-                project_id=project_id,
-                path=secret_path,
-            )
-        )
-        out: dict[str, str] = {}
-        for item in secrets:
-            key = str(getattr(item, "secret_key", "")).strip()
-            if not key:
-                continue
-            out[key] = str(getattr(item, "secret_value", "") or "")
-        return out
-    except Exception as exc:
-        logger.warning("Infisical SDK fetch failed; falling back to REST bootstrap (%s)", _safe_error(exc))
-        return _fetch_infisical_secrets_via_rest(
-            api_url=api_url,
-            client_id=client_id,
-            client_secret=client_secret,
-            project_id=project_id,
-            environment=environment,
-            secret_path=secret_path,
-        )
+    return _fetch_infisical_secrets_via_rest(
+        api_url=api_url,
+        client_id=client_id,
+        client_secret=client_secret,
+        project_id=project_id,
+        environment=environment,
+        secret_path=secret_path,
+    )
 
 
 def _upsert_infisical_secret_via_rest(
@@ -319,68 +273,19 @@ def upsert_infisical_secret(key: str, value: str) -> bool:
         return False
 
     try:
-        from infisical_client import (
-            AuthenticationOptions,
-            ClientSettings,
-            CreateSecretOptions,
-            InfisicalClient,
-            UniversalAuthMethod,
-            UpdateSecretOptions,
+        _upsert_infisical_secret_via_rest(
+            api_url=api_url,
+            client_id=client_id,
+            client_secret=client_secret,
+            project_id=project_id,
+            environment=environment,
+            secret_path=secret_path,
+            key=key,
+            value=value,
         )
-
-        client = InfisicalClient(
-            ClientSettings(
-                auth=AuthenticationOptions(
-                    universal_auth=UniversalAuthMethod(
-                        client_id=client_id,
-                        client_secret=client_secret,
-                    )
-                )
-            )
-        )
-        
-        try:
-            client.updateSecret(
-                options=UpdateSecretOptions(
-                    environment=environment,
-                    project_id=project_id,
-                    path=secret_path,
-                    secret_name=key,
-                    secret_value=value,
-                    type="shared",
-                )
-            )
-        except Exception as exc:
-            if "not found" in str(exc).lower() or "404" in str(exc):
-                client.createSecret(
-                    options=CreateSecretOptions(
-                        environment=environment,
-                        project_id=project_id,
-                        path=secret_path,
-                        secret_name=key,
-                        secret_value=value,
-                        type="shared",
-                    )
-                )
-            else:
-                raise
-                
-    except Exception as exc:
-        logger.warning("Infisical SDK upsert failed; falling back to REST bootstrap (%s)", _safe_error(exc))
-        try:
-            _upsert_infisical_secret_via_rest(
-                api_url=api_url,
-                client_id=client_id,
-                client_secret=client_secret,
-                project_id=project_id,
-                environment=environment,
-                secret_path=secret_path,
-                key=key,
-                value=value,
-            )
-        except Exception as rest_exc:
-            logger.error("Infisical REST upsert failed for %s: %s", key, _safe_error(rest_exc))
-            return False
+    except Exception as rest_exc:
+        logger.error("Infisical REST upsert failed for %s: %s", key, _safe_error(rest_exc))
+        return False
 
     # Update current process environment so changes reflect immediately without restart
     os.environ[key] = value

--- a/uv.lock
+++ b/uv.lock
@@ -2334,19 +2334,6 @@ wheels = [
 ]
 
 [[package]]
-name = "infisical-python"
-version = "2.3.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/9f/1a1d144302b761509c71ac9d407d443a039811a78bdc76e5fb9301dff4b9/infisical_python-2.3.5.tar.gz", hash = "sha256:68437d7178c220948166726d6ca8ca544e8e7f9fa960230e0ea9b39ea440a40a", size = 55920, upload-time = "2024-08-19T21:29:12.905Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/b3/214016e624887c6859329da8a905302eaf7266652e30e2d2ffacb172673a/infisical_python-2.3.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:d1d5c4797bee9c83cf34b39b088d32b1302f964973e38642868bf676c334dcae", size = 5171748, upload-time = "2024-08-19T21:28:26Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/58/79f6987d1471866231b3e45a5692a4d9f063abcb2291a8afde32cdf2d1f0/infisical_python-2.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d86c9f6bfc88cc4694e2850da80c82b05c1479995337ba650971752aacc1c0fa", size = 4950698, upload-time = "2024-08-19T21:28:27.865Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/1c/c0f4748c5aa0a05aae28ad8ee3d525d59642b72b6977cfab11491ce01924/infisical_python-2.3.5-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:87f166ce9fee1ac316412a7f019189a6485e93e53a0d29bec4eccece591f0511", size = 5538754, upload-time = "2024-08-19T21:28:29.336Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/d5/76976935a03e9bda5e8c69e2ed7270a0a0c2f4b203fed5ec3da47d98c30f/infisical_python-2.3.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:8d426713143ec49edc77e059059d97bb47f371c56e8de8ab83d60d2d3b7f239f", size = 5559570, upload-time = "2024-08-19T21:28:31.271Z" },
-    { url = "https://files.pythonhosted.org/packages/72/80/5c0e0ebe695689f02d68efbaecb1b76b2eba3d8e5ef87117382452370226/infisical_python-2.3.5-cp312-none-win_amd64.whl", hash = "sha256:f52ca7f6a63150eb0ebf0eda5f350cb3b2519e7a0b4a88f2b74827f72e8cae06", size = 4858223, upload-time = "2024-08-19T21:28:32.836Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6628,7 +6615,6 @@ dependencies = [
     { name = "google-genai" },
     { name = "gradio" },
     { name = "httpx" },
-    { name = "infisical-python" },
     { name = "json-repair" },
     { name = "json5" },
     { name = "lancedb" },
@@ -6723,7 +6709,6 @@ requires-dist = [
     { name = "google-genai", specifier = ">=1.56.0" },
     { name = "gradio", specifier = ">=6.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "infisical-python", specifier = "==2.3.5" },
     { name = "json-repair", specifier = ">=0.55.1" },
     { name = "json5", specifier = ">=0.13.0" },
     { name = "lancedb", specifier = ">=0.27.1" },


### PR DESCRIPTION
## Summary
Drops the `infisical-python==2.3.5` SDK pin and switches UA to call Infisical's REST API directly via the httpx helpers that have always existed in `infisical_loader.py` as the SDK's exception fallback. Unblocks Python 3.13 dev everywhere (desktop, CI, future-proofs the VPS).

## Why now
- **Upstream has no cp313 manylinux x86_64 wheel on any released version** (verified against PyPI JSON for 2.3.5 and 2.3.6).
- **2.3.6 (latest, 2025-04-17) is a regression:** lost the cp312 manylinux x86_64 wheel UA's VPS depends on, dropped the sdist, added only a cp313-Windows wheel.
- The package wraps a Rust core whose PyO3 0.20.3 ceiling caps at Python 3.12; even a 3.13 source build via maturin fails on a vanilla CI runner.
- Production stayed on 3.13 only because the VPS happened to cache a source-built wheel from an earlier deploy. That cache is fragile — `uv cache clean` would re-break prod.
- Desktop dev on Python 3.13 is currently blocked by the same gap (this PR was triggered by `uv run pytest tests/unit/test_simone_chat_tasks.py` failing on a 3.13 sandbox).

## What's in this PR

| File | Change |
|---|---|
| `pyproject.toml` | Remove `"infisical-python==2.3.5"` with rationale comment |
| `uv.lock` | Regenerated; 365 → 364 packages (Rust transitive deps drop too) |
| `src/universal_agent/infisical_loader.py` | Delete both SDK try-blocks; call REST helpers directly. 574 → 479 lines |
| `.github/workflows/pr-validate.yml` | Bump setup-python 3.12 → 3.13; drop `--python 3.12` pins everywhere |

The REST helpers (`_fetch_infisical_secrets_via_rest`, `_upsert_infisical_secret_via_rest`) are unchanged — they already cover universal-auth login → `/api/v3/secrets/raw` and the PATCH-then-POST upsert flow.

## Smoke test (Python 3.13.11 desktop dev)

- `uv lock` cleanly removed `infisical-python v2.3.5`.
- Direct test of the public function with `_fetch_infisical_secrets_via_rest` monkey-patched: `_fetch_infisical_secrets()` calls REST and returns the expected dict.
- `grep -c "from infisical_client" src/universal_agent/infisical_loader.py` returns 0.

## Risk

**Low.** The REST path is the existing fallback — already exercised in production every time the SDK threw. This PR is mostly delete-code, not write-code. Reversible if Infisical's REST API ever changes in a way that's harder to track than the SDK is to upgrade.

## Out of scope

- `CSI_Ingester/development/` (a separate sub-project with its own `pyproject.toml` and venv) still imports `from infisical_client import …` in two files. Out of scope here — that project has its own Python-version target and will need its own migration when it moves to 3.13.
- `scripts/x_oauth2_bootstrap.py:254` is unaffected — it already uses its own REST helper (`scripts/infisical_upsert_secret.py`), not the SDK.

## Test plan
- [x] Local sanity: `uv lock` succeeds on 3.13, smoke import works, no `infisical_client` references remain.
- [ ] PR-Validate runs the full lint+pytest gate against Python 3.13. If it passes, the band-aid removal is validated.
- [ ] After merge, watch Deploy succeed on 3.13 with no `infisical-python` in the lockfile. The VPS will rebuild the venv during sync and skip the (now-removed) infisical-python source build — should make the deploy *faster*.
- [ ] Post-deploy: `curl -sS http://127.0.0.1:8002/api/v1/version` returns the new SHA; gateway can still bootstrap secrets from Infisical (the REST path is what runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)