### PR TITLE
feat(cron): per-cron model_tier + max_attempts metadata

### DIFF
--- a/src/universal_agent/cron_service.py
+++ b/src/universal_agent/cron_service.py
@@ -780,6 +780,68 @@ class CronService:
         finally:
             conn.close()
 
+    # Per-cron model tier resolution. The LLM cron path (cron_service.py
+    # ~line 1591) historically hard-coded ``force_complex=True``, which biases
+    # the agent loop toward Opus-tier reasoning on ZAI (``glm-5.1``). For
+    # low-complexity content crons (codie_cleanup, csi_demo_triage_rank,
+    # proactive_artifact_digest, etc.) that's wasteful and exacerbates ZAI
+    # Fair-Usage 429s. ``metadata.model_tier`` lets each cron declare its
+    # required reasoning tier. Default remains ``"high"`` to preserve the
+    # pre-change behavior for any cron that hasn't opted in.
+    #
+    # NOTE — Cody dispatch path is NOT affected by this helper. When a cron
+    # enqueues a Cody mission via ``vp_dispatch_mission``, Cody's model
+    # selection lives in ``vp/clients/claude_cli_client.py`` (her CLI env
+    # build). The Cody-on-ZAI rule (Opus always, never downgrade) is
+    # documented in ``memory/feedback_cody_on_zai_opus.md`` and enforced
+    # there, not here.
+    _MODEL_TIER_HIGH = ("high", "opus")
+    _MODEL_TIER_LOW = ("low", "sonnet", "haiku")
+
+    @classmethod
+    def _force_complex_for_job(cls, job: CronJob) -> bool:
+        """Resolve the ``force_complex`` flag from ``metadata.model_tier``.
+
+        Returns True (Opus-tier reasoning) for unset or "high"/"opus",
+        False (Sonnet-tier or lower) for "low"/"sonnet"/"haiku". Unknown
+        values fall back to True so a typo never silently downgrades a
+        critical cron.
+        """
+        metadata = getattr(job, "metadata", None) or {}
+        tier = str(metadata.get("model_tier") or "").strip().lower()
+        if not tier:
+            return True  # preserves pre-2026-05-13 default
+        if tier in cls._MODEL_TIER_LOW:
+            return False
+        if tier in cls._MODEL_TIER_HIGH:
+            return True
+        logger.warning(
+            "Unknown model_tier=%r on cron job %s; falling back to force_complex=True",
+            tier, job.job_id,
+        )
+        return True
+
+    @staticmethod
+    def _max_attempts_for_job(job: CronJob) -> int:
+        """Resolve workflow ``max_attempts`` from ``metadata.max_attempts``.
+
+        Default 3 preserves the pre-change behavior. Lower bound is 1
+        (i.e., the first dispatch counts; no retries). Floats, bools,
+        and other non-integer types fall back to the default rather
+        than silently truncating (e.g., ``2.5`` should not become 2).
+        """
+        metadata = getattr(job, "metadata", None) or {}
+        raw = metadata.get("max_attempts")
+        # bool is a subclass of int in Python; reject it explicitly.
+        # Only accept actual ints or integer-valued strings.
+        if isinstance(raw, bool) or not isinstance(raw, (int, str)):
+            return 3
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return 3
+        return max(1, value)
+
     def _schedule_retry_run(
         self,
         *,
@@ -857,7 +919,7 @@ class CronService:
                 workspace_dir=job.workspace_dir,
                 failure_reason=failure_reason or "cron_dispatch_failed",
                 failure_class=failure_class or "cron_dispatch_failed",
-                max_attempts=3,
+                max_attempts=self._max_attempts_for_job(job),
             )
             if retry_decision.action == "start_new_attempt" and retry_decision.attempt_id:
                 next_attempt_number = self._attempt_number(retry_decision.attempt_id)
@@ -1019,7 +1081,7 @@ class CronService:
                     trigger,
                     entrypoint="cron_service._run_job",
                     workspace_dir=job.workspace_dir,
-                    max_attempts=3,
+                    max_attempts=self._max_attempts_for_job(job),
                 )
                 workflow_run_id = decision.run_id
                 workflow_attempt_id = decision.attempt_id
@@ -1590,7 +1652,7 @@ class CronService:
 
                                 request = GatewayRequest(
                                     user_input=resolved_command,
-                                    force_complex=True,
+                                    force_complex=self._force_complex_for_job(job),
                                     metadata=request_metadata,
                                 )
 

--- a/tests/unit/test_cron_per_cron_model_tier.py
+++ b/tests/unit/test_cron_per_cron_model_tier.py
@@ -1,0 +1,166 @@
+"""Per-cron model_tier + max_attempts metadata resolution.
+
+Covers the two helpers added to ``CronService``:
+
+- ``_force_complex_for_job`` — translates ``metadata.model_tier`` into
+  the ``force_complex`` flag passed to ``GatewayRequest`` for LLM-prompt
+  crons. Default behavior must match the pre-change hardcoded
+  ``force_complex=True`` so any cron that hasn't opted in keeps running
+  on Opus tier.
+
+- ``_max_attempts_for_job`` — reads ``metadata.max_attempts`` for the
+  workflow admission / retry-queue path. Default 3 matches the
+  pre-change hardcoded value; a value of 1 disables retries entirely.
+
+These tests exercise the helpers directly without going through the
+full ``_run_job`` orchestration (which requires gateway / admission /
+session mocking — out of scope here, in line with the pattern in
+``test_cron_llm_path_f_observability.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from universal_agent.cron_service import CronJob, CronService
+
+
+def _make_job(metadata: dict | None = None) -> CronJob:
+    return CronJob(
+        job_id="test-job",
+        user_id="cron",
+        workspace_dir="/tmp/test-workspace",
+        command="!script universal_agent.scripts.example",
+        metadata=metadata or {},
+    )
+
+
+# ── _force_complex_for_job ──────────────────────────────────────────────────
+
+
+class TestForceComplexForJob:
+    def test_no_metadata_returns_true(self) -> None:
+        """Pre-change default: missing metadata.model_tier → force_complex=True (Opus)."""
+        job = _make_job(metadata={})
+        assert CronService._force_complex_for_job(job) is True
+
+    def test_empty_string_returns_true(self) -> None:
+        job = _make_job(metadata={"model_tier": ""})
+        assert CronService._force_complex_for_job(job) is True
+
+    def test_explicit_high_returns_true(self) -> None:
+        job = _make_job(metadata={"model_tier": "high"})
+        assert CronService._force_complex_for_job(job) is True
+
+    def test_opus_returns_true(self) -> None:
+        job = _make_job(metadata={"model_tier": "opus"})
+        assert CronService._force_complex_for_job(job) is True
+
+    def test_low_returns_false(self) -> None:
+        job = _make_job(metadata={"model_tier": "low"})
+        assert CronService._force_complex_for_job(job) is False
+
+    def test_sonnet_returns_false(self) -> None:
+        job = _make_job(metadata={"model_tier": "sonnet"})
+        assert CronService._force_complex_for_job(job) is False
+
+    def test_haiku_returns_false(self) -> None:
+        """Haiku tier requests Sonnet-or-lower via force_complex=False.
+
+        True Haiku-tier routing (forcing claude-haiku-4-5 explicitly)
+        would need an additional mechanism (model_override field or
+        prompt directive). This change just opens the door — Haiku-tier
+        crons no longer pay Opus prices.
+        """
+        job = _make_job(metadata={"model_tier": "haiku"})
+        assert CronService._force_complex_for_job(job) is False
+
+    def test_case_insensitive(self) -> None:
+        for variant in ("LOW", "Low", "  low  ", "HAIKU"):
+            job = _make_job(metadata={"model_tier": variant})
+            assert CronService._force_complex_for_job(job) is False, variant
+
+    def test_unknown_tier_falls_back_to_true(self) -> None:
+        """A typo in metadata.model_tier must not silently downgrade.
+
+        Defaulting unknown values to ``force_complex=True`` is the
+        safer choice: a misspelled "opass" should keep running on
+        Opus, not get silently routed to Sonnet.
+        """
+        job = _make_job(metadata={"model_tier": "opass"})
+        assert CronService._force_complex_for_job(job) is True
+
+    def test_none_metadata_attribute_returns_true(self) -> None:
+        """Some code paths construct CronJob with metadata=None despite the dataclass default.
+
+        The helper must not blow up on ``None``.
+        """
+        job = _make_job(metadata={})
+        job.metadata = None  # type: ignore[assignment]
+        assert CronService._force_complex_for_job(job) is True
+
+
+# ── _max_attempts_for_job ────────────────────────────────────────────────────
+
+
+class TestMaxAttemptsForJob:
+    def test_no_metadata_returns_3(self) -> None:
+        """Pre-change default: 3 attempts."""
+        job = _make_job(metadata={})
+        assert CronService._max_attempts_for_job(job) == 3
+
+    def test_explicit_3(self) -> None:
+        job = _make_job(metadata={"max_attempts": 3})
+        assert CronService._max_attempts_for_job(job) == 3
+
+    def test_explicit_1_disables_retries(self) -> None:
+        """max_attempts=1 means the first dispatch is the only one.
+
+        Used to silence the retry storm for crons whose failures are
+        not recoverable by retry (e.g., hackernews_snapshot when the
+        ``hackernews`` CLI is flaky on a 60s timeout).
+        """
+        job = _make_job(metadata={"max_attempts": 1})
+        assert CronService._max_attempts_for_job(job) == 1
+
+    def test_explicit_5(self) -> None:
+        job = _make_job(metadata={"max_attempts": 5})
+        assert CronService._max_attempts_for_job(job) == 5
+
+    def test_string_coerced(self) -> None:
+        """API callers often pass integer-valued strings — coerce them."""
+        job = _make_job(metadata={"max_attempts": "2"})
+        assert CronService._max_attempts_for_job(job) == 2
+
+    def test_zero_clamped_to_one(self) -> None:
+        """max_attempts=0 is nonsensical (no dispatch at all). Clamp to 1."""
+        job = _make_job(metadata={"max_attempts": 0})
+        assert CronService._max_attempts_for_job(job) == 1
+
+    def test_negative_clamped_to_one(self) -> None:
+        job = _make_job(metadata={"max_attempts": -7})
+        assert CronService._max_attempts_for_job(job) == 1
+
+    def test_garbage_falls_back_to_default(self) -> None:
+        for value in ("abc", None, [3], {}, 2.5):
+            job = _make_job(metadata={"max_attempts": value})
+            assert CronService._max_attempts_for_job(job) == 3, value
+
+
+# ── Integration sanity: dataclass default metadata is empty dict ─────────────
+
+
+def test_cronjob_dataclass_default_metadata_works() -> None:
+    """If someone forgets to pass metadata, both helpers must still work.
+
+    Smoke test that the dataclass's default-factory `dict` lets the
+    helpers see an empty mapping rather than crash on AttributeError.
+    """
+    job = CronJob(
+        job_id="smoke",
+        user_id="cron",
+        workspace_dir="/tmp",
+        command="!script foo",
+    )
+    assert CronService._force_complex_for_job(job) is True
+    assert CronService._max_attempts_for_job(job) == 3


### PR DESCRIPTION
## Summary
- Adds two opt-in metadata fields on cron jobs: `model_tier` (controls `force_complex` for LLM crons) and `max_attempts` (caps the workflow retry chain).
- Both default to the pre-change hardcoded values (`force_complex=True`, `max_attempts=3`) — zero behavior change for crons that don't opt in.
- Out-of-scope: Cody dispatch path is untouched. The Cody-on-ZAI=Opus rule lives in `vp/clients/claude_cli_client.py` and `memory/feedback_cody_on_zai_opus.md`, not here.

## Why
Today every LLM-prompt cron pays Opus-tier prices on ZAI (`glm-5.1`) via the unconditional `force_complex=True` at `cron_service.py:1591`. And every failure triggers up to 3 retries within ~5 minutes via the unconditional `max_attempts=3` at `cron_service.py:860` + `:1022`. When ZAI starts throttling under their Fair-Usage Policy (HTTP 429 / code 1313 — observed starting 2026-05-11 23:43 UTC), the unconditional retries turn a single 429 into a 3× burst per cron, which exacerbates the throttle into a sustained storm. This PR is the lever to:

- Drop low-complexity crons (`codie_cleanup`, `csi_demo_triage_rank`, `proactive_artifact_digest`) to Sonnet/Haiku tier.
- Disable retries for crons whose failures aren't recoverable by retry (`hackernews_snapshot` when its CLI binary is flaky on a 60s network timeout).

## Metadata schema

```python
{
    # Existing fields…
    "model_tier": "high" | "opus" | "low" | "sonnet" | "haiku",  # default: "high"
    "max_attempts": int,  # default: 3, minimum: 1
}
```

| `model_tier` | `force_complex` | ZAI mapping today |
|---|---|---|
| (unset) / `"high"` / `"opus"` | `True` | `glm-5.1` (Opus) |
| `"low"` / `"sonnet"` | `False` | `glm-5-turbo` (Sonnet) |
| `"haiku"` | `False` | Currently routes to Sonnet via `force_complex=False`. True Haiku routing (forcing `claude-haiku-4-5` explicitly) needs an additional mechanism — out of scope. |

| `max_attempts` | Behavior |
|---|---|
| (unset) / `3` | 3 attempts before "needs_review" (current default) |
| `1` | First dispatch is the only attempt; failures route straight to "needs_review" |
| `n` | `n` total attempts |

Unknown `model_tier` values fall back to `True` so a typo (`"opass"`) never silently downgrades a critical cron. Floats / bools / other non-integer types in `max_attempts` fall back to `3` rather than silently truncating (e.g., `2.5` does not become `2`).

## Test plan
- [x] 19 new unit tests in `tests/unit/test_cron_per_cron_model_tier.py` — tier resolution + retry-cap edge cases. All passing.
- [x] Existing cron suite (`tests/unit/test_cron_*.py`) — 42/42 passing, no regression.
- [x] `ruff check` — clean.
- [ ] **Post-merge operational follow-ups** (not in this PR — separate PR or operator-applied):
  - Set `metadata.model_tier = "low"` on `youtube_daily_digest`, `proactive_report_*`, `paper_to_podcast`, `nightly_wiki`.
  - Set `metadata.model_tier = "haiku"` on `codie_cleanup`, `csi_demo_triage_rank`, `proactive_artifact_digest`.
  - Set `metadata.max_attempts = 1` on `hackernews_snapshot` until the underlying CLI flakiness is fixed.

## Related findings (not addressed by this PR)
This PR addresses a contributing factor to the 2026-05-13 incident (Simone-orchestrated cron content gap, 20.8h gateway freeze on 2026-05-12 18:09 UTC → 2026-05-13 14:57 UTC, ZAI 429 storm). The freeze root cause (likely a synchronous SQLite call inside Hermes-F's async cron path) is **separate** and needs its own investigation + fix. This change reduces the blast radius of *future* ZAI throttle events but does not prevent the underlying deadlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)