### PR TITLE
ci(deploy,pr-validate): shrink checkout fetch + baseline-aware discord gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,6 +239,22 @@ jobs:
             echo "--> Installing canonical VP worker unit template from repo..."
             sudo bash "$PROD_DIR/scripts/install_vp_worker_services.sh" vp.coder.primary vp.general.primary
 
+            # Capture discord-services state BEFORE the restart so the
+            # post-restart health gate can distinguish "this deploy broke
+            # discord" (regression — fail) from "discord was already
+            # crashing before this deploy" (pre-existing — warn only).
+            # See PR #259 deploy-fail (2026-05-12): all HTTP services
+            # healthy on the new SHA, but ua-discord-intelligence was in
+            # an existing crash loop and the old hard gate flagged the
+            # whole deploy as failed.
+            discord_cc_pre="unknown"
+            discord_intel_pre="unknown"
+            if command -v systemctl >/dev/null 2>&1; then
+              discord_cc_pre="$(systemctl is-active ua-discord-cc-bot 2>/dev/null || echo unknown)"
+              discord_intel_pre="$(systemctl is-active ua-discord-intelligence 2>/dev/null || echo unknown)"
+              echo "--> Discord baseline (pre-deploy): cc-bot=$discord_cc_pre intelligence=$discord_intel_pre"
+            fi
+
             echo "--> Restarting production services..."
             if command -v systemctl >/dev/null 2>&1; then
               if command -v sudo >/dev/null 2>&1; then
@@ -366,9 +382,31 @@ jobs:
               fi
             done
             rm -rf "$health_status_dir"
+            # Discord services: baseline-aware health check. Only fail
+            # the deploy if the service was healthy BEFORE the deploy
+            # and is unhealthy AFTER (true regression). Pre-existing
+            # crash loops surface as a warning so chronic discord
+            # flakiness doesn't mask real PR-caused failures elsewhere.
+            check_discord_regression() {
+              svc="$1"
+              pre_state="$2"
+              if systemctl is-active --quiet "$svc"; then
+                if [ "$pre_state" != "active" ] && [ "$pre_state" != "unknown" ]; then
+                  echo "    [RECOVERED] $svc transitioned $pre_state -> active across this deploy."
+                fi
+                return 0
+              fi
+              now_state="$(systemctl is-active "$svc" 2>/dev/null || echo unknown)"
+              if [ "$pre_state" = "active" ]; then
+                echo "::error::$svc was active pre-deploy but is now $now_state — likely regression caused by this deploy."
+                return 1
+              fi
+              echo "::warning::$svc is $now_state (pre-deploy was $pre_state). Pre-existing failure, not blocking this deploy."
+              return 0
+            }
             if command -v systemctl >/dev/null 2>&1; then
-              systemctl is-active --quiet ua-discord-cc-bot || health_ok=false
-              systemctl is-active --quiet ua-discord-intelligence || health_ok=false
+              check_discord_regression ua-discord-cc-bot "$discord_cc_pre" || health_ok=false
+              check_discord_regression ua-discord-intelligence "$discord_intel_pre" || health_ok=false
             fi
 
             if [ "$health_ok" != "true" ]; then

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -53,9 +53,16 @@ jobs:
       - name: Checkout PR head
         uses: actions/checkout@v6
         with:
-          # Need full history so we can diff against the base branch
-          # to identify only the .py files this PR touches.
-          fetch-depth: 0
+          # Shallow history sized for "diff against base branch only."
+          # The `Identify changed Python files` step below re-fetches the
+          # base ref at `--depth=1` and runs `git diff origin/$BASE_REF...HEAD`,
+          # which needs the merge-base plus a few commits of head history —
+          # never tens of thousands. Previously `fetch-depth: 0` (full
+          # history + all branches + all tags + PR merge ref) made the
+          # initial `git fetch` huge and prone to network-stall hangs;
+          # PR #259's first PR-Validate run timed out at 15 min waiting
+          # on that fetch (2026-05-12). 50 is generous for any PR diff.
+          fetch-depth: 50
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v6
@@ -79,7 +86,12 @@ jobs:
         id: changed
         run: |
           BASE_REF="${{ github.base_ref }}"
-          git fetch origin "$BASE_REF" --depth=1
+          # Match the fetch-depth window used at checkout (50) so the
+          # triple-dot diff's merge-base lookup can succeed even when
+          # the PR diverged a few dozen commits back. A shallow `--depth=1`
+          # paired with a shallow head would race the merge-base computation
+          # for any non-trivial PR.
+          git fetch origin "$BASE_REF" --depth=50
           CHANGED=$(git diff --name-only --diff-filter=AMR "origin/$BASE_REF...HEAD" -- '*.py' || true)
           if [ -z "$CHANGED" ]; then
             echo "No Python files changed; skipping py_compile + targeted tests."

--- a/tests/unit/test_deploy_prod_workflow_guard.py
+++ b/tests/unit/test_deploy_prod_workflow_guard.py
@@ -105,5 +105,14 @@ def test_production_systemd_installer_manages_discord_services() -> None:
     assert '"ua-discord-cc-bot.service"' in content
     assert '"ua-discord-intelligence.service"' in content
     deploy_content = _DEPLOY_WORKFLOW.read_text(encoding="utf-8")
+    # Discord services must still be restarted by deploy.
     assert "ua-discord-cc-bot ua-discord-intelligence" in deploy_content
-    assert "systemctl is-active --quiet ua-discord-cc-bot" in deploy_content
+    # Discord services must still be health-checked, but the gate is now
+    # baseline-aware (see `check_discord_regression`) so chronic crash
+    # loops don't false-positive the deploy. Pin the new mechanism so a
+    # future refactor can't silently drop discord from the health gate.
+    assert "discord_cc_pre=" in deploy_content
+    assert "discord_intel_pre=" in deploy_content
+    assert "check_discord_regression()" in deploy_content
+    assert "check_discord_regression ua-discord-cc-bot" in deploy_content
+    assert "check_discord_regression ua-discord-intelligence" in deploy_content


### PR DESCRIPTION
## Summary

Two flake fixes after auditing today's failures (PR #259 first attempt hung 15 min on `git fetch`; PR #259 deploy "failed" but actually shipped — the 4 production verification curls pass on the new SHA).

### 1. `pr-validate.yml` — narrower checkout fetch
- `fetch-depth: 0` → `50` at checkout
- Base-ref fetch `--depth=1` → `--depth=50` at diff step (so triple-dot merge-base still resolves)
- Eliminates the wide-refspec network-stall hang. 50 commits is generous for any PR diff.

### 2. `deploy.yml` — baseline-aware discord health gate
- Capture `ua-discord-cc-bot` and `ua-discord-intelligence` state BEFORE restart.
- New `check_discord_regression()` function:
  - `active pre, active post` → OK
  - `not-active pre, not-active post` → warning, deploy succeeds (pre-existing flakiness)
  - `active pre, not-active post` → error, deploy fails (true regression)
  - `not-active pre, active post` → "[RECOVERED]" log line
- Eliminates the false-positive deploy fail when `ua-discord-intelligence` is in its chronic crash loop.

## Test plan

- [x] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] First PR-Validate run on this PR exercises the new `fetch-depth: 50` path
- [ ] First deploy on this branch landing in `main` exercises the baseline gate (discord-intel is currently flapping on prod, so this will hit the warning path — the expected outcome)

## Not in scope

- The actual `ua-discord-intelligence` crash loop (chronic daemon failure). That's a separate bug to fix in `src/discord_intelligence/daemon.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)