### PR TITLE
fix(mission-guardrail): widen email-negation regex to cover "do not send email"

### DIFF
--- a/src/universal_agent/mission_guardrails.py
+++ b/src/universal_agent/mission_guardrails.py
@@ -35,7 +35,15 @@ _EMAIL_ACTION_PATTERNS = (
     # "one per gmail" (existing interim pattern dependency)
     re.compile(r"\bone\s+per\s+gmail\b", re.IGNORECASE),
 )
-_EMAIL_NEGATION_PATTERN = re.compile(r"\b(do\s*not|don['']t|no)\s+(gmail|e-?mail)\b", re.IGNORECASE)
+# Negation must allow intervening words so we catch phrases like
+# "do not send email", "don't send an email", "do not deliver the email"
+# in addition to bare "do not email" / "don't email".  The execution
+# prompt template line "do not send email unless the user explicitly
+# asked for email delivery" is the canonical false positive this guards.
+_EMAIL_NEGATION_PATTERN = re.compile(
+    r"\b(do\s*not|don['']t|no)\b(?:\s+\w+){0,3}\s+(gmail|e-?mail)\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_mission_guardrails.py
+++ b/tests/unit/test_mission_guardrails.py
@@ -96,13 +96,10 @@ def test_code_gen_request_does_not_trigger_email_required():
     assert contract.min_email_sends == 0
 
 
-def test_inflated_execution_prompt_would_falsely_trigger_email():
-    """Documents that the inflated prompt template contains email-triggering
-    language.  If build_mission_contract ever receives this instead of the
-    raw user input, email_required would be a false positive."""
-    # This is the actual delivery contract text appended by build_todo_execution_prompt
-    # for interactive_chat tasks.  The phrase "do not send email unless" contains
-    # the token pair "send ... email" which matches _EMAIL_ACTION_PATTERNS[2].
+def test_inflated_execution_prompt_no_longer_triggers_email_required():
+    """The inflated prompt template contains 'do not send email unless ...';
+    the negation pattern must suppress the 'send ... email' action match so
+    purely-chat tasks aren't forced to email."""
     inflated = (
         "You are Simone. Execute the assigned work items.\n"
         "== DELIVERY CONTRACT ==\n"
@@ -111,10 +108,30 @@ def test_inflated_execution_prompt_would_falsely_trigger_email():
         "Work Item 1: Direct Codie to create a demo application at /tmp/test\n"
     )
     contract = build_mission_contract(inflated)
-    # The inflated prompt matches _EMAIL_ACTION_PATTERNS ("send ... email"),
-    # which is exactly the false positive we guard against.
-    assert contract.email_required is True, (
-        "If this starts passing as False, the prompt template language changed "
-        "and the guard in todo_dispatch_service.py may no longer be necessary."
+    assert contract.email_required is False
+    assert contract.min_email_sends == 0
+
+
+def test_email_negation_handles_intervening_verbs():
+    """Negation should cover 'do not send/deliver/forward (a|the)? email' too,
+    not just bare 'do not email'."""
+    for phrase in (
+        "do not send email about this",
+        "don't send an email about this",
+        "do not deliver the email summary",
+        "don't forward any email",
+        "no send email please",
+    ):
+        contract = build_mission_contract(phrase)
+        assert contract.email_required is False, f"negation failed for: {phrase!r}"
+
+
+def test_explicit_email_request_still_required_despite_nearby_negation():
+    """A real 'email me the report' request should still set email_required even
+    if a separate negated clause sits in the same prompt — they're independent
+    matches and we err on the side of fulfilling the explicit ask."""
+    contract = build_mission_contract(
+        "Email me the report. Do not include any private attachments."
     )
+    assert contract.email_required is True
 


### PR DESCRIPTION
## Summary
- Production fired `Mission Guardrail Blocked Completion` notifications because the email-negation regex was narrower than the email-action regex.
- `_EMAIL_ACTION_PATTERNS[2]` matches `send … email` with up to 20 chars between — so the inflated execution-prompt line "do not send email unless the user explicitly asked for email delivery" set `email_required=True`.
- `_EMAIL_NEGATION_PATTERN` only matched `do not` / `don't` / `no` directly adjacent to `email`/`gmail`, so it never suppressed the action match. When the run later called `task_hub_task_action(action="complete")` (the correct disposition for a non-email task), the guardrail rejected the run with "Final completion attempted without the required email delivery step."
- Widened the negation to allow up to 3 intervening words. Phrases now correctly suppressed: `do not send email`, `don't send an email`, `do not deliver the email summary`, `no send email please`. Explicit positive asks (`Email me the report …`) still trip the contract independently.

## Why this is the root-cause fix
There was already a workaround in `services/todo_dispatch_service.py` that bypasses the inflated prompt by using raw task descriptions for `mission_contract_input`. But the chat-panel path in `gateway_server.py:32923-32925` passes `original_user_input` through unchanged — so any user message containing "don't send email about this" would still trigger the false positive. Fixing the negation pattern itself closes both paths and any future call site.

## Test plan
- [x] `pytest tests/unit/test_mission_guardrails.py -v` — 9/9 pass
- [x] Flipped `test_inflated_execution_prompt_would_falsely_trigger_email` from documenting the false positive (asserting `True`) to asserting it no longer fires (`False`)
- [x] Added `test_email_negation_handles_intervening_verbs` covering 5 phrasings of "do not <verb> email"
- [x] Added `test_explicit_email_request_still_required_despite_nearby_negation` so we don't over-correct — a real "email me the report" ask in a prompt that also has a negated clause must still set `email_required=True`

🤖 Generated with [Claude Code](https://claude.com/claude-code)