### PR TITLE
feat(cron-f): timing instrumentation for Hermes-F site-wiring sync SQL

### DIFF
--- a/src/universal_agent/cron_service.py
+++ b/src/universal_agent/cron_service.py
@@ -85,6 +85,74 @@ def _normalize_timeout_seconds(value: Any) -> Optional[int]:
     return max(MIN_CRON_TIMEOUT_SECONDS, min(MAX_CRON_TIMEOUT_SECONDS, seconds))
 
 
+# ── Hermes-F site-wiring timing instrumentation ─────────────────────────────
+#
+# The Hermes-F cron task-link helpers (``ensure_cron_task_link``,
+# ``_task_hub_open_conn``, ``_close_run``, etc.) run *synchronous* SQLite
+# work inside the cron service's *async* coroutines. Sync SQL inside async
+# code blocks the entire event loop if the call hangs.
+#
+# After the 2026-05-12 gateway freeze (20.8h silence — see
+# plans/2026-05-13_proactivity_gap_findings.md primary root cause), we
+# need breadcrumbs in the journal so a future freeze can be diagnosed
+# without operator intervention. The pattern is:
+#
+#     _t = _phase_f_start(job_id, "step_name")
+#     <synchronous sql call>
+#     _phase_f_done(job_id, "step_name", _t)
+#
+# ``_phase_f_start`` logs an entry marker at DEBUG (always present at that
+# level, so a journal slice with DEBUG enabled shows every step).
+# ``_phase_f_done`` logs the elapsed time:
+#   - WARNING if > 5s — possible deadlock root cause
+#   - INFO if > 500ms — slow, worth investigating
+#   - DEBUG otherwise — normal, kept for full breadcrumb trail
+#
+# If a step's "entering" log appears with no corresponding "took N ms"
+# log later in the journal, that step is the freeze site.
+
+_PHASE_F_WARN_MS = 5000.0  # > 5s — flag as potential deadlock root cause
+_PHASE_F_INFO_MS = 500.0   # > 500ms — flag as slow but not catastrophic
+
+
+def _phase_f_start(job_id: str, step_name: str) -> float:
+    """Log entry into a Hermes-F site-wiring step and return its start time.
+
+    Always logs at DEBUG so the full breadcrumb trail is available when
+    the journal is queried at that level. Returns ``time.perf_counter()``
+    so ``_phase_f_done`` can compute the elapsed.
+    """
+    logger.debug("Phase F site-wiring [%s]: entering %s", job_id, step_name)
+    return time.perf_counter()
+
+
+def _phase_f_done(job_id: str, step_name: str, t0: float) -> None:
+    """Log exit from a Hermes-F site-wiring step with elapsed time.
+
+    Tiered logging so the journal isn't flooded:
+      - WARNING if > 5s
+      - INFO if > 500ms
+      - DEBUG otherwise (matched pair with the entry log at DEBUG)
+    """
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    if elapsed_ms > _PHASE_F_WARN_MS:
+        logger.warning(
+            "Phase F site-wiring [%s]: %s took %.0fms "
+            "(>5s — possible deadlock root cause)",
+            job_id, step_name, elapsed_ms,
+        )
+    elif elapsed_ms > _PHASE_F_INFO_MS:
+        logger.info(
+            "Phase F site-wiring [%s]: %s took %.0fms",
+            job_id, step_name, elapsed_ms,
+        )
+    else:
+        logger.debug(
+            "Phase F site-wiring [%s]: %s took %.1fms",
+            job_id, step_name, elapsed_ms,
+        )
+
+
 def _resolve_run_at_timezone(timezone_name: str | None) -> Any:
     name = (timezone_name or "").strip() or "UTC"
     try:
@@ -1291,14 +1359,18 @@ class CronService:
                                     from universal_agent.services.cron_task_hub_link import (
                                         ensure_cron_task_link as _f_ensure_link,
                                     )
+                                    _t_open = _phase_f_start(job.job_id, "script.open_conn")
                                     _f_link_conn = _f_link_open_conn()
+                                    _phase_f_done(job.job_id, "script.open_conn", _t_open)
                                     try:
+                                        _t_link = _phase_f_start(job.job_id, "script.ensure_link")
                                         _f_linkage = _f_ensure_link(
                                             _f_link_conn,
                                             job_id=job.job_id,
                                             job_metadata=_f_job_metadata,
                                             description=(job.description or job.command)[:500],
                                         )
+                                        _phase_f_done(job.job_id, "script.ensure_link", _t_link)
                                     finally:
                                         _f_link_conn.close()
                                     if _f_linkage:
@@ -1347,19 +1419,25 @@ class CronService:
                                         from universal_agent.services.worker_exit_classifier import (
                                             find_active_assignment_for_task as _f_find_aid,
                                         )
+                                        _t_pid_open = _phase_f_start(job.job_id, "script.pid_stamp_open_conn")
                                         _f_conn = _f_open_conn()
+                                        _phase_f_done(job.job_id, "script.pid_stamp_open_conn", _t_pid_open)
                                         try:
                                             if not _f_assignment_id:
+                                                _t_find = _phase_f_start(job.job_id, "script.find_assignment")
                                                 _f_assignment_id = _f_find_aid(
                                                     _f_conn, task_id=_f_task_id,
                                                 )
+                                                _phase_f_done(job.job_id, "script.find_assignment", _t_find)
                                             if _f_assignment_id and proc.pid:
+                                                _t_pid = _phase_f_start(job.job_id, "script.record_worker_pid")
                                                 _f_th.record_worker_pid(
                                                     _f_conn,
                                                     assignment_id=_f_assignment_id,
                                                     worker_pid=int(proc.pid),
                                                 )
                                                 _f_conn.commit()
+                                                _phase_f_done(job.job_id, "script.record_worker_pid", _t_pid)
                                         finally:
                                             _f_conn.close()
                                     except Exception as _f_pid_exc:
@@ -1628,14 +1706,18 @@ class CronService:
                                         from universal_agent.services.cron_task_hub_link import (
                                             ensure_cron_task_link as _f_ensure_link_llm,
                                         )
+                                        _t_llm_open = _phase_f_start(job.job_id, "llm.open_conn")
                                         _f_link_conn_llm = _f_link_open_conn_llm()
+                                        _phase_f_done(job.job_id, "llm.open_conn", _t_llm_open)
                                         try:
+                                            _t_llm_link = _phase_f_start(job.job_id, "llm.ensure_link")
                                             _f_linkage = _f_ensure_link_llm(
                                                 _f_link_conn_llm,
                                                 job_id=job.job_id,
                                                 job_metadata=_f_job_metadata,
                                                 description=(job.description or job.command)[:500],
                                             )
+                                            _phase_f_done(job.job_id, "llm.ensure_link", _t_llm_link)
                                         finally:
                                             _f_link_conn_llm.close()
                                         if _f_linkage:

--- a/tests/unit/test_hermes_f_timing_instrumentation.py
+++ b/tests/unit/test_hermes_f_timing_instrumentation.py
@@ -1,0 +1,188 @@
+"""Hermes-F site-wiring timing instrumentation unit tests.
+
+Covers the ``_phase_f_start`` / ``_phase_f_done`` helpers added to
+``cron_service.py`` to leave breadcrumbs in the journal so a future
+event-loop freeze can be diagnosed without operator intervention.
+
+Background: the 2026-05-12 → 2026-05-13 gateway-freeze incident left
+operators with a 20.8h silence and no information about which exact
+synchronous SQL call deadlocked the asyncio event loop. The
+instrumentation here logs an entry marker (DEBUG) before each sync
+call and an exit marker (DEBUG/INFO/WARNING based on elapsed) after.
+A future freeze leaves an "entering X" log with no matching "took N ms"
+log — pointing directly at X as the freeze site.
+
+See plans/2026-05-13_proactivity_gap_findings.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from unittest import mock
+
+import pytest
+
+from universal_agent.cron_service import (
+    _PHASE_F_INFO_MS,
+    _PHASE_F_WARN_MS,
+    _phase_f_done,
+    _phase_f_start,
+)
+
+# ── _phase_f_start ──────────────────────────────────────────────────────────
+
+
+class TestPhaseFStart:
+    def test_returns_perf_counter_float(self) -> None:
+        """Returns a monotonic timestamp that ``_phase_f_done`` can use."""
+        before = time.perf_counter()
+        result = _phase_f_start("job-abc", "open_conn")
+        after = time.perf_counter()
+        assert isinstance(result, float)
+        # The returned value must be from the same clock that
+        # _phase_f_done will sample. Sanity-check it falls in the
+        # before/after window (allowing a generous margin for jitter).
+        assert before - 0.01 <= result <= after + 0.01
+
+    def test_logs_entry_at_debug_level(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Entry log is at DEBUG so the journal at INFO+ doesn't get flooded."""
+        with caplog.at_level(logging.DEBUG, logger="universal_agent.cron_service"):
+            _phase_f_start("job-xyz", "ensure_link")
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert len(debug_records) == 1
+        msg = debug_records[0].getMessage()
+        assert "job-xyz" in msg
+        assert "ensure_link" in msg
+        assert "entering" in msg.lower()
+
+    def test_entry_log_not_emitted_at_info_level(self, caplog: pytest.LogCaptureFixture) -> None:
+        """When logging level is INFO, entry log is suppressed (DEBUG-only)."""
+        with caplog.at_level(logging.INFO, logger="universal_agent.cron_service"):
+            _phase_f_start("job-info", "open_conn")
+        info_records = [r for r in caplog.records if r.levelno >= logging.INFO]
+        # The entry-log is DEBUG, so nothing at INFO+ should fire here.
+        assert info_records == []
+
+
+# ── _phase_f_done — fast path (DEBUG only) ──────────────────────────────────
+
+
+class TestPhaseFDoneFastPath:
+    def test_fast_call_logs_at_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A <500ms call only emits a DEBUG log — no INFO/WARNING noise."""
+        with caplog.at_level(logging.DEBUG, logger="universal_agent.cron_service"):
+            t0 = time.perf_counter()
+            _phase_f_done("job-fast", "open_conn", t0)
+        # Should have exactly one log record, at DEBUG.
+        debug_recs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        higher_recs = [r for r in caplog.records if r.levelno > logging.DEBUG]
+        assert len(debug_recs) == 1
+        assert higher_recs == []
+        msg = debug_recs[0].getMessage()
+        assert "job-fast" in msg
+        assert "open_conn" in msg
+        assert "took" in msg
+
+    def test_fast_call_suppressed_at_info_level(self, caplog: pytest.LogCaptureFixture) -> None:
+        """At INFO level, a fast call produces no log noise at all."""
+        with caplog.at_level(logging.INFO, logger="universal_agent.cron_service"):
+            t0 = time.perf_counter()
+            _phase_f_done("job-quiet", "open_conn", t0)
+        assert caplog.records == []
+
+
+# ── _phase_f_done — slow paths (INFO and WARNING) ───────────────────────────
+
+
+class TestPhaseFDoneSlowPath:
+    def test_slow_call_logs_at_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A 500ms-5s call escalates to INFO so it's visible in production logs."""
+        # Synthesize a "took 600ms" outcome by faking perf_counter on exit.
+        # ``_phase_f_done`` reads ``time.perf_counter()`` once at entry; we
+        # patch it to return a value 0.6s after t0 so the elapsed math
+        # is deterministic regardless of test runtime.
+        t0 = 100.0
+        with mock.patch("universal_agent.cron_service.time.perf_counter", return_value=t0 + 0.600):
+            with caplog.at_level(logging.INFO, logger="universal_agent.cron_service"):
+                _phase_f_done("job-slow", "ensure_link", t0)
+        info_recs = [r for r in caplog.records if r.levelno == logging.INFO]
+        warn_recs = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(info_recs) == 1
+        assert warn_recs == []
+        msg = info_recs[0].getMessage()
+        assert "job-slow" in msg
+        assert "ensure_link" in msg
+        # The elapsed is rendered as an integer-ms in INFO path; just
+        # verify the rough number is in the message.
+        assert "600" in msg
+
+    def test_very_slow_call_logs_at_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A >5s call escalates to WARNING — the "possible deadlock" signal."""
+        t0 = 200.0
+        with mock.patch("universal_agent.cron_service.time.perf_counter", return_value=t0 + 7.0):
+            with caplog.at_level(logging.WARNING, logger="universal_agent.cron_service"):
+                _phase_f_done("job-deadlock", "ensure_link", t0)
+        warn_recs = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warn_recs) == 1
+        msg = warn_recs[0].getMessage()
+        assert "job-deadlock" in msg
+        assert "ensure_link" in msg
+        assert "7000" in msg  # 7.0s = 7000ms
+        # The warning message includes the "possible deadlock" phrase so
+        # log-scraping tools can grep for it specifically.
+        assert "deadlock" in msg.lower()
+
+    def test_threshold_boundary_exactly_500ms_is_debug(self, caplog: pytest.LogCaptureFixture) -> None:
+        """500.0ms is NOT > 500ms (strict greater-than), so it stays DEBUG."""
+        t0 = 0.0
+        with mock.patch("universal_agent.cron_service.time.perf_counter", return_value=0.500):
+            with caplog.at_level(logging.DEBUG, logger="universal_agent.cron_service"):
+                _phase_f_done("job-edge", "open_conn", t0)
+        info_recs = [r for r in caplog.records if r.levelno >= logging.INFO]
+        assert info_recs == []
+
+    def test_threshold_boundary_just_over_500ms_is_info(self, caplog: pytest.LogCaptureFixture) -> None:
+        """500.001ms IS > 500ms, so it escalates to INFO."""
+        t0 = 0.0
+        with mock.patch("universal_agent.cron_service.time.perf_counter", return_value=0.5001):
+            with caplog.at_level(logging.INFO, logger="universal_agent.cron_service"):
+                _phase_f_done("job-edge2", "open_conn", t0)
+        info_recs = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert len(info_recs) == 1
+
+    def test_threshold_boundary_exactly_5s_is_info_not_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """5000.0ms is NOT > 5000ms, so it stays at INFO."""
+        t0 = 0.0
+        with mock.patch("universal_agent.cron_service.time.perf_counter", return_value=5.0):
+            with caplog.at_level(logging.INFO, logger="universal_agent.cron_service"):
+                _phase_f_done("job-edge3", "open_conn", t0)
+        warn_recs = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warn_recs == []
+        # And there IS an INFO record (since 5000.0 > 500.0).
+        info_recs = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert len(info_recs) == 1
+
+
+# ── Module-level constants ──────────────────────────────────────────────────
+
+
+def test_threshold_constants_are_floats_in_ms() -> None:
+    """Constants are floats so the comparison in _phase_f_done is unambiguous.
+
+    Guards against a future refactor that introduces ints (which can
+    surprise the boundary tests above).
+    """
+    assert isinstance(_PHASE_F_INFO_MS, float)
+    assert isinstance(_PHASE_F_WARN_MS, float)
+    assert _PHASE_F_INFO_MS < _PHASE_F_WARN_MS
+
+
+def test_warn_threshold_at_least_5s() -> None:
+    """The 5-second WARNING threshold is the operationally meaningful one.
+
+    Any sync SQL call taking >5s inside an async coroutine is almost
+    certainly a deadlock candidate. Tightening below 5s would risk
+    operator alert fatigue from cold-cache spikes.
+    """
+    assert _PHASE_F_WARN_MS >= 5000.0


### PR DESCRIPTION
## Summary
Pure observability change. Adds entry + elapsed-time breadcrumb logs around the 7 most suspect synchronous SQLite calls in the Hermes-F cron site-wiring (open paths only). Logs tier on elapsed:

- **WARNING** if a step takes >5s — "possible deadlock root cause"
- **INFO** if >500ms — slow but not catastrophic
- **DEBUG** otherwise — full breadcrumb trail at that level

Zero behavior change. The same Task Hub linkage / PID stamping happens exactly as before; we just know how long each step takes.

## Why
The 2026-05-12 → 2026-05-13 gateway-freeze incident left the asyncio event loop deadlocked for **20.8 hours** with no log information about which exact synchronous call hung. The journal pattern was:

```
INFO ... Chron job 2e2e40373e executing native script: simone_chat_auto_complete
<silence for 20.8 hours>
INFO ... Reaper closing stale session ... inactive=74907s
```

Hermes-F's site-wiring runs synchronous SQLite calls inside async coroutines (open the conn, run an INSERT/upsert, close the conn). If any of those hangs (lock contention, busy-timeout edge case, threading.Lock interaction with another coroutine), the event loop freezes. With this instrumentation a future freeze leaves an `entering X` log with no matching `X took N ms` log → pinpoints X as the freeze site **without** operator intervention.

## Instrumented call sites (7 total, open paths only)

| # | Step name | Location | What it does |
|---|---|---|---|
| 1 | `script.open_conn` | !script branch | `_task_hub_open_conn()` before ensure_link |
| 2 | `script.ensure_link` | !script branch | `ensure_cron_task_link()` — INSERT/upsert |
| 3 | `script.pid_stamp_open_conn` | !script branch | Second conn open after subprocess spawn |
| 4 | `script.find_assignment` | !script branch | `find_active_assignment_for_task()` |
| 5 | `script.record_worker_pid` | !script branch | `UPDATE task_hub_assignments` |
| 6 | `llm.open_conn` | LLM-prompt branch | Same as #1 |
| 7 | `llm.ensure_link` | LLM-prompt branch | Same as #2 |

Close-path sync SQL (`close_run`, `close_link`, `park_protocol_violation`) is NOT instrumented in this PR. The 2026-05-12 freeze symptom (silence immediately after "executing native script") strongly suggests the open path is the right starting point. Can extend later if a future freeze surfaces a close-path culprit.

## Helpers added (module-level in `cron_service.py`)

```python
_PHASE_F_WARN_MS = 5000.0   # > 5s
_PHASE_F_INFO_MS = 500.0    # > 500ms

def _phase_f_start(job_id, step_name) -> float:
    """Log entry at DEBUG; return perf_counter timestamp."""
    ...

def _phase_f_done(job_id, step_name, t0):
    """Log elapsed at DEBUG / INFO / WARNING tier."""
    ...
```

Usage pattern at each call site:

```python
_t = _phase_f_start(job.job_id, "script.ensure_link")
_f_linkage = _f_ensure_link(...)
_phase_f_done(job.job_id, "script.ensure_link", _t)
```

## Test plan
- [x] 12 new unit tests in `tests/unit/test_hermes_f_timing_instrumentation.py`:
  - Return value, log level, message content
  - Fast path (DEBUG only, suppressed at INFO)
  - Slow path (INFO at >500ms, WARNING at >5s with "deadlock" phrase)
  - Threshold-boundary tests (exactly 500ms / 5000ms / just-over)
  - Constants are floats; warn threshold ≥ 5s
- [x] Full existing cron + hermes-f suite (143 tests across 6 files): no regression
- [x] `ruff check` clean
- [ ] Post-deploy: confirm production journal shows occasional `INFO` logs for slow steps and no `WARNING`s during normal operation

## Future work (separate PRs)
- Asyncio-loop watchdog: periodic heartbeat task that force-restarts the gateway if the loop is silent for >N minutes. Uses these WARNING logs as one of its signals.
- Convert `_activity_store_lock` (a `threading.Lock` at `gateway_server.py:2636`) to async-safe semantics. That lock is the other latent deadlock risk discussed in `plans/2026-05-13_proactivity_gap_findings.md`.
- Close-path instrumentation if a future freeze surfaces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)