### PR TITLE
feat(cron-f1): detect asyncio CancelledError as cancelled_mid_run

### DIFF
--- a/src/universal_agent/cron_service.py
+++ b/src/universal_agent/cron_service.py
@@ -1619,6 +1619,19 @@ class CronService:
                                 _f_auto_linked = False
                                 _f_was_timeout_killed = False
                                 _f_was_exception = False
+                                # Tracks ``asyncio.CancelledError`` separately
+                                # from timeouts and exceptions. The gateway's
+                                # session reaper invokes ``task.cancel()`` on
+                                # the in-process LLM coroutine when the
+                                # 600s TTL elapses. ``CancelledError`` inherits
+                                # from ``BaseException`` so it bypasses the
+                                # generic ``except Exception`` block below —
+                                # without explicit detection, ``_f_rc_equiv_llm``
+                                # falls through to 0 and the F.1 classifier
+                                # mis-paints the reap as ``clean_exit_zero``.
+                                # See plans/2026-05-13_proactivity_gap_findings.md
+                                # Contributing Factor #3.
+                                _f_was_cancelled = False
                                 _f_run_error_text = ""
                                 if not _f_skip_link:
                                     try:
@@ -1677,6 +1690,19 @@ class CronService:
                                         _f_was_timeout_killed = True
                                         _f_run_error_text = (
                                             f"LLM cron timed out after {timeout_seconds}s"
+                                        )
+                                        raise
+                                    except asyncio.CancelledError:
+                                        # Session reaper or operator cancellation.
+                                        # MUST be re-raised so the cancellation
+                                        # propagates correctly to the asyncio
+                                        # runtime; swallowing it would resume the
+                                        # coroutine and break asyncio's cancel
+                                        # contract.
+                                        _f_was_cancelled = True
+                                        _f_run_error_text = (
+                                            "LLM cron cancelled mid-run "
+                                            "(session reaper or operator action)"
                                         )
                                         raise
                                     except Exception as _llm_exc:
@@ -1777,6 +1803,7 @@ class CronService:
                                                 0
                                                 if not _f_was_timeout_killed
                                                 and not _f_was_exception
+                                                and not _f_was_cancelled
                                                 else 1
                                             )
                                             _f_conn_llm = _f_open_conn_llm()
@@ -1817,6 +1844,7 @@ class CronService:
                                                     was_signaled=False,
                                                     was_timeout_killed=_f_was_timeout_killed,
                                                     task_closed_normally=_f_closed_normally_llm,
+                                                    was_cancelled=_f_was_cancelled,
                                                 )
                                                 logger.info(
                                                     "Phase F.1 LLM cron job %s exit classified as %s "

--- a/src/universal_agent/services/worker_exit_classifier.py
+++ b/src/universal_agent/services/worker_exit_classifier.py
@@ -1,7 +1,8 @@
 """Hermes Phase F.1 — Worker exit classification.
 
 Classifies the termination of an owned-subprocess worker (cron `!script`,
-VP CLI client, demo workspace) into one of five buckets so Task Hub can
+VP CLI client, demo workspace) or an in-process LLM coroutine
+(cron LLM-prompt path) into one of six buckets so Task Hub can
 distinguish "clean success" from "clean exit but didn't close its task"
 (protocol violation — F.3) and from real errors.
 
@@ -11,7 +12,9 @@ returned classification into ``task_hub._close_run`` via the ``outcome``
 parameter.
 
 The classification taxonomy mirrors Hermes' kanban_db.py:2879-2911
-``_classify_worker_exit`` but is scoped to UA's three subprocess sites.
+``_classify_worker_exit`` but is scoped to UA's three subprocess sites
+(and the in-process LLM cron path, which uses cancellation detection
+rather than a return code).
 
 Outcomes:
     * ``clean_exit_zero`` — rc=0 AND task was closed via finalize_assignments
@@ -27,6 +30,12 @@ Outcomes:
     * ``timeout_killed`` — UA's own timeout machinery killed it. Distinct
       from ``signaled`` because the kill was intentional and the worker
       may have made partial progress worth surfacing in the run's metadata.
+    * ``cancelled_mid_run`` — the coroutine was cancelled externally
+      (gateway session reaper, operator action). Distinct from
+      ``timeout_killed`` (UA's own timeout) and ``signaled`` (OS-level
+      kill to a subprocess). Added 2026-05-13 after the gateway-freeze
+      incident where reaped LLM-cron coroutines were mis-painted as
+      ``clean_exit_zero``. See plans/2026-05-13_proactivity_gap_findings.md.
 """
 
 from __future__ import annotations
@@ -44,6 +53,7 @@ WorkerOutcome = Literal[
     "nonzero_exit",
     "signaled",
     "timeout_killed",
+    "cancelled_mid_run",
 ]
 
 
@@ -81,6 +91,7 @@ def classify_worker_exit(
     was_signaled: bool = False,
     was_timeout_killed: bool = False,
     task_closed_normally: bool = True,
+    was_cancelled: bool = False,
 ) -> WorkerExit:
     """Classify a subprocess termination into one of the F.1 outcome buckets.
 
@@ -99,10 +110,25 @@ def classify_worker_exit(
             ``perform_task_action(action="complete")`` BEFORE this
             classification ran. Distinguishes clean success from
             protocol violation.
+        was_cancelled: ``True`` iff the coroutine was cancelled mid-run
+            (e.g. the gateway session reaper called ``task.cancel()``
+            after the 600s TTL elapsed, or the cron was operator-
+            cancelled via ``task_hub_task_action``). ``asyncio.CancelledError``
+            inherits from ``BaseException`` (not ``Exception``), so it
+            bypasses generic ``except Exception`` handlers — callers
+            must explicitly detect it and pass ``was_cancelled=True``.
+            Distinct from ``was_timeout_killed`` (UA's own timeout) and
+            ``was_signaled`` (OS-level signal to a subprocess).
 
     Returns:
         A ``WorkerExit`` record.
     """
+    if was_cancelled:
+        return WorkerExit(
+            outcome="cancelled_mid_run",
+            is_protocol_violation=False,
+            is_failure=True,
+        )
     if was_timeout_killed:
         return WorkerExit(
             outcome="timeout_killed",
@@ -217,7 +243,9 @@ def park_task_for_protocol_violation(
     try:
         # Lazy import to avoid a hard module-level dependency cycle with
         # task_hub (task_hub may import from services in the future).
-        from universal_agent import task_hub  # noqa: WPS433 (local import is intentional)
+        from universal_agent import (
+            task_hub,  # noqa: WPS433 (local import is intentional)
+        )
 
         task_hub.perform_task_action(
             conn,

--- a/tests/unit/test_hermes_phase_f_foundation.py
+++ b/tests/unit/test_hermes_phase_f_foundation.py
@@ -28,7 +28,6 @@ from universal_agent.services.worker_exit_classifier import (
     classify_worker_exit,
 )
 
-
 # ── Fixtures ────────────────────────────────────────────────────────────────
 
 
@@ -157,6 +156,109 @@ def test_protocol_violation_reasons_has_three_sites() -> None:
     for value in PROTOCOL_VIOLATION_REASONS.values():
         assert value.startswith("protocol_violation_")
         assert value.endswith("_clean_exit_no_disposition")
+
+
+# ── F.1: cancelled_mid_run outcome (2026-05-13 follow-up) ────────────────────
+# Added after the 2026-05-12 → 2026-05-13 gateway-freeze incident where the
+# session reaper cancelled stuck LLM-cron coroutines (asyncio.CancelledError)
+# and the F.1 classifier mis-painted them as clean_exit_zero. See
+# plans/2026-05-13_proactivity_gap_findings.md Contributing Factor #3.
+
+
+def test_classify_cancelled_mid_run_basic() -> None:
+    """``was_cancelled=True`` is a distinct outcome from timeout/signaled.
+
+    Models the case where the gateway's session reaper called
+    ``task.cancel()`` on the in-process LLM coroutine because the 600s
+    TTL elapsed. The coroutine raised ``asyncio.CancelledError``; the
+    caller flagged it and passed ``was_cancelled=True`` here.
+    """
+    result = classify_worker_exit(
+        return_code=0, was_cancelled=True, task_closed_normally=True
+    )
+    assert result.outcome == "cancelled_mid_run"
+    assert result.is_protocol_violation is False
+    # Cancellation is a real failure for the operator's retry budget.
+    # The run did not complete its mission (briefing didn't go out,
+    # paper-to-podcast didn't dispatch, etc.).
+    assert result.is_failure is True
+
+
+def test_classify_cancelled_takes_priority_over_clean_exit_zero() -> None:
+    """``was_cancelled`` wins over rc=0 + task_closed_normally.
+
+    The original incident: a reaped session had rc_equiv=0 (falsy
+    timeout/exception flags) and task_closed_normally was True
+    because Simone had manually cancelled the cron Task Hub item via
+    ``task_hub_task_action`` before the classifier ran. Without the
+    cancellation flag the classifier would say ``clean_exit_zero``
+    (success!) — the opposite of the truth.
+    """
+    result = classify_worker_exit(
+        return_code=0,
+        was_cancelled=True,
+        task_closed_normally=True,
+        was_timeout_killed=False,
+        was_signaled=False,
+    )
+    assert result.outcome == "cancelled_mid_run"
+    assert result.is_failure is True
+
+
+def test_classify_cancelled_takes_priority_over_timeout_killed() -> None:
+    """If both flags somehow true, cancellation wins.
+
+    Timeout = UA's own ``asyncio.wait_for`` raising TimeoutError.
+    Cancellation = external ``task.cancel()`` (typically session reaper).
+    These should be mutually exclusive in practice, but if a race
+    produces both, ``cancelled_mid_run`` is the more informative
+    classification — it tells the operator the kill came from outside
+    UA's own timeout machinery.
+    """
+    result = classify_worker_exit(
+        return_code=0,
+        was_cancelled=True,
+        was_timeout_killed=True,
+    )
+    assert result.outcome == "cancelled_mid_run"
+
+
+def test_classify_cancelled_with_no_task_closure_not_protocol_violation() -> None:
+    """Cancellation pre-empts the protocol-violation check.
+
+    A cancelled coroutine never had a chance to close its task —
+    that's the cancellation, not a protocol violation. The
+    ``cancelled_mid_run`` outcome is the right signal; F.3's
+    "needs_review" path is for genuinely silent successes
+    (rc=0 + no close), which is a different operational concern.
+    """
+    result = classify_worker_exit(
+        return_code=0,
+        was_cancelled=True,
+        task_closed_normally=False,
+    )
+    assert result.outcome == "cancelled_mid_run"
+    assert result.is_protocol_violation is False
+
+
+def test_classify_default_was_cancelled_false_preserves_old_paths() -> None:
+    """Existing callers that don't pass ``was_cancelled`` keep old behavior.
+
+    Guards against accidentally regressing the four pre-existing
+    classification paths now that ``was_cancelled`` is in the signature.
+    """
+    # rc=0 + closed → clean_exit_zero
+    r1 = classify_worker_exit(return_code=0, task_closed_normally=True)
+    assert r1.outcome == "clean_exit_zero"
+    # rc=0 + not-closed → protocol violation
+    r2 = classify_worker_exit(return_code=0, task_closed_normally=False)
+    assert r2.outcome == "clean_exit_zero_no_disposition"
+    # rc != 0 → nonzero_exit
+    r3 = classify_worker_exit(return_code=1)
+    assert r3.outcome == "nonzero_exit"
+    # timeout
+    r4 = classify_worker_exit(return_code=-9, was_timeout_killed=True)
+    assert r4.outcome == "timeout_killed"
 
 
 # ── F.2: max_runtime_seconds column ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- F.1 worker exit classifier now distinguishes external cancellation (gateway session reaper, operator action) from clean success.
- Adds new ``cancelled_mid_run`` outcome + ``was_cancelled`` parameter.
- LLM cron path (``cron_service.py``) now has an explicit ``except asyncio.CancelledError`` handler that flags the cancellation before re-raising.

## Why
``asyncio.CancelledError`` inherits from ``BaseException``, NOT ``Exception`` — so it bypassed the generic ``except Exception`` block in the LLM cron's ``await run_coro`` site. When the gateway's session reaper called ``task.cancel()`` on a stuck coroutine (after the 600s TTL), the classifier's ``rc_equiv`` computation fell through to 0 with both timeout-killed and exception flags False, and ``classify_worker_exit`` happily returned ``clean_exit_zero``. The operator-facing log read:

```
Phase F.1 LLM cron job 6df69e8e9e exit classified as clean_exit_zero (rc_equiv=0)
Chron job 6df69e8e9e cancelled mid-run
Reaper closing stale session cron_6df69e8e9e (inactive=633s, ttl=600s)
```

Three signals in 5 minutes, but ``clean_exit_zero`` was the one that propagated to dashboards. **This is the observability hole that hid the 20.8h gateway freeze incident (2026-05-12 18:09 UTC → 2026-05-13 14:57 UTC) for so long.** Operators only noticed it when missing emails surfaced the gap.

## What changed

### `worker_exit_classifier.py`
- New literal in ``WorkerOutcome``: ``"cancelled_mid_run"``
- New kwarg on ``classify_worker_exit``: ``was_cancelled: bool = False``
- New branch checked **first** (cancellation wins over rc=0/closed/timeout ambiguity): returns ``WorkerExit(outcome="cancelled_mid_run", is_protocol_violation=False, is_failure=True)``
- Module docstring updated from "five buckets" → "six buckets"

### `cron_service.py` (LLM cron path)
- New local flag ``_f_was_cancelled = False`` next to the existing ``_f_was_timeout_killed`` / ``_f_was_exception`` flags
- New ``except asyncio.CancelledError`` handler that sets the flag AND re-raises (preserves asyncio's cancellation contract — swallowing CancelledError without re-raising would resume the coroutine)
- ``_f_rc_equiv_llm`` calculation now also gated on ``not _f_was_cancelled``
- Classifier call now passes ``was_cancelled=_f_was_cancelled``

## Test plan
- [x] 5 new tests in ``tests/unit/test_hermes_phase_f_foundation.py``:
  - ``test_classify_cancelled_mid_run_basic``
  - ``test_classify_cancelled_takes_priority_over_clean_exit_zero``
  - ``test_classify_cancelled_takes_priority_over_timeout_killed``
  - ``test_classify_cancelled_with_no_task_closure_not_protocol_violation``
  - ``test_classify_default_was_cancelled_false_preserves_old_paths`` (regression guard)
- [x] Existing F.1 / F.3 suite (72 tests across 4 files): all passing, no regression
- [x] ``ruff check`` clean

## Out of scope
- Pinning the actual synchronous SQL call that froze the event loop for 20.8h on 2026-05-12 — primary root cause investigation lives in `plans/2026-05-13_proactivity_gap_findings.md` and needs a follow-up PR with instrumentation.
- Wiring cancellation detection into the ``!script`` cron path. Subprocesses don't directly raise CancelledError up to the cron caller in the same way; the existing ``signaled`` outcome covers the OS-level kill case. Can be added later if a real symptom shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)