### PR TITLE
feat(csi): fetch linked tweet URLs via X API instead of filtering as social_noise

### DIFF
--- a/src/universal_agent/services/claude_code_intel.py
+++ b/src/universal_agent/services/claude_code_intel.py
@@ -509,6 +509,32 @@ def fetch_user_by_username_with_fallbacks(client: httpx.Client, *, token: str, u
     return _get_json_with_auth_fallbacks(client, url=url, params=params, app_bearer_token=token)
 
 
+# Tweet lookup endpoint (X API v2 GET /2/tweets/{id}).
+# Used by csi_url_judge to fetch linked tweet URLs as structured signal
+# instead of dropping them via the social-domain pre-filter. The /tweets/{id}
+# lookup costs 1 read per call and supports app-bearer + user-context auth via
+# the same fallback chain as the user/posts endpoints.
+_TWEET_LOOKUP_PARAMS: dict[str, str] = {
+    "tweet.fields": "id,text,created_at,author_id,public_metrics,entities,conversation_id,referenced_tweets",
+    "expansions": "author_id",
+    "user.fields": "id,name,username,verified",
+}
+
+
+def fetch_tweet_by_id(client: httpx.Client, *, token: str, tweet_id: str) -> dict[str, Any]:
+    resp = client.get(
+        f"https://api.x.com/2/tweets/{tweet_id}",
+        headers=_auth_headers(token),
+        params=dict(_TWEET_LOOKUP_PARAMS),
+    )
+    return _json_response(resp)
+
+
+def fetch_tweet_by_id_with_fallbacks(client: httpx.Client, *, token: str, tweet_id: str) -> dict[str, Any]:
+    url = f"https://api.x.com/2/tweets/{tweet_id}"
+    return _get_json_with_auth_fallbacks(client, url=url, params=dict(_TWEET_LOOKUP_PARAMS), app_bearer_token=token)
+
+
 def fetch_user_posts(
     client: httpx.Client,
     *,

--- a/src/universal_agent/services/csi_url_judge.py
+++ b/src/universal_agent/services/csi_url_judge.py
@@ -143,6 +143,55 @@ PRODUCT_APP_DOMAINS = frozenset({
 })
 
 
+# Tweet-URL extraction for the X API tweet-fetch fallback (Tier B1).
+# Linked tweets carry real signal (replies, threads, quoted reactions). The
+# pre_filter_urls() pass classifies every x.com/twitter.com URL as
+# social_noise; this short-circuit pulls tweet-status URLs out first so we
+# can fetch them via the X API /2/tweets/{id} endpoint and persist the
+# tweet body as a synthesized source page. Non-tweet x.com URLs (profiles,
+# search, etc.) still flow through pre_filter_urls and remain filtered.
+_TWEET_STATUS_URL_PATTERN = re.compile(
+    r"^https?://(?:www\.)?(?:x|twitter)\.com/[^/]+/status/(\d+)",
+    re.IGNORECASE,
+)
+
+
+def parse_tweet_id_from_url(url: str) -> str | None:
+    """Extract the numeric tweet ID from an x.com/twitter.com /status/ URL."""
+    if not url:
+        return None
+    match = _TWEET_STATUS_URL_PATTERN.match(url.strip())
+    if not match:
+        return None
+    return match.group(1)
+
+
+def extract_tweet_urls(urls: list[str]) -> tuple[list[tuple[str, str]], list[str]]:
+    """Split URLs into (tweet_url_pairs, remaining_urls).
+
+    tweet_url_pairs is [(url, tweet_id), ...] for x.com/twitter.com /status/
+    URLs. remaining_urls is everything else, suitable to feed into
+    pre_filter_urls().
+    """
+    tweet_pairs: list[tuple[str, str]] = []
+    remaining: list[str] = []
+    for url in urls:
+        clean = url.strip().rstrip(".,)") if isinstance(url, str) else ""
+        if not clean:
+            continue
+        tweet_id = parse_tweet_id_from_url(clean)
+        if tweet_id:
+            tweet_pairs.append((clean, tweet_id))
+        else:
+            remaining.append(clean)
+    return tweet_pairs, remaining
+
+
+def _x_api_tweet_fetch_enabled() -> bool:
+    raw = str(os.getenv("UA_CSI_X_API_TWEET_FETCH_ENABLED") or "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
 def pre_filter_urls(urls: list[str]) -> tuple[list[str], list[EnrichmentRecord]]:
     """Pass 1: Fast deterministic filter.
 
@@ -608,6 +657,145 @@ def fetch_url_content(
     return _fetch_with_httpx(url, output_path, timeout)
 
 
+def _render_tweet_markdown(tweet_payload: dict[str, Any], url: str) -> str:
+    """Render an X API /2/tweets/{id} response as a markdown source page."""
+    data = tweet_payload.get("data") or {}
+    includes_users = (tweet_payload.get("includes") or {}).get("users") or []
+    author_lookup: dict[str, dict[str, Any]] = {}
+    for user in includes_users:
+        if isinstance(user, dict) and user.get("id"):
+            author_lookup[str(user["id"])] = user
+
+    text = str(data.get("text") or "").strip()
+    tweet_id = str(data.get("id") or "").strip()
+    created_at = str(data.get("created_at") or "").strip()
+    author_id = str(data.get("author_id") or "").strip()
+    author = author_lookup.get(author_id) or {}
+    author_handle = str(author.get("username") or "").strip()
+    author_name = str(author.get("name") or "").strip()
+    metrics = data.get("public_metrics") or {}
+    referenced = data.get("referenced_tweets") or []
+
+    header_lines = [f"# Tweet: {url}", ""]
+    if author_handle or author_name:
+        byline = f"@{author_handle}" if author_handle else ""
+        if author_name:
+            byline = f"{author_name} ({byline})" if byline else author_name
+        header_lines.append(f"- **Author**: {byline}")
+    if created_at:
+        header_lines.append(f"- **Created**: {created_at}")
+    if tweet_id:
+        header_lines.append(f"- **Tweet ID**: {tweet_id}")
+    if metrics:
+        header_lines.append(
+            "- **Metrics**: "
+            + ", ".join(f"{k}={v}" for k, v in metrics.items() if v is not None)
+        )
+    if referenced:
+        refs = [
+            f"{r.get('type', '?')}:{r.get('id', '?')}"
+            for r in referenced
+            if isinstance(r, dict)
+        ]
+        if refs:
+            header_lines.append(f"- **Referenced**: {', '.join(refs)}")
+
+    return "\n".join(header_lines) + "\n\n---\n\n" + text + "\n"
+
+
+def _fetch_tweet_via_x_api(
+    url: str,
+    tweet_id: str,
+    output_dir: Path,
+    *,
+    timeout: int,
+) -> EnrichmentRecord:
+    """Fetch one tweet via the X API and persist it as a synthesized source page.
+
+    Returns an EnrichmentRecord shaped exactly like a regular fetched URL so
+    downstream callers (build_linked_context, classifier prompts) treat it
+    identically. On any failure, returns a record with fetch_status=failed
+    and a structured skip_reason — never raises.
+    """
+    record = EnrichmentRecord(
+        url=url,
+        category="other",
+        worth_fetching=True,
+        reasoning="x_api_tweet_fetch: linked tweet body",
+        fetch_status="pending",
+    )
+
+    try:
+        from universal_agent.services.claude_code_intel import (
+            fetch_tweet_by_id_with_fallbacks,
+            get_x_bearer_token,
+        )
+    except Exception as exc:
+        record.fetch_status = "failed"
+        record.skip_reason = f"x_api_import_error:{type(exc).__name__}"
+        logger.warning("X API tweet fetch unavailable: %s", exc)
+        return record
+
+    token = get_x_bearer_token()
+    # Bearer absent AND no OAuth fallback creds → caller must downgrade to
+    # the legacy social_noise filter for this URL. We signal that via a
+    # specific skip_reason the orchestrator checks for.
+    if not token and not all(
+        str(os.getenv(key) or "").strip()
+        for key in (
+            "X_OAUTH_CONSUMER_KEY",
+            "X_OAUTH_CONSUMER_SECRET",
+            "X_OAUTH_ACCESS_TOKEN",
+            "X_OAUTH_ACCESS_TOKEN_SECRET",
+        )
+    ) and not str(os.getenv("X_OAUTH2_ACCESS_TOKEN") or "").strip():
+        record.fetch_status = "failed"
+        record.skip_reason = "x_api_no_auth"
+        return record
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            payload = fetch_tweet_by_id_with_fallbacks(
+                client, token=token, tweet_id=tweet_id
+            )
+    except Exception as exc:
+        record.fetch_status = "failed"
+        reason = str(exc) or type(exc).__name__
+        record.skip_reason = f"x_api_{reason[:120]}"
+        logger.warning("X API tweet fetch failed for %s: %s", url, exc)
+        return record
+
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        markdown = _render_tweet_markdown(payload, url)
+        cap = DOC_STORAGE_MAX_CHARS
+        if len(markdown) > cap:
+            markdown = markdown[:cap] + f"\n\n... [Content truncated at {cap} chars]"
+        md_path = output_dir / f"tweet_{tweet_id}.md"
+        md_path.write_text(markdown, encoding="utf-8")
+        # Also persist the raw JSON next to it for downstream debugging.
+        json_path = output_dir / f"tweet_{tweet_id}.json"
+        json_path.write_text(
+            json.dumps(
+                {k: v for k, v in payload.items() if k != "_ua_auth_mode"},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        record.fetch_status = "fetched"
+        record.content_path = str(md_path)
+        record.content_chars = len(markdown)
+        logger.info(
+            "Fetched tweet via X API [%s] → %d chars at %s",
+            url, record.content_chars, md_path,
+        )
+    except Exception as exc:
+        record.fetch_status = "failed"
+        record.skip_reason = f"x_api_persist_error:{type(exc).__name__}"
+        logger.warning("Failed to persist X API tweet %s: %s", url, exc)
+    return record
+
+
 # ── Orchestrator ─────────────────────────────────────────────────────────────
 
 def enrich_urls(
@@ -642,9 +830,20 @@ def enrich_urls(
     if max_fetch is None:
         max_fetch = DEFAULT_MAX_FETCH
 
-    # Pass 1: fast pre-filter
-    candidates, discarded = pre_filter_urls(urls)
-    if not candidates:
+    # Pass 0: pull tweet-status URLs aside so we can fetch them via the X API
+    # /2/tweets/{id} endpoint. Without this short-circuit, pre_filter_urls()
+    # classifies every x.com/twitter.com URL as social_noise and we lose
+    # linked-tweet signal entirely. Set UA_CSI_X_API_TWEET_FETCH_ENABLED=0
+    # to disable and fall back to legacy filtering.
+    tweet_pairs: list[tuple[str, str]] = []
+    if _x_api_tweet_fetch_enabled():
+        tweet_pairs, remaining_urls = extract_tweet_urls(urls)
+    else:
+        remaining_urls = list(urls)
+
+    # Pass 1: fast pre-filter (operates only on non-tweet URLs).
+    candidates, discarded = pre_filter_urls(remaining_urls)
+    if not candidates and not tweet_pairs:
         return discarded
 
     # Pass 2: LLM judge — bypassed when trust_source is on AND env permits.
@@ -699,11 +898,38 @@ def enrich_urls(
             record.skip_reason = result.get("error", "unknown_fetch_error")
             logger.warning("Failed to fetch URL %s: %s", record.url, record.skip_reason)
 
-    all_records = discarded + records
+    # Pass 4: X API tweet fetch — synthesizes EnrichmentRecords for linked
+    # tweets that would otherwise be lost to the social_noise filter. Each
+    # tweet costs one /2/tweets/{id} read; we keep them outside the
+    # max_fetch budget because the API quota is independently rate-limited
+    # and these are not web crawls.
+    tweet_records: list[EnrichmentRecord] = []
+    for tweet_url, tweet_id in tweet_pairs:
+        url_hash = hashlib.sha256(tweet_url.encode("utf-8")).hexdigest()[:12]
+        fetch_dir = output_dir / url_hash
+        tweet_record = _fetch_tweet_via_x_api(
+            tweet_url, tweet_id, fetch_dir, timeout=timeout
+        )
+        if tweet_record.skip_reason == "x_api_no_auth":
+            # No usable creds. Downgrade this URL to the legacy filter so
+            # behavior matches the pre-Tier-B1 pipeline.
+            discarded.append(
+                EnrichmentRecord(
+                    url=tweet_url,
+                    category="social_noise",
+                    fetch_status="filtered",
+                    skip_reason="social_domain",
+                )
+            )
+            continue
+        tweet_records.append(tweet_record)
+
+    all_records = discarded + records + tweet_records
     logger.info(
-        "URL enrichment complete: %d total, %d filtered, %d judged, %d fetched",
+        "URL enrichment complete: %d total, %d filtered, %d judged, %d fetched, %d tweets via x_api",
         len(all_records), len(discarded), len(records),
         sum(1 for r in records if r.fetch_status == "fetched"),
+        sum(1 for r in tweet_records if r.fetch_status == "fetched"),
     )
     return all_records
 

--- a/tests/unit/test_csi_url_judge_x_api.py
+++ b/tests/unit/test_csi_url_judge_x_api.py
@@ -1,0 +1,233 @@
+"""Tests for the X API tweet-URL fetch fallback (Tier B1).
+
+Verifies that:
+- ``parse_tweet_id_from_url`` extracts numeric IDs from x.com / twitter.com
+  /status/<id> URLs and returns None for non-tweet URLs.
+- ``extract_tweet_urls`` separates tweet URLs from a mixed list, returning
+  the (url, tweet_id) pairs and the remaining URLs.
+- ``_x_api_tweet_fetch_enabled`` honors the ``UA_CSI_X_API_TWEET_FETCH_ENABLED``
+  kill switch.
+- ``fetch_tweet_by_id`` issues the correct GET to api.x.com/2/tweets/{id}
+  with the expected params and auth header.
+- ``enrich_urls`` routes tweet URLs to the X API fetch path (not the legacy
+  social_noise filter) when the kill switch is enabled, and falls back to
+  social_noise when disabled.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+# ── parse_tweet_id_from_url ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://x.com/foo/status/123", "123"),
+        ("https://www.x.com/foo/status/123", "123"),
+        ("http://x.com/foo/status/123", "123"),
+        ("https://x.com/foo/status/123?s=20", "123"),
+        ("https://x.com/foo/status/123/photo/1", "123"),
+        ("https://twitter.com/foo/status/9876543210", "9876543210"),
+        ("https://www.twitter.com/foo/status/123", "123"),
+        ("HTTPS://X.COM/FOO/STATUS/123", "123"),
+    ],
+)
+def test_parse_tweet_id_matches(url, expected):
+    from universal_agent.services.csi_url_judge import parse_tweet_id_from_url
+
+    assert parse_tweet_id_from_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "https://x.com/foo",
+        "https://x.com/foo/bar",
+        "https://example.com/foo/status/123",
+        "https://x.com.evil.com/foo/status/123",
+        "not a url",
+    ],
+)
+def test_parse_tweet_id_rejects_non_tweet_urls(url):
+    from universal_agent.services.csi_url_judge import parse_tweet_id_from_url
+
+    assert parse_tweet_id_from_url(url) is None
+
+
+def test_parse_tweet_id_handles_none_safely():
+    from universal_agent.services.csi_url_judge import parse_tweet_id_from_url
+
+    # type-checker hates this but we still want runtime resilience
+    assert parse_tweet_id_from_url(None) is None  # type: ignore[arg-type]
+
+
+# ── extract_tweet_urls ───────────────────────────────────────────────────────
+
+
+def test_extract_tweet_urls_splits_mixed_list():
+    from universal_agent.services.csi_url_judge import extract_tweet_urls
+
+    inputs = [
+        "https://x.com/foo/status/111",
+        "https://docs.example.com/page",
+        "https://twitter.com/bar/status/222?s=20",
+        "https://github.com/foo/repo",
+        "https://x.com/foo",  # not a tweet URL
+    ]
+    tweets, remaining = extract_tweet_urls(inputs)
+    assert tweets == [
+        ("https://x.com/foo/status/111", "111"),
+        ("https://twitter.com/bar/status/222?s=20", "222"),
+    ]
+    assert remaining == [
+        "https://docs.example.com/page",
+        "https://github.com/foo/repo",
+        "https://x.com/foo",
+    ]
+
+
+def test_extract_tweet_urls_strips_trailing_noise():
+    from universal_agent.services.csi_url_judge import extract_tweet_urls
+
+    tweets, remaining = extract_tweet_urls(
+        ["https://x.com/foo/status/123).", "  "]
+    )
+    assert tweets == [("https://x.com/foo/status/123", "123")]
+    assert remaining == []
+
+
+def test_extract_tweet_urls_handles_empty():
+    from universal_agent.services.csi_url_judge import extract_tweet_urls
+
+    tweets, remaining = extract_tweet_urls([])
+    assert tweets == []
+    assert remaining == []
+
+
+# ── kill switch ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off"])
+def test_kill_switch_disables(monkeypatch, value):
+    monkeypatch.setenv("UA_CSI_X_API_TWEET_FETCH_ENABLED", value)
+    from universal_agent.services.csi_url_judge import _x_api_tweet_fetch_enabled
+
+    assert _x_api_tweet_fetch_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", ""])
+def test_kill_switch_enabled_by_default(monkeypatch, value):
+    monkeypatch.setenv("UA_CSI_X_API_TWEET_FETCH_ENABLED", value)
+    from universal_agent.services.csi_url_judge import _x_api_tweet_fetch_enabled
+
+    assert _x_api_tweet_fetch_enabled() is True
+
+
+def test_kill_switch_unset_defaults_to_enabled(monkeypatch):
+    monkeypatch.delenv("UA_CSI_X_API_TWEET_FETCH_ENABLED", raising=False)
+    from universal_agent.services.csi_url_judge import _x_api_tweet_fetch_enabled
+
+    assert _x_api_tweet_fetch_enabled() is True
+
+
+# ── fetch_tweet_by_id ────────────────────────────────────────────────────────
+
+
+def test_fetch_tweet_by_id_issues_expected_request():
+    from universal_agent.services.claude_code_intel import fetch_tweet_by_id
+
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(
+            200,
+            json={
+                "data": {"id": "123", "text": "hello", "author_id": "9"},
+                "includes": {
+                    "users": [{"id": "9", "name": "X", "username": "x"}]
+                },
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        payload = fetch_tweet_by_id(client, token="test-bearer", tweet_id="123")
+
+    assert payload["data"]["id"] == "123"
+    url = str(captured["url"])
+    assert url.startswith("https://api.x.com/2/tweets/123")
+    assert "tweet.fields=" in url
+    assert "expansions=author_id" in url
+    assert captured["headers"]["authorization"] == "Bearer test-bearer"
+
+
+# ── enrich_urls integration: kill switch routes correctly ────────────────────
+
+
+def test_enrich_urls_skips_x_api_path_when_disabled(monkeypatch, tmp_path: Path):
+    """When the kill switch is off, tweet URLs go through the legacy filter."""
+    monkeypatch.setenv("UA_CSI_X_API_TWEET_FETCH_ENABLED", "0")
+    from universal_agent.services import csi_url_judge
+
+    importlib.reload(csi_url_judge)
+
+    records = csi_url_judge.enrich_urls(
+        urls=["https://x.com/foo/status/111"],
+        context="ctx",
+        output_dir=tmp_path,
+        trust_source=False,
+    )
+    # With the kill switch off, the tweet URL flows through pre_filter_urls
+    # which classifies x.com as social_noise.
+    assert len(records) == 1
+    assert records[0].url == "https://x.com/foo/status/111"
+    assert records[0].fetch_status == "filtered"
+    assert records[0].skip_reason == "social_domain"
+
+
+def test_enrich_urls_takes_x_api_path_when_enabled_but_no_auth(
+    monkeypatch, tmp_path: Path
+):
+    """With the switch on but no creds, we downgrade to social_noise so the
+    behavior matches the pre-Tier-B1 pipeline."""
+    monkeypatch.setenv("UA_CSI_X_API_TWEET_FETCH_ENABLED", "1")
+    # Strip all X creds so the X API helper returns x_api_no_auth.
+    for key in (
+        "X_BEARER_TOKEN",
+        "X_OAUTH_CONSUMER_KEY",
+        "X_OAUTH_CONSUMER_SECRET",
+        "X_OAUTH_ACCESS_TOKEN",
+        "X_OAUTH_ACCESS_TOKEN_SECRET",
+        "X_OAUTH2_ACCESS_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    from universal_agent.services import csi_url_judge
+
+    importlib.reload(csi_url_judge)
+
+    # Patch get_x_bearer_token at import-time to return empty.
+    with patch(
+        "universal_agent.services.claude_code_intel.get_x_bearer_token",
+        return_value="",
+    ):
+        records = csi_url_judge.enrich_urls(
+            urls=["https://x.com/foo/status/111"],
+            context="ctx",
+            output_dir=tmp_path,
+            trust_source=False,
+        )
+
+    assert len(records) == 1
+    assert records[0].fetch_status == "filtered"
+    assert records[0].skip_reason == "social_domain"


### PR DESCRIPTION
## Summary

Tier B1 of the ClaudeDevs Intelligence v2 fix plan. Follows PR #283 (Tier A + C1).

**Before:** `csi_url_judge.pre_filter_urls()` classified every `x.com` / `twitter.com` URL as `social_noise` and discarded them. Linked tweets in our intel feed carry real signal (replies, threads, quoted reactions) and we were dropping all of it. The early-May `webhooks__demo-1` BUILD_NOTES also flagged JS-walled X pages reaching SOURCES — this bypasses HTML entirely.

**After:** a new Pass 0 in `enrich_urls` extracts tweet-status URLs via `extract_tweet_urls`, and Pass 4 fetches each via the X API v2 `/2/tweets/{id}` endpoint using the same auth-fallback chain as the existing daily poller. Tweet body + raw JSON are persisted as a synthesized source page in the same `EnrichmentRecord` shape as a fetched URL, so downstream code (build_linked_context, classifier prompts) treats them identically.

## Design

- **New helpers in `claude_code_intel.py`**: `fetch_tweet_by_id` + `fetch_tweet_by_id_with_fallbacks` (mirrors `fetch_user_by_username` exactly).
- **New helpers in `csi_url_judge.py`**: `parse_tweet_id_from_url`, `extract_tweet_urls`, `_x_api_tweet_fetch_enabled` (kill switch), `_render_tweet_markdown`, `_fetch_tweet_via_x_api`.
- **Orchestration**: Pass 0 splits tweet URLs from the input list; Pass 1-3 unchanged; Pass 4 issues one X API call per tweet and persists results.

## Safety rails

- Env kill switch `UA_CSI_X_API_TWEET_FETCH_ENABLED=0` reverts to legacy social_noise filtering.
- No X creds available → `x_api_no_auth` path downgrades the URL to legacy filter so behavior matches pre-Tier-B1.
- API errors (404 / 429 / network / persist failures) caught, logged, recorded as `fetch_status=failed` with structured `skip_reason` — never crashes the enrich pass.
- Non-tweet `x.com` URLs (profiles, search) still flow through the existing pre-filter and remain filtered as social_noise.

## Tests

- 32 new tests in `tests/unit/test_csi_url_judge_x_api.py` covering: parse helper edge cases, URL splitter, kill switch envs, X API request shape via `httpx.MockTransport`, and integration paths for both disabled-switch and no-auth fallbacks.
- All 47 `csi_url_judge` tests green (`pytest tests/unit/test_csi_url_judge*.py`).

## Test plan

- [x] `uv run ruff check src/universal_agent/services/csi_url_judge.py src/universal_agent/services/claude_code_intel.py tests/unit/test_csi_url_judge_x_api.py` — clean
- [x] `uv run pytest tests/unit/test_csi_url_judge_x_api.py tests/unit/test_csi_url_judge_limits.py tests/unit/test_csi_url_judge_trust_source.py` — 47 passed
- [ ] Production smoke (post-merge): manual cron tick → next packet's SOURCES/ should include synthesized tweet pages for any linked x.com URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)