### PR TITLE
fix(notifications): route outbound operator emails to gmail, not outlook

### DIFF
--- a/src/universal_agent/services/proactive_codie.py
+++ b/src/universal_agent/services/proactive_codie.py
@@ -223,7 +223,7 @@ def _cleanup_task_description(*, chosen_theme: str, note: str = "", preference_c
         "8. Open a pull request targeting develop for Kevin review. A PR is the required final work product unless no worthwhile improvement is found.",
         "9. Do not merge, push to main, deploy, delete production data, or make public releases.",
         "10. In the PR body, include rationale, changed files, tests run, red-green evidence or why it was not applicable, risks, rollback notes, and why the scope remained low/medium complexity.",
-        "11. After creating the PR, use the AgentMail tools from the shared VP mailbox (vp.agents@agentmail.to) to send an email to kevin.dragan@outlook.com.",
+        "11. After creating the PR, use the AgentMail tools from the shared VP mailbox (vp.agents@agentmail.to) to send an email to kevinjdragan@gmail.com.",
         "12. CC Simone's inbox (oddcity216@agentmail.to) on the email for situational awareness.",
         "13. Prefix the subject with '[VP Status]' and include this header at the top of the email body before your content:",
         "   '── VP Status Update (FYI — no action required) ──",

--- a/src/universal_agent/urw/esg_plan.json
+++ b/src/universal_agent/urw/esg_plan.json
@@ -61,7 +61,7 @@
                 },
                 {
                     "name": "Email Report",
-                    "description": "Email the final report as an attachment to kevin.dragan@outlook.com. Include a brief executive summary in the email body.",
+                    "description": "Email the final report as an attachment to kevinjdragan@gmail.com. Include a brief executive summary in the email body.",
                     "use_case": "Deliver findings to stakeholder.",
                     "subagent": "computer-user",
                     "success_criteria": [

--- a/src/universal_agent/urw/esg_template.json
+++ b/src/universal_agent/urw/esg_template.json
@@ -1,5 +1,5 @@
 {
-    "massive_request": "Compare the ESG performance of Coca-Cola vs PepsiCo for 2024. Email report to kevin.dragan@outlook.com",
+    "massive_request": "Compare the ESG performance of Coca-Cola vs PepsiCo for 2024. Email report to kevinjdragan@gmail.com",
     "questions_and_answers": [
         {
             "question": "What is the primary purpose of this comparison?",


### PR DESCRIPTION
## Summary

Three outbound email destinations in the codebase were hardcoded to `kevin.dragan@outlook.com`. Kevin's preferred operator inbox is `kevinjdragan@gmail.com`; outlook's protection layer (`olc.protection.outlook.com`) quarantines mail from senders it doesn't recognize (including the shared VP AgentMail mailbox), so notifications routed there were effectively invisible.

## Files changed

| File | Site | Why |
|---|---|---|
| `src/universal_agent/services/proactive_codie.py:226` | Codie's post-PR notification instruction | Likely cause of the unexpected outlook email after PR #283 merged tonight |
| `src/universal_agent/urw/esg_template.json` | Sample massive_request text | Template default; gmail is the operator address |
| `src/universal_agent/urw/esg_plan.json` | "Email Report" subagent step description | Same reason |

## What I did NOT change

The inbound trust allowlists keep BOTH addresses since Kevin may send mail or calendar invites from either:
- `src/universal_agent/services/agentmail_service.py:184` (`_DEFAULT_TRUSTED_SENDERS`)
- `src/universal_agent/services/calendar_task_bridge.py:82` (`_TRUSTED_ORGANIZER_EMAILS`)

These are sender-recognition sets, not delivery destinations.

## Test plan

- [x] `grep -rn "kevin\.dragan@outlook" src/ --include="*.py" --include="*.json"` shows only the two intended allowlist sites remaining.
- [x] JSON files parse cleanly.
- [x] Compile check on the modified Python file passes.
- [ ] Production verification: after next Codie proactive PR cycle, notification should arrive at gmail rather than outlook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)