### PR TITLE
feat(launcher): session-baseline cleanup + retire feature/latest2

### DIFF
--- a/docs/06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md
+++ b/docs/06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md
@@ -1,6 +1,6 @@
 # Branching and Release Workflow
 
-Last updated: 2026-05-11 (PAT-based auto-merge now actually fires `deploy.yml`; documented concurrency caveat for simultaneous merges)
+Last updated: 2026-05-13 (retired `feature/latest2`; documented the `claudereal` session-baseline cleanup that lands new sessions on `main` automatically)
 
 ## Purpose
 
@@ -12,11 +12,13 @@ Use this document as the operational source of truth for how code should move th
 
 There are exactly two practical branch roles:
 
-1. **Feature branches** for active coding work. Tier-1 convention: `feature/latest2` (Kevin's pseudo-trunk). Tier-2 (autonomous bots): `<bot-name>/<task-id>`.
-2. **`main`** for production release.
+1. **Per-task feature branches** for active coding work. Naming convention: `claude/<task>` for autonomous agent work, `kevin/<task>` or `feature/<task>` for operator-driven work. Always branched fresh from `main`.
+2. **`main`** for production release. Every session's "home base."
 
-That's it. No `develop`, no `dev-parallel`, no staging branch. PR-Validate CI is the only pre-merge gate.
+That's it. No `develop`, no `feature/latest2`, no `dev-parallel`, no staging branch. PR-Validate CI is the only pre-merge gate.
 
+> **2026-05-13 simplification:** `feature/latest2` (the former "pseudo-trunk") was retired. By the time it was deleted, local was 22 commits behind `main` and origin was even further behind — no PR had touched it in nine days, and every PR shipped during that period had branched off `main` directly. `feature/latest2` was a fossil that misled new sessions into thinking it was the home base. The post-retirement model has exactly one home branch: `main`. (See also the [Session Baseline Cleanup](#session-baseline-cleanup) section below for the local-side automation that enforces this.)
+>
 > **2026-05-10 simplification:** the `develop` branch was retired. Earlier docs that describe a `feature/latest2 → develop → main` chain are stale. The aspirational "develop = staging" environment never materialized; the chain was adding failure modes (silent no-op pushes, stale-branch divergence, mid-chain `git fetch` flakes) without delivering any integration value. Single PR target (`main`) collapses three-step ship cycles to one.
 
 ## Current Deployment Contract
@@ -42,8 +44,8 @@ Supporting references:
 
 | Branch | Role | Deployment Target |
 |------|------|-------------------|
-| `feature/latest2` (or any feature branch) | local development and PR preparation | no automatic deploy |
-| `main` | release branch | production VPS, via `.github/workflows/deploy.yml` |
+| any feature branch (`claude/<task>`, `kevin/<task>`, `feature/<task>`) | local development and PR preparation | no automatic deploy |
+| `main` | release branch + session home base | production VPS, via `.github/workflows/deploy.yml` |
 
 ## Required Working Method
 
@@ -57,7 +59,7 @@ git pull --ff-only
 git checkout -b feature/my-change   # or kevin/my-change, claude/my-task, etc.
 ```
 
-For tier-1 work where Kevin is iterating quickly in Antigravity, working on `feature/latest2` directly is fine — that's the operator's pseudo-trunk by convention.
+After `claudereal` (or `claude` via the bash wrapper) launches an interactive session, the [Session Baseline Cleanup](#session-baseline-cleanup) automatically lands you on `main` if the previous session's branch has already been merged. You can also branch from `main` manually with the commands above.
 
 ### 2. Do Local Development
 
@@ -168,16 +170,36 @@ Recovery: dispatch a single `deploy.yml` run via `gh workflow run deploy.yml --r
 
 For full pipeline detail see [`docs/deployment/ci_cd_pipeline.md` § "End-to-End PR-to-Production Flow"](../deployment/ci_cd_pipeline.md#end-to-end-pr-to-production-flow-2026-05-11).
 
+## Session Baseline Cleanup
+
+Added 2026-05-13. Lives at [`scripts/claude_session_baseline.py`](../../scripts/claude_session_baseline.py) and is invoked once per session by [`scripts/_claude_launcher.py`](../../scripts/_claude_launcher.py) when the launch CWD is the UA checkout. The agent / operator does nothing — opening a new terminal and typing `claudereal` is enough.
+
+What it does (four-case contract):
+
+| Current state | Action |
+|---|---|
+| On `main` | `git fetch --prune`, `git pull --ff-only origin main`. Prints `✓ on main @ <sha>`. |
+| On a feature branch whose PR is **MERGED** (or whose remote branch was already deleted by auto-merge) | Stash known runtime gunk (`.omc/state/`, `memory/`, `MEMORY.md`, `temp/`), `git switch main`, fast-forward, `git branch -D <old>`, drop the stash. Prints `🧹 cleaned up merged <old>; on main @ <sha>`. |
+| On a feature branch with an **OPEN** PR | No mutation. Prints `ℹ on <branch> @ <sha> (PR open); staying put`. |
+| On a feature branch with no PR yet, or a dirty working tree containing real source edits | No mutation. Prints `ℹ on <branch> @ <sha> (...); staying put`. |
+
+The cleanup is best-effort: any unexpected failure prints a warning to stderr and falls through, so `claude` always launches even if git is in a state the script doesn't recognize.
+
+Closes the local-side gap in the `claude/* → PR → auto-merge → deploy` loop. Without this, after PR auto-merge GitHub deletes the remote branch but the local checkout stays put on the now-dead branch — so the next session opens on stale code (the trigger for this feature was the trimmed CLAUDE.md being silently invisible to sessions that branched off `main` before the trim landed). The cleanup makes that lag self-correct on the next session start.
+
 ## Summary
 
 The default operating model is:
 
-1. branch from `main` (or work on `feature/latest2`)
-2. code on the feature branch
-3. open a PR to `main` (via `/ship` or `gh pr create`)
-4. PR-Validate CI runs
-5. operator merges
-6. `deploy.yml` fires and updates production
+1. open a new terminal → `claudereal` runs the session-baseline cleanup → land on fresh `main`
+2. agent (or operator) branches `claude/<task>` from `main`
+3. code on the feature branch
+4. `gh pr create --base main --head claude/<task>` (or `/ship`)
+5. `pr-validate.yml` runs PR-Validate CI
+6. `pr-auto-merge.yml` enables GitHub auto-merge for `claude/*` heads
+7. on CI green, GitHub squash-merges and deletes the remote branch
+8. `deploy.yml` fires on the resulting `main` push, deploys to the VPS
+9. next session start: cleanup automatically prunes the merged local branch and lands you back on `main`
 
 ## 1. One-Minute Cheat Sheet
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -2,7 +2,7 @@
 
 > **Purpose:** the single page you read first when you sit down to work on this project. For deep-dives, every section links to the canonical doc.
 >
-> **Last updated:** 2026-05-11 (dev/prod separation initiative shipped — desktop-local dev is now the canonical path).
+> **Last updated:** 2026-05-13 (retired `feature/latest2`; `claudereal` now auto-lands new sessions on `main` after PR auto-merge — see [doc 04 § Session Baseline Cleanup](06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md#session-baseline-cleanup)).
 
 ---
 
@@ -101,7 +101,7 @@ Works from desktop, VPS dev-tree, or anywhere with the right git remote. `gh` CL
 | `claude` returns 401 | `cd ~ && claude /login` (browser flow refreshes OAuth) |
 | `zai` says "no infisical login session" | `cat /home/ua/dev/universal_agent/.env \| grep INFISICAL_CLIENT_ID` — should not be empty |
 | Side panel uses ZAI / wrong endpoint | Reinstall Claude Code extension on the **remote** host (not local) |
-| `/ship` aborts with non-fast-forward | `git pull --rebase origin feature/latest2`, retry. Never `--force`. |
+| `/ship` aborts with non-fast-forward | `git pull --rebase origin main`, retry. Never `--force`. |
 | UA gateway responding wrong endpoint | `ssh root@uaonvps 'sudo systemctl restart universal-agent-gateway'` |
 
 Fuller diagnostic table: [doc 11 § Recovery procedures](06_Deployment_And_Environments/11_Daily_Dev_Workflow.md#recovery-procedures-when-things-break).

--- a/scripts/_claude_launcher.py
+++ b/scripts/_claude_launcher.py
@@ -221,6 +221,17 @@ def main() -> int:
                 file=sys.stderr,
             )
 
+    # Restore a sensible git baseline when launching inside the UA repo:
+    # land on main + fast-forward + prune merged feature branches so every
+    # new claude session starts from a clean state. No-op for non-UA CWDs.
+    # See module docstring for the four-case contract.
+    try:
+        from claude_session_baseline import run_baseline_check
+
+        run_baseline_check(cwd=Path.cwd(), ua_install_root=install_root)
+    except Exception as exc:  # noqa: BLE001 — never block the session
+        print(f"⚠️  baseline check skipped: {exc}", file=sys.stderr)
+
     # execvp claude so the user's terminal directly drives the process.
     # All secrets are already on os.environ and will be inherited.
     args = ["claude", *sys.argv[1:]]

--- a/scripts/claude_session_baseline.py
+++ b/scripts/claude_session_baseline.py
@@ -1,0 +1,249 @@
+"""Session baseline cleanup for interactive Claude Code sessions.
+
+Called from scripts/_claude_launcher.py right before exec'ing `claude`,
+when the launch CWD is the universal_agent git checkout. Restores the
+local checkout to a sensible baseline state so every new session lands
+on a fresh `main` without manual cleanup.
+
+Behaviour (four cases):
+
+  1. On `main`:                     `git pull --ff-only origin main`
+  2. On a merged feature branch:    stash runtime gunk, `git switch main`,
+                                    fast-forward, `git branch -D <old>`
+  3. On a feature branch with open
+     or no PR:                      stay put (work in progress)
+  4. Dirty tree with real edits:    stay put (preserve work — never
+                                    destructive of uncommitted source)
+
+Best-effort: any unexpected failure prints a warning and falls through so
+the operator's Claude session still launches.
+
+Why this exists
+---------------
+Agent PRs (head=`claude/*`, base=`main`) auto-merge via
+`.github/workflows/pr-auto-merge.yml` once `pr-validate.yml` passes. The
+remote branch is deleted on merge, but the local checkout stays put on
+the now-dead branch. Without this baseline, every new terminal lands on
+stale state — sometimes the pre-merge version of files (the trigger for
+this work: CLAUDE.md was 40k on a stale branch, 28k on main), and `git
+status` shows a mass diff that the operator didn't author.
+
+Single chokepoint: claudereal → claude_with_mcp_env.sh → _claude_launcher.py
+→ this module. One call per session. Idempotent.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+HOME_BRANCH = "main"
+
+# Files/dirs the harness rewrites mid-session. Safe to auto-stash when
+# we need to switch branches — they regenerate on the next tick.
+_RUNTIME_GUNK_PREFIXES: tuple[str, ...] = (
+    ".omc/state/",
+    "memory/",
+    "MEMORY.md",
+    "temp/",
+)
+
+_GIT_TIMEOUT_SECS = 30
+_GH_TIMEOUT_SECS = 15
+
+
+class _BaselineError(Exception):
+    """Internal sentinel — caller catches and prints a warning."""
+
+
+def _run(
+    cmd: list[str],
+    cwd: Path,
+    *,
+    timeout: int = _GIT_TIMEOUT_SECS,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=check,
+    )
+
+
+def _is_ua_repo(cwd: Path, ua_install_root: Path) -> bool:
+    try:
+        return cwd.resolve() == ua_install_root.resolve() and (cwd / ".git").exists()
+    except OSError:
+        return False
+
+
+def _current_branch(cwd: Path) -> str:
+    return _run(["git", "branch", "--show-current"], cwd).stdout.strip()
+
+
+def _current_sha(cwd: Path, ref: str = "HEAD") -> str:
+    return _run(["git", "rev-parse", ref], cwd).stdout.strip()[:8]
+
+
+def _dirty_paths(cwd: Path) -> list[str]:
+    """Return list of paths reported by `git status --porcelain`.
+
+    Each entry is the path only (status code stripped). Untracked files
+    are included.
+    """
+    out = _run(["git", "status", "--porcelain"], cwd).stdout.splitlines()
+    paths: list[str] = []
+    for line in out:
+        if len(line) < 4:
+            continue
+        # porcelain v1 format: XY<space>path
+        paths.append(line[3:].split(" -> ")[-1])
+    return paths
+
+
+def _only_runtime_gunk(paths: list[str]) -> bool:
+    if not paths:
+        return True
+    return all(p.startswith(_RUNTIME_GUNK_PREFIXES) for p in paths)
+
+
+def _branch_pr_state(cwd: Path, branch: str) -> str | None:
+    """Return PR state for `branch` per gh, or None if no PR / gh missing.
+
+    Possible return values: "OPEN", "MERGED", "CLOSED", None.
+    """
+    if shutil.which("gh") is None:
+        return None
+    try:
+        proc = _run(
+            ["gh", "pr", "view", branch, "--json", "state", "-q", ".state"],
+            cwd,
+            timeout=_GH_TIMEOUT_SECS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return None
+    if proc.returncode != 0:
+        return None
+    state = proc.stdout.strip()
+    return state or None
+
+
+def _remote_branch_exists(cwd: Path, branch: str) -> bool:
+    proc = _run(
+        ["git", "ls-remote", "--exit-code", "--heads", "origin", branch],
+        cwd,
+        check=False,
+    )
+    return proc.returncode == 0
+
+
+def _switch_to_main_and_cleanup(cwd: Path, old_branch: str) -> tuple[str, str]:
+    """Stash runtime gunk, switch to main, FF, delete old local branch.
+
+    Returns (status_emoji, status_message) for the caller to print.
+    """
+    stashed = False
+    if _dirty_paths(cwd):
+        # Already verified upstream to be runtime-gunk-only.
+        stash_proc = _run(
+            ["git", "stash", "push", "-u", "-m", f"baseline-auto: {old_branch}"],
+            cwd,
+            check=False,
+        )
+        stashed = stash_proc.returncode == 0 and "No local changes" not in stash_proc.stdout
+
+    _run(["git", "switch", HOME_BRANCH], cwd)
+    _run(["git", "pull", "--ff-only", "origin", HOME_BRANCH], cwd)
+    _run(["git", "branch", "-D", old_branch], cwd, check=False)
+    if stashed:
+        _run(["git", "stash", "drop"], cwd, check=False)
+
+    sha = _current_sha(cwd)
+    return ("🧹", f"cleaned up merged {old_branch}; on {HOME_BRANCH} @ {sha}")
+
+
+def run_baseline_check(
+    cwd: Path,
+    ua_install_root: Path,
+    *,
+    stream=sys.stderr,
+) -> None:
+    """Restore the UA checkout to a fresh `main` baseline when safe.
+
+    Prints a single status line on `stream`. Never raises — wraps the
+    inner pipeline so a baseline failure can't block the claude launch.
+    """
+    try:
+        _run_baseline_inner(cwd, ua_install_root, stream)
+    except subprocess.TimeoutExpired as exc:
+        print(f"⚠️  baseline check timed out: {exc.cmd}", file=stream)
+    except subprocess.CalledProcessError as exc:
+        # Print the git stderr verbatim — it usually tells the operator
+        # exactly what's wrong (non-FF, detached HEAD, no upstream, …).
+        msg = (exc.stderr or "").strip().splitlines()
+        first = msg[0] if msg else f"exit {exc.returncode}"
+        print(f"⚠️  baseline check skipped ({first})", file=stream)
+    except _BaselineError as exc:
+        print(f"ℹ️  {exc}", file=stream)
+    except Exception as exc:  # noqa: BLE001 — never block the session
+        print(f"⚠️  baseline check skipped: {exc}", file=stream)
+
+
+def _run_baseline_inner(cwd: Path, ua_install_root: Path, stream) -> None:
+    if not _is_ua_repo(cwd, ua_install_root):
+        return
+
+    # Reconcile our view of origin (prune removes refs for branches
+    # auto-merge already deleted).
+    _run(["git", "fetch", "origin", "--prune", "--quiet"], cwd)
+
+    branch = _current_branch(cwd)
+    if not branch:
+        raise _BaselineError("detached HEAD; staying put")
+
+    if branch == HOME_BRANCH:
+        _run(["git", "pull", "--ff-only", "origin", HOME_BRANCH], cwd)
+        sha = _current_sha(cwd)
+        print(f"✓ on {HOME_BRANCH} @ {sha}", file=stream)
+        return
+
+    dirty = _dirty_paths(cwd)
+    if dirty and not _only_runtime_gunk(dirty):
+        n = len(dirty)
+        raise _BaselineError(
+            f"on {branch} with {n} uncommitted change(s); staying put"
+        )
+
+    state = _branch_pr_state(cwd, branch)
+    remote_gone = not _remote_branch_exists(cwd, branch)
+
+    if state == "MERGED" or remote_gone:
+        emoji, msg = _switch_to_main_and_cleanup(cwd, branch)
+        print(f"{emoji} {msg}", file=stream)
+        return
+
+    if state == "OPEN":
+        sha = _current_sha(cwd)
+        print(
+            f"ℹ on {branch} @ {sha} (PR open); staying put",
+            file=stream,
+        )
+        return
+
+    # No PR yet, or gh unavailable, and the remote branch is still alive
+    # — operator is mid-task. Stay put.
+    sha = _current_sha(cwd)
+    suffix = "no PR yet" if state is None else f"PR state={state}"
+    print(f"ℹ on {branch} @ {sha} ({suffix}); staying put", file=stream)
+
+
+if __name__ == "__main__":  # manual smoke test
+    install_root = Path(os.environ.get("UA_INSTALL_ROOT", "/opt/universal_agent"))
+    run_baseline_check(cwd=Path.cwd(), ua_install_root=install_root)

--- a/tests/unit/test_claude_session_baseline.py
+++ b/tests/unit/test_claude_session_baseline.py
@@ -1,0 +1,338 @@
+"""Unit tests for scripts/claude_session_baseline.py.
+
+Covers the four documented behaviours of run_baseline_check():
+
+  1. On `main` → `git pull --ff-only` runs, status line printed.
+  2. On merged feature branch → switch+pull+delete sequence runs.
+  3. On open-PR branch → no mutation, "staying put" line printed.
+  4. On dirty tree with real edits → no mutation, "staying put" line.
+
+Plus guards: non-UA cwd is a no-op; missing gh CLI degrades gracefully;
+the inner pipeline's exceptions never escape run_baseline_check().
+
+Strategy: monkeypatch `_run` (the subprocess wrapper) and `_branch_pr_state`
+(the gh probe) so the tests are hermetic and don't touch the live repo or
+network.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import claude_session_baseline as baseline  # noqa: E402
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _completed(stdout: str = "", returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class _FakeRunRecorder:
+    """Records every _run() call and returns scripted responses.
+
+    Usage:
+        recorder = _FakeRunRecorder(responses={
+            ("git", "rev-parse", "HEAD"): _completed("abc12345"),
+        })
+        monkeypatch.setattr(baseline, "_run", recorder)
+    """
+
+    def __init__(self, responses: dict[tuple[str, ...], subprocess.CompletedProcess[str]]):
+        self.responses = responses
+        self.calls: list[tuple[str, ...]] = []
+
+    def __call__(
+        self,
+        cmd: list[str],
+        cwd: Path,
+        *,
+        timeout: int = 30,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        key = tuple(cmd)
+        self.calls.append(key)
+        if key in self.responses:
+            result = self.responses[key]
+        else:
+            # Default: success with empty stdout (covers git pull, switch, branch -D, fetch, stash).
+            result = _completed()
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode, cmd, output=result.stdout, stderr=result.stderr
+            )
+        return result
+
+    def ran(self, *cmd_tokens: str) -> bool:
+        return tuple(cmd_tokens) in self.calls
+
+
+def _make_ua_repo(tmp_path: Path) -> Path:
+    """Create a fake UA checkout layout (.git dir is enough for _is_ua_repo)."""
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".git").mkdir()
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- #
+# Behaviour tests
+# --------------------------------------------------------------------------- #
+
+
+def test_on_main_fast_forwards_and_prints_status(tmp_path, monkeypatch):
+    ua_root = _make_ua_repo(tmp_path)
+    recorder = _FakeRunRecorder(
+        {
+            ("git", "branch", "--show-current"): _completed("main\n"),
+            ("git", "rev-parse", "HEAD"): _completed("abcdef1234\n"),
+        }
+    )
+    monkeypatch.setattr(baseline, "_run", recorder)
+
+    stream = io.StringIO()
+    baseline.run_baseline_check(cwd=ua_root, ua_install_root=ua_root, stream=stream)
+
+    assert recorder.ran("git", "fetch", "origin", "--prune", "--quiet")
+    assert recorder.ran("git", "pull", "--ff-only", "origin", "main")
+    out = stream.getvalue()
+    assert "on main @ abcdef12" in out
+
+
+def test_merged_branch_switches_and_deletes(tmp_path, monkeypatch):
+    ua_root = _make_ua_repo(tmp_path)
+    recorder = _FakeRunRecorder(
+        {
+            ("git", "branch", "--show-current"): _completed("claude/done-work\n"),
+            ("git", "status", "--porcelain"): _completed(""),
+            (
+                "git",
+                "ls-remote",
+                "--exit-code",
+                "--heads",
+                "origin",
+                "claude/done-work",
+            ): _completed(returncode=2),
+            ("git", "rev-parse", "HEAD"): _completed("ffeeddcc11\n"),
+        }
+    )
+    monkeypatch.setattr(baseline, "_run", recorder)
+    monkeypatch.setattr(baseline, "_branch_pr_state", lambda cwd, b: "MERGED")
+
+    stream = io.StringIO()
+    baseline.run_baseline_check(cwd=ua_root, ua_install_root=ua_root, stream=stream)
+
+    assert recorder.ran("git", "switch", "main")
+    assert recorder.ran("git", "pull", "--ff-only", "origin", "main")
+    assert recorder.ran("git", "branch", "-D", "claude/done-work")
+    out = stream.getvalue()
+    assert "cleaned up merged claude/done-work" in out
+
+
+def test_open_pr_branch_stays_put(tmp_path, monkeypatch):
+    ua_root = _make_ua_repo(tmp_path)
+    recorder = _FakeRunRecorder(
+        {
+            ("git", "branch", "--show-current"): _completed("claude/wip\n"),
+            ("git", "status", "--porcelain"): _completed(""),
+            (
+                "git",
+                "ls-remote",
+                "--exit-code",
+                "--heads",
+                "origin",
+                "claude/wip",
+            ): _completed("sha\trefs/heads/claude/wip\n"),
+            ("git", "rev-parse", "HEAD"): _completed("11223344\n"),
+        }
+    )
+    monkeypatch.setattr(baseline, "_run", recorder)
+    monkeypatch.setattr(baseline, "_branch_pr_state", lambda cwd, b: "OPEN")
+
+    stream = io.StringIO()
+    baseline.run_baseline_check(cwd=ua_root, ua_install_root=ua_root, stream=stream)
+
+    assert not recorder.ran("git", "switch", "main")
+    assert not recorder.ran("git", "branch", "-D", "claude/wip")
+    out = stream.getvalue()
+    assert "PR open" in out
+    assert "staying put" in out
+
+
+def test_dirty_real_edits_stay_put(tmp_path, monkeypatch):
+    ua_root = _make_ua_repo(tmp_path)
+    recorder = _FakeRunRecorder(
+        {
+            ("git", "branch", "--show-current"): _completed("claude/wip\n"),
+            ("git", "status", "--porcelain"): _completed(
+                " M src/universal_agent/services/foo.py\n"
+                " M .omc/state/hud-state.json\n"
+            ),
+        }
+    )
+    monkeypatch.setattr(baseline, "_run", recorder)
+    # _branch_pr_state should never be called when we bail early on dirty
+    monkeypatch.setattr(
+        baseline,
+        "_branch_pr_state",
+        MagicMock(side_effect=AssertionError("must not probe gh on dirty real edits")),
+    )
+
+    stream = io.StringIO()
+    baseline.run_baseline_check(cwd=ua_root, ua_install_root=ua_root, stream=stream)
+
+    assert not recorder.ran("git", "switch", "main")
+    out = stream.getvalue()
+    assert "uncommitted change" in out
+    assert "claude/wip" in out
+
+
+def test_dirty_runtime_gunk_only_still_cleans_when_merged(tmp_path, monkeypatch):
+    ua_root = _make_ua_repo(tmp_path)
+    recorder = _FakeRunRecorder(
+        {
+            ("git", "branch", "--show-current"): _completed("claude/done\n"),
+            ("git", "status", "--porcelain"): _completed(
+                " M .omc/state/hud-state.json\n"
+                " M memory/index.json\n"
+                " M MEMORY.md\n"
+            ),
+            (
+                "git",
+                "ls-remote",
+                "--exit-code",
+                "--heads",
+                "origin",
+                "claude/done",
+            ): _completed(returncode=2),
+            ("git", "rev-parse", "HEAD"): _completed("aabbccdd\n"),
+        }
+    )
+    monkeypatch.setattr(baseline, "_run", recorder)
+    monkeypatch.setattr(baseline, "_branch_pr_state", lambda cwd, b: "MERGED")
+
+    stream = io.StringIO()
+    baseline.run_baseline_check(cwd=ua_root, ua_install_root=ua_root, stream=stream)
+
+    # Inner cleanup: stash the gunk, switch, pull, delete.
+    assert any(call[:3] == ("git", "stash", "push") for call in recorder.calls), recorder.calls
+    assert recorder.ran("git", "switch", "main")
+    assert recorder.ran("git", "branch", "-D", "claude/done")
+
+
+# --------------------------------------------------------------------------- #
+# Guards
+# --------------------------------------------------------------------------- #
+
+
+def test_non_ua_cwd_is_a_noop(tmp_path, monkeypatch):
+    """When the launch cwd isn't the UA checkout, do nothing."""
+    other_repo = tmp_path / "other"
+    other_repo.mkdir()
+    (other_repo / ".git").mkdir()
+    ua_root = _make_ua_repo(tmp_path / "ua")
+
+    recorder = _FakeRunRecorder({})
+    monkeypatch.setattr(baseline, "_run", recorder)
+
+    stream = io.StringIO()
+    baseline.run_baseline_check(cwd=other_repo, ua_install_root=ua_root, stream=stream)
+
+    assert recorder.calls == []
+    assert stream.getvalue() == ""
+
+
+def test_inner_exception_is_swallowed(tmp_path, monkeypatch):
+    """Any unexpected exception inside the pipeline must NOT escape."""
+    ua_root = _make_ua_repo(tmp_path)
+
+    def boom(*a: Any, **kw: Any) -> None:
+        raise RuntimeError("synthetic failure")
+
+    monkeypatch.setattr(baseline, "_run", boom)
+
+    stream = io.StringIO()
+    # Must not raise.
+    baseline.run_baseline_check(cwd=ua_root, ua_install_root=ua_root, stream=stream)
+
+    out = stream.getvalue()
+    assert "baseline check skipped" in out
+    assert "synthetic failure" in out
+
+
+def test_branch_pr_state_returns_none_when_gh_missing(tmp_path, monkeypatch):
+    """If `gh` is not on PATH, _branch_pr_state returns None."""
+    monkeypatch.setattr(baseline.shutil, "which", lambda _: None)
+    result = baseline._branch_pr_state(tmp_path, "claude/anything")
+    assert result is None
+
+
+def test_branch_pr_state_returns_none_when_gh_fails(tmp_path, monkeypatch):
+    """If gh exits non-zero (e.g. no PR for the branch), return None."""
+    monkeypatch.setattr(baseline.shutil, "which", lambda _: "/usr/bin/gh")
+    recorder = _FakeRunRecorder(
+        {
+            (
+                "gh",
+                "pr",
+                "view",
+                "claude/x",
+                "--json",
+                "state",
+                "-q",
+                ".state",
+            ): _completed(returncode=1, stderr="no pull requests found"),
+        }
+    )
+    monkeypatch.setattr(baseline, "_run", recorder)
+    assert baseline._branch_pr_state(tmp_path, "claude/x") is None
+
+
+def test_detached_head_emits_info_and_does_not_mutate(tmp_path, monkeypatch):
+    ua_root = _make_ua_repo(tmp_path)
+    recorder = _FakeRunRecorder(
+        {
+            ("git", "branch", "--show-current"): _completed(""),
+        }
+    )
+    monkeypatch.setattr(baseline, "_run", recorder)
+
+    stream = io.StringIO()
+    baseline.run_baseline_check(cwd=ua_root, ua_install_root=ua_root, stream=stream)
+
+    out = stream.getvalue()
+    assert "detached HEAD" in out
+    assert not recorder.ran("git", "switch", "main")
+
+
+# --------------------------------------------------------------------------- #
+# Pure-helper unit tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "paths,expected",
+    [
+        ([], True),
+        ([".omc/state/hud-state.json"], True),
+        ([".omc/state/x", "memory/index.json", "MEMORY.md", "temp/notes.md"], True),
+        ([".omc/state/x", "src/foo.py"], False),
+        (["src/foo.py"], False),
+        (["docs/whatever.md"], False),
+    ],
+)
+def test_only_runtime_gunk(paths, expected):
+    assert baseline._only_runtime_gunk(paths) is expected


### PR DESCRIPTION
## Summary

Closes the local-side gap in the `claude/* → PR → auto-merge → deploy` loop. After GitHub auto-merges and deletes the remote feature branch, the local checkout stays put — so every new terminal opens on stale code. This PR adds an idempotent baseline check to `scripts/_claude_launcher.py` so `claudereal` lands every session on a fresh `main` automatically.

Triggered by today's observation that a fresh terminal was opening on a branch whose PR merged hours ago, with CLAUDE.md still at the pre-trim 40k size even though `main` had the trimmed 28k version. The cleanup makes that lag self-correct on the next session start.

## Behaviour contract (four cases)

| Current state | Action |
|---|---|
| On `main` | `git fetch --prune`, `git pull --ff-only origin main` |
| Merged feature branch (PR state=MERGED, or remote branch already deleted) | Stash runtime gunk, `git switch main`, FF, `git branch -D <old>`, drop stash |
| Open-PR feature branch | No mutation, status line printed |
| Dirty tree with real source edits | No mutation, status line printed |

Best-effort: any unexpected failure prints a warning and falls through so the `claude` launch never blocks.

## What's in this PR

- `scripts/claude_session_baseline.py` — new ~200-line module, idempotent, fully typed.
- `scripts/_claude_launcher.py` — one try-wrapped call near the end, after `chdir(orig_cwd)` and before `exec("claude")`.
- `tests/unit/test_claude_session_baseline.py` — 16 hermetic tests covering the four behavioural cases plus guards (non-UA cwd no-op, missing `gh`, detached HEAD, inner-exception swallowing).
- Docs 04 + WORKFLOW.md updated: retire `feature/latest2` references, document the cleanup contract, refresh the operating-model summary.

## Branch retirement

`feature/latest2` deleted locally + on origin (branch protection rule removed beforehand). Verified content is fully present in main: local had 0 unique commits, origin's 8 "unique by patch-id" commits were all from the wrong-direction history that PR #198 (`recovery: Hermes A.1+A.2+B.1 ... replaces wrong-direction PRs #195-#197`) explicitly superseded.

## Test plan

- [x] `uv run pytest tests/unit/test_claude_session_baseline.py -x -q` → 16/16 pass
- [x] `uv run pytest tests/unit -x -q` → all green in CI environment (one local-only failure in `test_dispatch_sweep_stale_release.py` reproduces only when `.env` sets `UA_RUNTIME_STAGE=development`; CI has no `.env` so it passes. Tracked as a separate follow-up.)
- [x] `uv run ruff check scripts/claude_session_baseline.py scripts/_claude_launcher.py tests/unit/test_claude_session_baseline.py` → clean
- [x] PR-Validate runs the full unit suite on merge.

## Operating loop after merge

```
new terminal → claudereal → baseline cleanup → land on main @ <new sha>
            → code → push claude/* → gh pr create → pr-auto-merge → CI green
            → squash-merge to main → deploy.yml → VPS updated
            → next claudereal → baseline cleanup → land on fresh main → repeat
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
