### PR TITLE
docs(link): add missing docstrings to Link services public functions

### DIFF
--- a/src/universal_agent/services/link_card_tokens.py
+++ b/src/universal_agent/services/link_card_tokens.py
@@ -37,6 +37,11 @@ def _project_root() -> Path:
 
 
 def resolve_tokens_path() -> Path:
+    """Return the JSON file path for one-shot card-detail tokens.
+
+    Override with ``UA_LINK_CARD_TOKENS_PATH``; defaults to
+    ``<project-root>/AGENT_RUN_WORKSPACES/link_card_tokens.json``.
+    """
     override = os.getenv("UA_LINK_CARD_TOKENS_PATH")
     if override:
         return Path(override).expanduser().resolve()

--- a/src/universal_agent/services/link_notifier.py
+++ b/src/universal_agent/services/link_notifier.py
@@ -37,6 +37,11 @@ def _project_root() -> Path:
 
 
 def resolve_state_path() -> Path:
+    """Return the JSON file path for notification-idempotency state.
+
+    Override with UA_LINK_NOTIFIER_STATE_PATH; defaults to
+    <project-root>/AGENT_RUN_WORKSPACES/link_notifications.json.
+    """
     override = os.getenv("UA_LINK_NOTIFIER_STATE_PATH")
     if override:
         return Path(override).expanduser().resolve()
@@ -114,6 +119,7 @@ def _send_via_agentmail(
 
 
 def already_notified(spend_request_id: str) -> bool:
+    """Return True if a notification was already sent for *spend_request_id*."""
     state = _load_state()
     return bool((state.get("notified") or {}).get(spend_request_id))
 
@@ -125,6 +131,11 @@ def mark_notified(
     sent_to: Optional[str],
     via: Optional[str],
 ) -> None:
+    """Record that *spend_request_id* has been notified.
+
+    Persists the card-token, recipient, and delivery channel alongside a
+    timestamp so subsequent already_notified calls return True.
+    """
     state = _load_state()
     notified = state.setdefault("notified", {})
     notified[spend_request_id] = {

--- a/src/universal_agent/services/link_purchaser.py
+++ b/src/universal_agent/services/link_purchaser.py
@@ -54,6 +54,11 @@ def _project_root() -> Path:
 
 
 def resolve_captcha_usage_path() -> Path:
+    """Return the JSONL path used to track daily captcha-solver invocations.
+
+    Override with ``UA_LINK_CAPTCHA_USAGE_PATH``; defaults to
+    ``<project-root>/AGENT_RUN_WORKSPACES/link_captcha_usage.jsonl``.
+    """
     override = os.getenv("UA_LINK_CAPTCHA_USAGE_PATH")
     if override:
         return Path(override).expanduser().resolve()
@@ -61,6 +66,11 @@ def resolve_captcha_usage_path() -> Path:
 
 
 def resolve_attempts_path() -> Path:
+    """Return the JSON file path for checkout-attempt idempotency records.
+
+    Override with ``UA_LINK_PURCHASER_ATTEMPTS_PATH``; defaults to
+    ``<project-root>/AGENT_RUN_WORKSPACES/link_purchaser_attempts.json``.
+    """
     override = os.getenv("UA_LINK_PURCHASER_ATTEMPTS_PATH")
     if override:
         return Path(override).expanduser().resolve()
@@ -100,6 +110,7 @@ def _read_captcha_usage_today() -> int:
 
 
 def captcha_budget_snapshot() -> dict[str, Any]:
+    """Return a dict with ``cap``, ``used``, ``remaining`` and ``window`` for the rolling 24h captcha budget."""
     cap = feature_flags.link_daily_captcha_budget()
     used = _read_captcha_usage_today()
     return {
@@ -125,6 +136,7 @@ def record_captcha_usage(spend_request_id: str, *, merchant_url: str | None = No
 
 
 def captcha_budget_available() -> bool:
+    """Return ``True`` when the daily captcha budget has not been exhausted."""
     snap = captcha_budget_snapshot()
     return snap["remaining"] > 0
 
@@ -151,10 +163,15 @@ def _save_attempts(payload: dict[str, Any]) -> None:
 
 
 def get_attempt(spend_request_id: str) -> Optional[dict[str, Any]]:
+    """Return the previously recorded outcome for *spend_request_id*, or ``None``."""
     return (_load_attempts().get("attempts") or {}).get(spend_request_id)
 
 
 def record_attempt(spend_request_id: str, outcome: dict[str, Any]) -> None:
+    """Persist a checkout outcome keyed by *spend_request_id*.
+
+    Card details are stripped before writing; only status metadata is stored.
+    """
     payload = _load_attempts()
     attempts = payload.setdefault("attempts", {})
     attempts[spend_request_id] = {

--- a/src/universal_agent/tools/link_bridge.py
+++ b/src/universal_agent/tools/link_bridge.py
@@ -571,6 +571,12 @@ def retrieve_spend_request(
 
 
 def list_payment_methods(*, caller: str) -> dict[str, Any]:
+    """List payment methods available in the authenticated Link wallet.
+
+    Guarded by the master switch and caller allowlist. In stub mode
+    returns a canned list. Otherwise shells out to ``link-cli
+    payment-methods list`` and returns the parsed JSON payload.
+    """
     audit_id = _new_audit_id()
     for check in (_check_master_switch(), _check_caller(caller)):
         if check is not None:


### PR DESCRIPTION
## Summary
- Adds docstrings to public functions in `link_card_tokens.py`, `link_notifier.py`, `link_purchaser.py`, and `tools/link_bridge.py`.
- One of three Cody-authored docstring branches flagged in Simone's 2026-05-14 daily digest (pairs with #276 and the intelligence-reporter PR).

## Test plan
- [x] PR-Validate is the only pre-deploy gate; this is a docstring-only diff across four files.
- [x] No runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)