### PR TITLE
feat(dashboard): release AgentMail quarantine on archive/dismiss verbs

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -23511,6 +23511,89 @@ async def dashboard_todolist_delete_all_completed():
     return {"status": "ok", "hidden_count": count, "new_status": task_hub.TASK_STATUS_PARKED}
 
 
+def _clear_email_quarantine_local(conn, task_id: str) -> Optional[str]:
+    """Sync-side quarantine cleanup invoked after a terminal-flip on an email task.
+
+    Inspects the row at ``task_id``; if it's an email task carrying the
+    `quarantined` label, strips the label, flips
+    ``email_task_mappings.status`` from `quarantined` to `released`, and
+    returns the AgentMail thread_id so the caller can fire the
+    AgentMail-side label removal asynchronously.
+
+    Designed to be called WHILE holding ``_activity_store_lock`` so the
+    state change is atomic with the dashboard verb's status UPDATE.
+
+    Returns ``None`` for non-email tasks, non-quarantined tasks, or missing
+    rows — the caller short-circuits the AgentMail call on None.
+    """
+    try:
+        from universal_agent.services.email_task_bridge import (
+            EmailTaskBridge,
+            ensure_email_task_schema,
+        )
+        from universal_agent.task_hub import get_item
+    except Exception as exc:
+        logger.debug(
+            "📧 _clear_email_quarantine_local: bridge import failed task=%s: %s",
+            task_id, exc,
+        )
+        return None
+
+    try:
+        row = get_item(conn, task_id) or {}
+    except Exception as exc:
+        logger.debug(
+            "📧 _clear_email_quarantine_local: get_item failed task=%s: %s",
+            task_id, exc,
+        )
+        return None
+
+    source_kind = str(row.get("source_kind") or "").strip().lower()
+    labels_norm = [str(label or "").strip().lower() for label in (row.get("labels") or [])]
+    if source_kind != "email" or "quarantined" not in labels_norm:
+        return None
+
+    try:
+        ensure_email_task_schema(conn)
+        bridge = EmailTaskBridge(db_conn=conn)
+        return bridge.clear_quarantine_state(task_id)
+    except Exception as exc:
+        logger.warning(
+            "📧 _clear_email_quarantine_local: bridge.clear_quarantine_state "
+            "raised for task=%s: %s",
+            task_id, exc,
+        )
+        return None
+
+
+async def _release_quarantine_agentmail(thread_id: Optional[str], task_id: str) -> None:
+    """Async-side companion to `_clear_email_quarantine_local`.
+
+    Fire-and-log call to AgentMailService to remove the `quarantined` label
+    from the thread. Runs outside `_activity_store_lock` because it's a
+    network round-trip. Failure is logged but never raised — the local DB
+    state has already been corrected; AgentMail-side drift is acceptable.
+    """
+    if not thread_id:
+        return
+    svc = _agentmail_service
+    if svc is None:
+        logger.debug(
+            "📧 _release_quarantine_agentmail: AgentMail service not initialized "
+            "task=%s thread=%s — skipping AgentMail-side cleanup",
+            task_id, thread_id,
+        )
+        return
+    try:
+        await svc.release_quarantine_label(thread_id)
+    except Exception as exc:
+        logger.warning(
+            "📧⚠️ AgentMail release_quarantine_label raised for thread=%s "
+            "task=%s — UA-side quarantine state is already cleared: %s",
+            thread_id, task_id, exc,
+        )
+
+
 @app.delete("/api/v1/dashboard/todolist/dismiss/{task_id}")
 async def dashboard_todolist_dismiss_task(task_id: str):
     """Dismiss any active work item by moving it to cancelled status.
@@ -23522,6 +23605,7 @@ async def dashboard_todolist_dismiss_task(task_id: str):
     tid = str(task_id or "").strip()
     if not tid:
         raise HTTPException(status_code=400, detail="task_id is required")
+    thread_id_to_release: Optional[str] = None
     with _activity_store_lock:
         conn = _task_hub_open_conn()
         try:
@@ -23539,8 +23623,13 @@ async def dashboard_todolist_dismiss_task(task_id: str):
                 (task_hub.TASK_STATUS_CANCELLED, "dashboard_dismissed", "unseized", _utc_now_iso(), tid),
             )
             conn.commit()
+            # Quarantine-clear runs inside the lock so the UA-side state
+            # change is atomic with the dismiss above.
+            thread_id_to_release = _clear_email_quarantine_local(conn, tid)
         finally:
             conn.close()
+    # AgentMail-side label removal is network — fire-and-log outside the lock.
+    await _release_quarantine_agentmail(thread_id_to_release, tid)
     return {"status": "ok", "task_id": tid, "new_status": task_hub.TASK_STATUS_CANCELLED}
 
 
@@ -23558,6 +23647,7 @@ async def dashboard_todolist_archive_task(task_id: str):
     tid = str(task_id or "").strip()
     if not tid:
         raise HTTPException(status_code=400, detail="task_id is required")
+    thread_id_to_release: Optional[str] = None
     with _activity_store_lock:
         conn = _task_hub_open_conn()
         try:
@@ -23586,8 +23676,13 @@ async def dashboard_todolist_archive_task(task_id: str):
                 ),
             )
             conn.commit()
+            # Quarantine-clear runs inside the lock so the UA-side state
+            # change is atomic with the archive above.
+            thread_id_to_release = _clear_email_quarantine_local(conn, tid)
         finally:
             conn.close()
+    # AgentMail-side label removal is network — fire-and-log outside the lock.
+    await _release_quarantine_agentmail(thread_id_to_release, tid)
     return {"status": "ok", "task_id": tid, "new_status": task_hub.TASK_STATUS_COMPLETED}
 
 

--- a/src/universal_agent/services/agentmail_service.py
+++ b/src/universal_agent/services/agentmail_service.py
@@ -1116,6 +1116,97 @@ class AgentMailService:
         logger.info("📧 Deleted thread thread_id=%s inbox_id=%s", thread_id, inbox_id)
         return {"status": "deleted", "thread_id": thread_id, "inbox_id": inbox_id}
 
+    async def release_quarantine_label(
+        self,
+        thread_id: str,
+        *,
+        inbox_id: Optional[str] = None,
+        label: str = _QUEUE_STATUS_QUARANTINED,
+    ) -> bool:
+        """Best-effort removal of the quarantine label from an AgentMail thread.
+
+        Wired into the dashboard archive/dismiss verb handlers
+        (`dashboard_todolist_archive_task` / `dashboard_todolist_dismiss_task`)
+        so that when the operator clears a quarantined-email card, the
+        AgentMail-side label state is also cleared. Today UA does not write a
+        `quarantined` label to AgentMail itself — the local bridge tables are
+        the canonical store — but the API is wired defensively so this call
+        is a no-op-and-log when no AgentMail label is present, AND becomes a
+        real cleanup if UA ever starts mirroring quarantine state into
+        AgentMail.
+
+        Idempotent. Returns True if AgentMail accepted the update on at least
+        one inbox, False otherwise. Failures are logged but never raised — the
+        caller is expected to have already flipped Task Hub status and should
+        not roll back if the AgentMail side stays dirty.
+
+        Inbox resolution: if ``inbox_id`` is provided it's the only target.
+        Otherwise the helper tries every inbox UA owns (single inbox in the
+        common production case; multi-inbox installs are rare but supported).
+        AgentMail 404s on the wrong inbox quickly so the iteration cost is
+        bounded.
+        """
+        thread = str(thread_id or "").strip()
+        if not thread:
+            return False
+        if self._client is None:
+            logger.debug(
+                "📧 release_quarantine_label called before client ready thread=%s",
+                thread,
+            )
+            return False
+
+        targets: list[str] = []
+        if inbox_id:
+            targets = [str(inbox_id).strip()]
+        elif self._inbox_ids:
+            targets = list(self._inbox_ids)
+        elif self._inbox_id:
+            targets = [self._inbox_id]
+
+        targets = [t for t in targets if t]
+        if not targets:
+            logger.debug(
+                "📧 release_quarantine_label has no inbox targets thread=%s",
+                thread,
+            )
+            return False
+
+        accepted = False
+        for tgt in targets:
+            try:
+                await self._await_read(
+                    self._client.inboxes.threads.update(
+                        inbox_id=tgt,
+                        thread_id=thread,
+                        remove_labels=[label],
+                    ),
+                    operation="agentmail_release_quarantine",
+                    target=f"{tgt}/{thread}",
+                )
+                logger.info(
+                    "📧✅ Released '%s' label thread=%s inbox=%s",
+                    label, thread, tgt,
+                )
+                accepted = True
+                break
+            except Exception as exc:
+                # 404 on wrong inbox is expected when iterating; other
+                # errors (auth, transient 5xx) are also non-fatal here.
+                logger.debug(
+                    "📧 release_quarantine_label inbox=%s thread=%s did not apply: %s",
+                    tgt, thread, exc,
+                )
+
+        if not accepted:
+            logger.warning(
+                "📧⚠️ release_quarantine_label could not remove '%s' thread=%s "
+                "across %d inbox(es) — AgentMail-side label state may drift "
+                "from UA's local state. UA-side state is already cleared.",
+                label, thread, len(targets),
+            )
+        return accepted
+
     def get_inbox_ids(self) -> list[str]:
         """Return all configured inbox IDs."""
         return list(self._inbox_ids) if self._inbox_ids else ([self._inbox_id] if self._inbox_id else [])

--- a/src/universal_agent/services/email_task_bridge.py
+++ b/src/universal_agent/services/email_task_bridge.py
@@ -953,6 +953,104 @@ class EmailTaskBridge:
         )
         return True
 
+    def clear_quarantine_state(self, task_id: str) -> Optional[str]:
+        """Clear UA-side quarantine state for an email task.
+
+        Called by the dashboard archive/dismiss verbs after the Task Hub
+        status flip so future re-renders (and any future re-derivation
+        of "is this still quarantined?") don't keep showing the badge:
+
+        - `task_hub_items.labels` JSON has the `quarantined` entry removed.
+        - `email_task_mappings.status` is moved from `quarantined` to
+          `released` (a non-quarantine sentinel; explicitly distinct from
+          `active` so we don't accidentally pick the row up as still-live
+          email work that needs response).
+
+        Idempotent. If the task_id is not an email task, returns None
+        without raising. If it IS an email task, returns the associated
+        `thread_id` so the caller can pass it to
+        `AgentMailService.release_quarantine_label` for the best-effort
+        AgentMail-side mirror call.
+
+        Args:
+            task_id: The Task Hub task_id (matches the deterministic
+                hash from `_deterministic_task_id(thread_id)`).
+
+        Returns:
+            The email thread_id if cleared, or None if the row didn't
+            exist / wasn't a quarantined email / wasn't an email at all.
+        """
+        tid = str(task_id or "").strip()
+        if not tid:
+            return None
+
+        # Look up the bridge mapping for this task. The bridge is keyed
+        # by thread_id, not task_id, so we have to search the secondary
+        # task_id column (indexed via idx_email_task_mappings_task_id).
+        mapping_row = self._conn.execute(
+            "SELECT thread_id, status FROM email_task_mappings "
+            "WHERE task_id = ? LIMIT 1",
+            (tid,),
+        ).fetchone()
+        if not mapping_row:
+            return None
+
+        thread_id = str(mapping_row["thread_id"] or "").strip()
+        if not thread_id:
+            return None
+
+        now = _now_iso()
+
+        # ── 1. Update email_task_mappings.status ──
+        # Only flip when actually quarantined; idempotent re-clear is a no-op.
+        if str(mapping_row["status"] or "").strip().lower() == "quarantined":
+            self._conn.execute(
+                "UPDATE email_task_mappings "
+                "SET status = 'released', "
+                "    security_classification = '', "
+                "    updated_at = ? "
+                "WHERE task_id = ?",
+                (now, tid),
+            )
+
+        # ── 2. Strip the 'quarantined' label from task_hub_items.labels ──
+        # task_hub_items.labels is stored as a JSON array on the row's
+        # labels_json column (see task_hub.upsert_item). We read, filter,
+        # and write back via task_hub helpers rather than poking JSON
+        # directly so future schema changes stay encapsulated.
+        try:
+            from universal_agent.task_hub import get_item, upsert_item
+
+            current = get_item(self._conn, tid) or {}
+            existing_labels = list(current.get("labels") or [])
+            new_labels = [
+                lbl for lbl in existing_labels
+                if str(lbl or "").strip().lower() != _EMAIL_TASK_QUARANTINED_LABEL
+            ]
+            if new_labels != existing_labels:
+                upsert_item(
+                    self._conn,
+                    {
+                        "task_id": tid,
+                        "labels": new_labels,
+                    },
+                )
+        except Exception as exc:
+            # Defensive: even if the label strip fails (e.g. row vanished
+            # between SELECT and UPDATE), the mapping table update above
+            # already changed the source-of-truth field. Log + continue.
+            logger.warning(
+                "📧 clear_quarantine_state label strip failed task=%s: %s",
+                tid, exc,
+            )
+
+        self._conn.commit()
+        logger.info(
+            "📧🔓 Cleared UA quarantine state task=%s thread=%s",
+            tid, thread_id,
+        )
+        return thread_id
+
     def _upsert_thread_task_state(
         self,
         *,

--- a/tests/unit/test_dashboard_quarantine_release.py
+++ b/tests/unit/test_dashboard_quarantine_release.py
@@ -1,0 +1,273 @@
+"""Tests for the quarantine-release wiring on dashboard archive/dismiss.
+
+When the operator clicks "Archive" or "Delete" on a quarantined-email card,
+the Task Hub row flips to a terminal status (existing behaviour). This file
+covers the follow-up cleanup added on top of that:
+
+  1. `EmailTaskBridge.clear_quarantine_state(task_id)` strips the
+     `quarantined` label from `task_hub_items.labels`, flips
+     `email_task_mappings.status` from `quarantined` to `released`,
+     and returns the thread_id for the AgentMail call.
+  2. `gateway_server._clear_email_quarantine_local(conn, task_id)` is a
+     no-op on non-email rows / non-quarantined rows.
+  3. `gateway_server._release_quarantine_agentmail(thread_id, task_id)`
+     is fire-and-log: it never raises even if the AgentMail SDK does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services.email_task_bridge import (
+    EmailTaskBridge,
+    _deterministic_task_id,
+    ensure_email_task_schema,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    task_hub.ensure_schema(conn)
+    ensure_email_task_schema(conn)
+    return conn
+
+
+def _seed_quarantined_email(
+    conn: sqlite3.Connection,
+    *,
+    thread_id: str = "thread_abc",
+    sender: str = "spammer@example.test",
+) -> str:
+    """Seed a quarantined email task: Task Hub row + bridge mapping. Returns task_id."""
+    task_id = _deterministic_task_id(thread_id)
+    now = datetime.now(timezone.utc).isoformat()
+
+    # ── 1. Bridge mapping row ──
+    conn.execute(
+        """
+        INSERT INTO email_task_mappings (
+            thread_id, task_id, master_key, subject, sender_email,
+            sender_trusted, security_classification, status,
+            last_message_id, created_at, updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, 0, 'quarantine', 'quarantined', ?, ?, ?)
+        """,
+        (thread_id, task_id, "k1", "Hello", sender, "msg_1", now, now),
+    )
+    conn.commit()
+
+    # ── 2. Task Hub row ──
+    task_hub.upsert_item(
+        conn,
+        {
+            "task_id": task_id,
+            "source_kind": "email",
+            "title": "📧 Hello",
+            "description": "quarantined email",
+            "status": task_hub.TASK_STATUS_OPEN,
+            "labels": ["email-task", "external-untriaged", "quarantined"],
+        },
+    )
+    return task_id
+
+
+# ── EmailTaskBridge.clear_quarantine_state ───────────────────────────────
+
+
+def test_clear_quarantine_state_strips_label_and_updates_mapping() -> None:
+    """Happy path: a quarantined email is fully scrubbed on both tables."""
+    conn = _conn()
+    try:
+        task_id = _seed_quarantined_email(conn, thread_id="t_clear")
+        bridge = EmailTaskBridge(db_conn=conn)
+
+        result = bridge.clear_quarantine_state(task_id)
+
+        # Returns thread_id so the dashboard can fire the AgentMail call.
+        assert result == "t_clear"
+
+        # Bridge mapping flipped from `quarantined` to `released`.
+        row = conn.execute(
+            "SELECT status, security_classification FROM email_task_mappings "
+            "WHERE task_id = ? LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert row["status"] == "released"
+        # security_classification is blanked so future re-derivation
+        # doesn't mistake this as "still being held for review."
+        assert row["security_classification"] == ""
+
+        # Task Hub label list no longer contains "quarantined" — the
+        # dashboard badge keys off this exact field.
+        item = task_hub.get_item(conn, task_id)
+        assert "quarantined" not in (item.get("labels") or [])
+        # Non-quarantine labels are preserved.
+        assert "email-task" in (item.get("labels") or [])
+    finally:
+        conn.close()
+
+
+def test_clear_quarantine_state_is_idempotent() -> None:
+    """Calling clear twice doesn't error and the second call is a no-op."""
+    conn = _conn()
+    try:
+        task_id = _seed_quarantined_email(conn, thread_id="t_idem")
+        bridge = EmailTaskBridge(db_conn=conn)
+        bridge.clear_quarantine_state(task_id)
+        # Second call: mapping is now `released`, label is gone; should be safe.
+        result = bridge.clear_quarantine_state(task_id)
+        # Returns thread_id (mapping still exists) but does no harm.
+        assert result == "t_idem"
+
+        row = conn.execute(
+            "SELECT status FROM email_task_mappings WHERE task_id = ? LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert row["status"] == "released"
+    finally:
+        conn.close()
+
+
+def test_clear_quarantine_state_returns_none_when_task_id_unknown() -> None:
+    """Non-email or never-seen task_id is a clean None — caller short-circuits."""
+    conn = _conn()
+    try:
+        bridge = EmailTaskBridge(db_conn=conn)
+        assert bridge.clear_quarantine_state("no_such_task") is None
+    finally:
+        conn.close()
+
+
+# ── gateway_server._clear_email_quarantine_local ──────────────────────────
+
+
+def test_clear_email_quarantine_local_returns_thread_id_for_quarantined_email() -> None:
+    """Sync helper used by the dashboard handlers returns the thread_id."""
+    from universal_agent.gateway_server import _clear_email_quarantine_local
+
+    conn = _conn()
+    try:
+        task_id = _seed_quarantined_email(conn, thread_id="t_gw_email")
+        out = _clear_email_quarantine_local(conn, task_id)
+        assert out == "t_gw_email"
+    finally:
+        conn.close()
+
+
+def test_clear_email_quarantine_local_returns_none_for_non_email_task() -> None:
+    """A non-email task — even if it has a stray 'quarantined' label — is not touched."""
+    from universal_agent.gateway_server import _clear_email_quarantine_local
+
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task_simone_chat_1",
+                "source_kind": "simone_chat",
+                "title": "chat",
+                "status": task_hub.TASK_STATUS_IN_PROGRESS,
+                "labels": ["simone-chat", "quarantined"],  # contrived
+            },
+        )
+        out = _clear_email_quarantine_local(conn, "task_simone_chat_1")
+        assert out is None
+    finally:
+        conn.close()
+
+
+def test_clear_email_quarantine_local_returns_none_for_email_without_quarantined_label() -> None:
+    """An ordinary (non-quarantined) email is left alone — only quarantined rows trigger cleanup."""
+    from universal_agent.gateway_server import _clear_email_quarantine_local
+
+    conn = _conn()
+    try:
+        task_hub.upsert_item(
+            conn,
+            {
+                "task_id": "task_email_normal",
+                "source_kind": "email",
+                "title": "normal mail",
+                "status": task_hub.TASK_STATUS_OPEN,
+                "labels": ["email-task", "agent-ready"],
+            },
+        )
+        out = _clear_email_quarantine_local(conn, "task_email_normal")
+        assert out is None
+    finally:
+        conn.close()
+
+
+# ── gateway_server._release_quarantine_agentmail ──────────────────────────
+
+
+def test_release_quarantine_agentmail_is_noop_when_thread_id_missing() -> None:
+    """No thread_id (sync helper returned None) → no AgentMail call attempted."""
+    from universal_agent import gateway_server
+
+    fake_service = MagicMock()
+    fake_service.release_quarantine_label = AsyncMock(return_value=True)
+    gateway_server._agentmail_service = fake_service
+    try:
+        asyncio.run(gateway_server._release_quarantine_agentmail(None, "task_1"))
+        fake_service.release_quarantine_label.assert_not_called()
+    finally:
+        gateway_server._agentmail_service = None
+
+
+def test_release_quarantine_agentmail_is_noop_when_service_none() -> None:
+    """AgentMail service not initialised → log + return; no crash."""
+    from universal_agent import gateway_server
+
+    prev = gateway_server._agentmail_service
+    gateway_server._agentmail_service = None
+    try:
+        # Should NOT raise.
+        asyncio.run(gateway_server._release_quarantine_agentmail("thread_x", "task_x"))
+    finally:
+        gateway_server._agentmail_service = prev
+
+
+def test_release_quarantine_agentmail_calls_service_with_thread_id() -> None:
+    """Happy path: thread_id + service present → AgentMail helper invoked."""
+    from universal_agent import gateway_server
+
+    fake_service = MagicMock()
+    fake_service.release_quarantine_label = AsyncMock(return_value=True)
+    gateway_server._agentmail_service = fake_service
+    try:
+        asyncio.run(
+            gateway_server._release_quarantine_agentmail("thread_happy", "task_happy")
+        )
+        fake_service.release_quarantine_label.assert_awaited_once_with("thread_happy")
+    finally:
+        gateway_server._agentmail_service = None
+
+
+def test_release_quarantine_agentmail_swallows_service_exception() -> None:
+    """Fire-and-log: AgentMail raising must NOT propagate (operator already saw row move)."""
+    from universal_agent import gateway_server
+
+    fake_service = MagicMock()
+    fake_service.release_quarantine_label = AsyncMock(
+        side_effect=RuntimeError("agentmail API down"),
+    )
+    gateway_server._agentmail_service = fake_service
+    try:
+        # Should NOT raise — log only.
+        asyncio.run(
+            gateway_server._release_quarantine_agentmail("thread_dead", "task_dead")
+        )
+        fake_service.release_quarantine_label.assert_awaited_once()
+    finally:
+        gateway_server._agentmail_service = None


### PR DESCRIPTION
## Summary
Implements **B3** from the simone-chat follow-up brief (`lrepos/universal_agent/plans/simone-chat-followups.md`) — the P2 correctness gap left open by PR #255. When the operator clicks **Archive** or **Delete** on a quarantined-email card, the Task Hub status flip is now followed by a sync UA-side state cleanup and a fire-and-log AgentMail-side mirror call.

## Why this matters

Before this PR, the dashboard verbs only flipped `task_hub_items.status`. Two pieces of state were left dirty:

1. **`task_hub_items.labels` JSON** still contained `"quarantined"`. The dashboard's red quarantine badge keys off exactly this — `web-ui/app/dashboard/todolist/page.tsx:1069`: `const isQuarantined = itemLabels.includes("quarantined")`.
2. **`email_task_mappings.status`** still said `"quarantined"`. Any future re-derivation of "is this still quarantined?" from the bridge table would see the row as still held.

If the same thread received a new email after archive (same `thread_id`), the upsert in `_upsert_thread_task_state` would have layered new state on top of the dirty labels.

## What's in this PR

| File | Change |
|---|---|
| `src/universal_agent/services/agentmail_service.py` | New async `release_quarantine_label(thread_id, ...)` — best-effort `client.inboxes.threads.update(remove_labels=["quarantined"])`, iterates UA's inboxes, idempotent, never raises |
| `src/universal_agent/services/email_task_bridge.py` | New `clear_quarantine_state(task_id)` — strips the label from `task_hub_items.labels` JSON via `task_hub.upsert_item`, flips `email_task_mappings.status` from `quarantined` → `released`, returns `thread_id` for the caller |
| `src/universal_agent/gateway_server.py` | Two new helpers (`_clear_email_quarantine_local` sync inside-the-lock + `_release_quarantine_agentmail` async outside-the-lock) wired into both `dashboard_todolist_archive_task` and `dashboard_todolist_dismiss_task` |
| `tests/unit/test_dashboard_quarantine_release.py` | 10 new tests — happy path, idempotency, non-email row, no-quarantine-label row, missing-thread-id, missing-service, exception-swallowing |

## Failure policy: fire-and-log

The plan brief recommended this and the operator confirmed it. The local DB cleanup is sync and atomic with the dashboard verb's UPDATE (under `_activity_store_lock`). The AgentMail-side call runs **outside** the lock as a network round-trip; any failure (404, auth, transient 5xx) logs a WARNING and returns. The dashboard verb still returns 200 — the operator's click is never blocked by AgentMail being slow or unreachable.

## AgentMail-side: defensive wiring

A read of `agentmail_service.py` and `email_task_bridge.py` shows that UA does **not** currently write a `quarantined` label to AgentMail's own thread state. Every `mark_quarantined` call updates UA's local bridge tables only. So today, `release_quarantine_label` is a no-op on the AgentMail side (the SDK's update will succeed silently because there's nothing to remove). The method is wired in defensively so that if UA ever starts mirroring quarantine into AgentMail's threads (e.g. for cross-system audit consistency), the dashboard verbs already do the release. This decision is documented inline in the helper's docstring.

## Test plan

- [x] `uv run pytest tests/unit/test_dashboard_quarantine_release.py tests/unit/test_dashboard_todolist_archive.py tests/unit/test_simone_chat_tasks.py tests/unit/test_cron_dormancy_defaults.py` → 41/41 green locally
- [ ] PR-Validate runs the full suite — should pass
- [ ] Post-deploy smoke: trigger a quarantine, click Archive on the card → red badge disappears AND `email_task_mappings.status == 'released'` AND `task_hub_items.labels` no longer contains `quarantined`. Logs should show the AgentMail call attempt + result.

## Out of scope (deferred to other follow-up items)

- **B1** Kanban `simone_chat` source-kind badge (frontend polish)
- **B2** Session tab tray for accumulating Simone chats (frontend feature)
- **B4** Surface `simone_chat` task status on `/dashboard/chat` and `/dashboard/sessions` (full-stack polish)

The "trust the sender / suppress future quarantine on same thread" scenario is also explicitly out of scope — that's a separate operator-intent feature, not a state-correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)