### PR TITLE
feat(csi): surface vault entities + concepts + demos in dashboard tab

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -19031,26 +19031,45 @@ def _claude_code_intel_packets(limit: int = 40, *, include_empty: bool = False) 
     return packets[:raw_limit]
 
 
-def _claude_code_intel_knowledge_pages(limit: int = 200) -> list[dict[str, Any]]:
+def _claude_code_intel_knowledge_pages(
+    limit: int = 200,
+    *,
+    categories: tuple[str, ...] = ("sources",),
+) -> list[dict[str, Any]]:
+    """Return vault knowledge pages filtered by top-level vault category.
+
+    Default ``categories=("sources",)`` preserves the historic per-tweet
+    source-page behaviour used by ``GET /api/v1/dashboard/claude-code-intel``.
+    The vault-browser endpoints pass ``("entities",)`` or ``("concepts",)``
+    to surface the synthesized knowledge base. Each returned record is
+    enriched with vault-aware fields (``kind``, ``source_count``,
+    ``confidence``, ``has_demos``) so the dashboard can render rich cards
+    without re-reading the markdown body.
+    """
     vault_root = _claude_code_intel_vault_root()
     if not vault_root.exists():
         return []
     from universal_agent.wiki.core import _frontmatter_and_body, _scan_page_records
 
+    category_filter = {str(c).strip() for c in categories if str(c).strip()}
     records = []
     for record in _scan_page_records(vault_root):
-        if str(record.get("category") or "") != "sources":
+        category = str(record.get("category") or "")
+        if category_filter and category not in category_filter:
             continue
         rel_path = str(record.get("path") or "").strip()
         if not rel_path:
             continue
         page_path = vault_root / rel_path
-        meta, _ = _frontmatter_and_body(page_path)
+        meta, body = _frontmatter_and_body(page_path)
         summary_text = str(record.get("summary") or "")
         lowered_summary = summary_text.lower()
         tags = [str(tag) for tag in (meta.get("tags") or []) if str(tag).strip()]
         lowered_tags = {tag.lower() for tag in tags}
-        if (
+        # Drop sources-category pages that captured a JS-disabled X.com
+        # error page instead of real content. Only applies to ``sources``;
+        # entities/concepts are LLM-synthesized so the guard is irrelevant.
+        if category == "sources" and (
             "javascript is not available" in lowered_summary
             or "please enable javascript or switch to a supported browser" in lowered_summary
             or (
@@ -19060,6 +19079,20 @@ def _claude_code_intel_knowledge_pages(limit: int = 200) -> list[dict[str, Any]]
         ):
             continue
         link_payload = _artifact_link_payload(page_path)
+        kind_value = ""
+        for tag in tags:
+            if tag.lower().startswith("kind:"):
+                kind_value = tag.split(":", 1)[1].strip()
+                break
+        if not kind_value:
+            kind_value = str(meta.get("kind") or "").strip()
+        source_ids = meta.get("source_ids") or []
+        source_count = len(source_ids) if isinstance(source_ids, (list, tuple)) else 0
+        confidence = str(meta.get("confidence") or "").strip()
+        # ``## Demos`` is the marker the demo-attach worker writes onto
+        # entity pages when it links a demo workspace. Match start-of-line
+        # to avoid false positives from prose.
+        has_demos = bool(re.search(r"(?m)^##\s+Demos\b", body or ""))
         records.append(
             {
                 "path": rel_path,
@@ -19067,12 +19100,96 @@ def _claude_code_intel_knowledge_pages(limit: int = 200) -> list[dict[str, Any]]
                 "summary": summary_text,
                 "tags": tags,
                 "updated_at": str(meta.get("updated_at") or ""),
+                "kind": kind_value,
+                "source_count": source_count,
+                "confidence": confidence,
+                "has_demos": has_demos,
                 "api_url": link_payload["api_url"],
                 "storage_href": link_payload["storage_href"],
             }
         )
     records.sort(key=lambda item: (str(item.get("updated_at") or ""), str(item.get("title") or "")), reverse=True)
     return records[: max(1, min(limit, 500))]
+
+
+def _claude_code_intel_demos_root() -> Path:
+    """Root directory for Cody-built demo workspaces.
+
+    Defaults to ``/opt/ua_demos`` (the production VPS layout). Overridable
+    via ``UA_DEMOS_ROOT`` so tests and dev boxes can point at a tmp dir.
+    """
+    return Path(os.environ.get("UA_DEMOS_ROOT") or "/opt/ua_demos")
+
+
+_DEMO_DIR_RE = re.compile(r"^(?P<slug>.+?)__demo-(?P<n>\d+)$")
+
+
+def _claude_code_intel_demos(
+    *,
+    demos_root: Path | None = None,
+    vault_root: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Walk ``/opt/ua_demos/<slug>__demo-N`` and emit a dashboard payload.
+
+    For each ``manifest.json`` we surface ``feature``, ``endpoint_hit``,
+    ``marker_verified``, ``timestamp`` plus a parsed ``entity_slug`` and
+    a cross-referenced ``linked_from_entity`` flag — the latter true iff
+    some ``entities/*.md`` page contains a ``## Demos`` section that
+    mentions the demo_id in backticks. This is the read-side companion
+    to the demo-attach worker that writes those links.
+    """
+    root = demos_root if demos_root is not None else _claude_code_intel_demos_root()
+    if not root.exists():
+        return []
+    vault = vault_root if vault_root is not None else _claude_code_intel_vault_root()
+
+    # Build the set of demo_ids that an entity page links to in its
+    # ``## Demos`` section. One pass over entities/*.md is cheaper than
+    # re-reading per demo. Tolerate a missing vault — orphan demos are
+    # still surfaced (just with linked_from_entity=False).
+    linked_demo_ids: set[str] = set()
+    entities_dir = vault / "entities" if vault else None
+    if entities_dir and entities_dir.exists():
+        demo_ref_re = re.compile(r"`([^`]+?__demo-\d+)`")
+        for entity_md in entities_dir.glob("*.md"):
+            try:
+                text = entity_md.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            # Only count references that live under a ``## Demos`` heading.
+            # Split on h2 headings and find the demos section body.
+            sections = re.split(r"(?m)^##\s+", text)
+            for section in sections[1:]:
+                if section.lower().startswith("demos"):
+                    linked_demo_ids.update(demo_ref_re.findall(section))
+
+    demos: list[dict[str, Any]] = []
+    for demo_dir in sorted(root.iterdir()):
+        if not demo_dir.is_dir():
+            continue
+        manifest_path = demo_dir / "manifest.json"
+        if not manifest_path.exists():
+            continue
+        manifest = _safe_read_json_file(manifest_path, {})
+        if not isinstance(manifest, dict):
+            manifest = {}
+        demo_id = demo_dir.name
+        slug_match = _DEMO_DIR_RE.match(demo_id)
+        entity_slug = slug_match.group("slug") if slug_match else ""
+        demos.append(
+            {
+                "demo_id": demo_id,
+                "workspace_path": str(demo_dir),
+                "feature": str(manifest.get("feature") or ""),
+                "endpoint_hit": str(manifest.get("endpoint_hit") or ""),
+                "marker_verified": bool(manifest.get("marker_verified") or False),
+                "timestamp": str(manifest.get("timestamp") or ""),
+                "entity_slug": entity_slug,
+                "linked_from_entity": demo_id in linked_demo_ids,
+            }
+        )
+    demos.sort(key=lambda item: (str(item.get("timestamp") or ""), str(item.get("demo_id") or "")), reverse=True)
+    return demos
 
 
 def _claude_code_intel_rolling_payload() -> dict[str, Any]:
@@ -19209,6 +19326,48 @@ async def dashboard_claude_code_intel_trigger(
         }
     except Exception as exc:
         return {"status": "error", "detail": f"Failed to launch pipeline: {type(exc).__name__}: {exc}"}
+
+
+# ── CSI vault-browser endpoints ──────────────────────────────────────────
+# These three GET endpoints surface the synthesized knowledge base
+# (entities + concepts + demo workspaces) on /dashboard/claude-code-intel/.
+# They are read-only siblings of the packet-centric
+# ``GET /api/v1/dashboard/claude-code-intel`` endpoint; they do not mutate
+# state and do not interact with Task Hub.
+
+
+@app.get("/api/v1/dashboard/claude-code-intel/vault/entities")
+async def dashboard_csi_vault_entities(
+    request: Request,
+    limit: int = 200,
+    kind: Optional[str] = None,
+):
+    _require_ops_auth(request)
+    pages = _claude_code_intel_knowledge_pages(limit=limit, categories=("entities",))
+    if kind:
+        kind_norm = str(kind).strip().lower()
+        pages = [p for p in pages if str(p.get("kind") or "").strip().lower() == kind_norm]
+    return {"status": "ok", "entities": pages}
+
+
+@app.get("/api/v1/dashboard/claude-code-intel/vault/concepts")
+async def dashboard_csi_vault_concepts(
+    request: Request,
+    limit: int = 200,
+    kind: Optional[str] = None,
+):
+    _require_ops_auth(request)
+    pages = _claude_code_intel_knowledge_pages(limit=limit, categories=("concepts",))
+    if kind:
+        kind_norm = str(kind).strip().lower()
+        pages = [p for p in pages if str(p.get("kind") or "").strip().lower() == kind_norm]
+    return {"status": "ok", "concepts": pages}
+
+
+@app.get("/api/v1/dashboard/claude-code-intel/demos")
+async def dashboard_csi_demos(request: Request):
+    _require_ops_auth(request)
+    return {"status": "ok", "demos": _claude_code_intel_demos()}
 
 
 # ── CSI demo triage flyout endpoints ─────────────────────────────────────

--- a/tests/unit/test_dashboard_vault_endpoints.py
+++ b/tests/unit/test_dashboard_vault_endpoints.py
@@ -1,0 +1,234 @@
+"""Unit tests for the CSI vault-browser dashboard helpers.
+
+Covers ``_claude_code_intel_knowledge_pages(categories=...)`` plus the
+demo-walker ``_claude_code_intel_demos`` that the three new endpoints
+under ``/api/v1/dashboard/claude-code-intel/vault/*`` and
+``/api/v1/dashboard/claude-code-intel/demos`` delegate to.
+
+The endpoints themselves are thin glue; testing the helpers directly
+keeps these fast and avoids a FastAPI TestClient setup.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from universal_agent import gateway_server
+from universal_agent.wiki.core import _dump_markdown
+
+
+def _write_page(
+    path: Path,
+    *,
+    title: str,
+    kind: str,
+    tags: list[str],
+    source_ids: list[str],
+    confidence: str,
+    summary: str,
+    body_extra: str = "",
+) -> None:
+    meta = {
+        "title": title,
+        "kind": kind,
+        "updated_at": "2026-05-10T12:00:00+00:00",
+        "tags": tags,
+        "source_ids": source_ids,
+        "provenance_kind": "synthesis",
+        "provenance_refs": [],
+        "confidence": confidence,
+        "status": "active",
+        "summary": summary,
+    }
+    body = f"# {title}\n\n{summary}\n"
+    if body_extra:
+        body += "\n" + body_extra
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dump_markdown(meta, body), encoding="utf-8")
+
+
+def test_knowledge_pages_entities_returns_enriched_fields(monkeypatch, tmp_path: Path):
+    """Calling with categories=('entities',) yields kind/source_count/confidence/has_demos."""
+    monkeypatch.setattr(gateway_server, "ARTIFACTS_DIR", tmp_path)
+    vault_root = tmp_path / "knowledge-vaults" / "claude-code-intelligence"
+
+    _write_page(
+        vault_root / "entities" / "custom-subagents.md",
+        title="Custom Subagents",
+        kind="feature",
+        tags=["kind:feature", "anthropic-product"],
+        source_ids=["s1", "s2", "s3"],
+        confidence="high",
+        summary="Anthropic's per-task subagent system.",
+        body_extra="## Demos\n\n- `custom-subagents__demo-1` — workspace at /opt/ua_demos/custom-subagents__demo-1\n",
+    )
+    _write_page(
+        vault_root / "entities" / "headless-mode.md",
+        title="Headless Mode",
+        kind="command",
+        tags=["kind:command"],
+        source_ids=["s4"],
+        confidence="medium",
+        summary="--headless flag for CLI invocations.",
+    )
+
+    result = gateway_server._claude_code_intel_knowledge_pages(categories=("entities",))
+    assert len(result) == 2
+    by_path = {r["path"]: r for r in result}
+
+    sub = by_path["entities/custom-subagents.md"]
+    assert sub["kind"] == "feature"
+    assert sub["source_count"] == 3
+    assert sub["confidence"] == "high"
+    assert sub["has_demos"] is True
+    assert sub["title"] == "Custom Subagents"
+    assert "kind:feature" in sub["tags"]
+
+    hl = by_path["entities/headless-mode.md"]
+    assert hl["kind"] == "command"
+    assert hl["source_count"] == 1
+    assert hl["confidence"] == "medium"
+    assert hl["has_demos"] is False
+
+
+def test_knowledge_pages_concepts_filtered(monkeypatch, tmp_path: Path):
+    """``categories=('concepts',)`` excludes entities and sources."""
+    monkeypatch.setattr(gateway_server, "ARTIFACTS_DIR", tmp_path)
+    vault_root = tmp_path / "knowledge-vaults" / "claude-code-intelligence"
+
+    _write_page(
+        vault_root / "concepts" / "context-engineering.md",
+        title="Context Engineering",
+        kind="concept",
+        tags=["kind:concept"],
+        source_ids=["c1", "c2"],
+        confidence="high",
+        summary="Curating model context windows deliberately.",
+    )
+    _write_page(
+        vault_root / "entities" / "something.md",
+        title="Something",
+        kind="feature",
+        tags=["kind:feature"],
+        source_ids=[],
+        confidence="low",
+        summary="An entity, should not appear.",
+    )
+
+    result = gateway_server._claude_code_intel_knowledge_pages(categories=("concepts",))
+    assert len(result) == 1
+    assert result[0]["path"] == "concepts/context-engineering.md"
+    assert result[0]["kind"] == "concept"
+    assert result[0]["source_count"] == 2
+
+
+def test_knowledge_pages_sources_default_regression(monkeypatch, tmp_path: Path):
+    """Default ``categories=('sources',)`` still works (backwards compat)."""
+    monkeypatch.setattr(gateway_server, "ARTIFACTS_DIR", tmp_path)
+    vault_root = tmp_path / "knowledge-vaults" / "claude-code-intelligence"
+
+    _write_page(
+        vault_root / "sources" / "src-good.md",
+        title="Good Source",
+        kind="source",
+        tags=["x.com"],
+        source_ids=["x1"],
+        confidence="medium",
+        summary="A normal source page with real content.",
+    )
+    # Should be filtered out — JS-disabled X.com error capture.
+    _write_page(
+        vault_root / "sources" / "src-broken.md",
+        title="Broken Source",
+        kind="source",
+        tags=["x.com", "twitter.com", "javascript"],
+        source_ids=["x2"],
+        confidence="low",
+        summary="JavaScript is not available. Please enable JavaScript or switch to a supported browser.",
+    )
+
+    result = gateway_server._claude_code_intel_knowledge_pages()
+    paths = [r["path"] for r in result]
+    assert "sources/src-good.md" in paths
+    assert "sources/src-broken.md" not in paths
+    # Enriched fields still populated.
+    good = next(r for r in result if r["path"] == "sources/src-good.md")
+    assert good["source_count"] == 1
+    assert good["confidence"] == "medium"
+    assert good["has_demos"] is False
+
+
+def test_demos_walker_returns_manifest_and_linkage(tmp_path: Path):
+    """``_claude_code_intel_demos`` reads manifest.json and cross-references entity pages."""
+    demos_root = tmp_path / "ua_demos"
+    vault_root = tmp_path / "vault"
+    entities_dir = vault_root / "entities"
+    entities_dir.mkdir(parents=True)
+
+    # Linked demo: entity page has ## Demos section mentioning the demo_id.
+    (demos_root / "custom-subagents__demo-1").mkdir(parents=True)
+    (demos_root / "custom-subagents__demo-1" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "feature": "custom subagents",
+                "endpoint_hit": "anthropic_native",
+                "marker_verified": True,
+                "timestamp": "2026-05-12T10:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (entities_dir / "custom-subagents.md").write_text(
+        "---\ntitle: Custom Subagents\n---\n\n"
+        "# Custom Subagents\n\n"
+        "Summary text.\n\n"
+        "## Demos\n\n"
+        "- `custom-subagents__demo-1` — built 2026-05-12\n",
+        encoding="utf-8",
+    )
+
+    # Orphan demo: no entity page links it.
+    (demos_root / "webhooks__demo-1").mkdir(parents=True)
+    (demos_root / "webhooks__demo-1" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "feature": "webhooks",
+                "endpoint_hit": "api.anthropic.com",
+                "marker_verified": False,
+                "timestamp": "2026-05-11T10:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Directory without a manifest — must be skipped.
+    (demos_root / "scaffold-only").mkdir(parents=True)
+
+    result = gateway_server._claude_code_intel_demos(
+        demos_root=demos_root, vault_root=vault_root
+    )
+    assert len(result) == 2
+    by_id = {d["demo_id"]: d for d in result}
+
+    sub = by_id["custom-subagents__demo-1"]
+    assert sub["feature"] == "custom subagents"
+    assert sub["endpoint_hit"] == "anthropic_native"
+    assert sub["marker_verified"] is True
+    assert sub["entity_slug"] == "custom-subagents"
+    assert sub["linked_from_entity"] is True
+    assert sub["workspace_path"].endswith("custom-subagents__demo-1")
+
+    wh = by_id["webhooks__demo-1"]
+    assert wh["entity_slug"] == "webhooks"
+    assert wh["linked_from_entity"] is False
+    assert wh["marker_verified"] is False
+
+
+def test_demos_walker_handles_missing_root(tmp_path: Path):
+    """Non-existent demos_root returns empty list, not an error."""
+    result = gateway_server._claude_code_intel_demos(
+        demos_root=tmp_path / "does-not-exist",
+        vault_root=tmp_path / "no-vault",
+    )
+    assert result == []

--- a/web-ui/app/dashboard/claude-code-intel/page.tsx
+++ b/web-ui/app/dashboard/claude-code-intel/page.tsx
@@ -76,6 +76,31 @@ type KnowledgePage = {
   storage_href?: string;
 };
 
+type VaultEntity = {
+  path?: string;
+  title?: string;
+  summary?: string;
+  tags?: string[];
+  updated_at?: string;
+  kind?: string;
+  source_count?: number;
+  confidence?: string;
+  has_demos?: boolean;
+  api_url?: string;
+  storage_href?: string;
+};
+
+type Demo = {
+  demo_id?: string;
+  workspace_path?: string;
+  feature?: string;
+  endpoint_hit?: string;
+  marker_verified?: boolean;
+  timestamp?: string;
+  entity_slug?: string;
+  linked_from_entity?: boolean;
+};
+
 type Primitive = {
   kind?: string;
   title?: string;
@@ -241,6 +266,12 @@ export default function DashboardClaudeCodeIntelPage() {
   const [triageTierFilter, setTriageTierFilter] = useState<"all" | 3 | 4>("all");
   const [showDismissed, setShowDismissed] = useState(false);
   const [expandedRationaleId, setExpandedRationaleId] = useState<string | null>(null);
+  // ── Vault browser state (entities + concepts + demos) ──────────────
+  const [vaultEntities, setVaultEntities] = useState<VaultEntity[]>([]);
+  const [vaultConcepts, setVaultConcepts] = useState<VaultEntity[]>([]);
+  const [vaultDemos, setVaultDemos] = useState<Demo[]>([]);
+  const [vaultLoading, setVaultLoading] = useState(true);
+
   const [triggerStatus, setTriggerStatus] = useState<"idle" | "pending" | "accepted" | "error">("idle");
   const [triggerMessage, setTriggerMessage] = useState("");
 
@@ -298,6 +329,38 @@ export default function DashboardClaudeCodeIntelPage() {
       }
     }
     void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load vault entities + concepts + demos in parallel. Errors fall back
+  // to an empty list so the rest of the page still renders.
+  useEffect(() => {
+    let cancelled = false;
+    async function loadVault() {
+      setVaultLoading(true);
+      try {
+        const [entitiesRes, conceptsRes, demosRes] = await Promise.all([
+          fetch(`${API_BASE}/api/v1/dashboard/claude-code-intel/vault/entities?limit=300`, { cache: "no-store" })
+            .then((r) => r.json())
+            .catch(() => ({ entities: [] })),
+          fetch(`${API_BASE}/api/v1/dashboard/claude-code-intel/vault/concepts?limit=300`, { cache: "no-store" })
+            .then((r) => r.json())
+            .catch(() => ({ concepts: [] })),
+          fetch(`${API_BASE}/api/v1/dashboard/claude-code-intel/demos`, { cache: "no-store" })
+            .then((r) => r.json())
+            .catch(() => ({ demos: [] })),
+        ]);
+        if (cancelled) return;
+        setVaultEntities(Array.isArray(entitiesRes?.entities) ? entitiesRes.entities : []);
+        setVaultConcepts(Array.isArray(conceptsRes?.concepts) ? conceptsRes.concepts : []);
+        setVaultDemos(Array.isArray(demosRes?.demos) ? demosRes.demos : []);
+      } finally {
+        if (!cancelled) setVaultLoading(false);
+      }
+    }
+    void loadVault();
     return () => {
       cancelled = true;
     };
@@ -642,6 +705,259 @@ export default function DashboardClaudeCodeIntelPage() {
         {error ? (
           <div className="rounded-2xl border border-red-400/20 bg-red-500/10 p-4 text-sm text-red-200">{error}</div>
         ) : null}
+
+        {/* ── Vault browser: entities (grouped by kind) ─────────────── */}
+        <section className="rounded-[28px] border border-border/40 bg-card/20 p-5 backdrop-blur-xl">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Knowledge Base</div>
+              <h2 className="mt-1 text-lg font-semibold text-slate-100">Entities</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Synthesized Anthropic-domain knowledge — features, commands, policies. Click a card to open the markdown page.
+              </p>
+            </div>
+            <div className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-slate-300">
+              {vaultLoading ? "…" : vaultEntities.length}
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3">
+            {vaultLoading && !vaultEntities.length ? (
+              <div className="text-sm text-muted-foreground">Loading vault entities…</div>
+            ) : null}
+            {!vaultLoading && !vaultEntities.length ? (
+              <div className="rounded-2xl border border-dashed border-border/40 p-4 text-sm text-muted-foreground">
+                No entity pages found in the vault yet.
+              </div>
+            ) : null}
+            {(() => {
+              if (!vaultEntities.length) return null;
+              const groups = new Map<string, VaultEntity[]>();
+              for (const entity of vaultEntities) {
+                const key = (entity.kind || "unspecified").toLowerCase();
+                const list = groups.get(key) || [];
+                list.push(entity);
+                groups.set(key, list);
+              }
+              const orderedKinds = Array.from(groups.keys()).sort();
+              return orderedKinds.map((kindKey) => {
+                const items = groups.get(kindKey) || [];
+                return (
+                  <details key={kindKey} className="rounded-2xl border border-white/8 bg-white/[0.03]" open={items.length <= 8}>
+                    <summary className="cursor-pointer select-none rounded-2xl px-4 py-3 text-sm font-medium text-slate-100 hover:bg-white/[0.05]">
+                      <span className="inline-flex items-center gap-2">
+                        <span className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-cyan-100">
+                          {kindKey}
+                        </span>
+                        <span>{items.length} {items.length === 1 ? "page" : "pages"}</span>
+                      </span>
+                    </summary>
+                    <div className="grid gap-3 px-4 pb-4 md:grid-cols-2 xl:grid-cols-3">
+                      {items.map((entity) => {
+                        const summary = asText(entity.summary);
+                        const truncated = summary.length > 200 ? `${summary.slice(0, 200)}…` : summary;
+                        const confidenceColor =
+                          entity.confidence === "high"
+                            ? "border-emerald-400/30 text-emerald-200"
+                            : entity.confidence === "low"
+                              ? "border-red-400/30 text-red-200"
+                              : "border-amber-400/30 text-amber-200";
+                        return (
+                          <a
+                            key={asText(entity.path)}
+                            href={asText(entity.storage_href) || asText(entity.api_url)}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="flex flex-col gap-2 rounded-2xl border border-white/8 bg-white/[0.04] p-3 transition hover:bg-white/[0.07]"
+                          >
+                            <div className="flex items-start justify-between gap-2">
+                              <div className="text-sm font-medium text-slate-100">{entity.title || entity.path}</div>
+                              <div className="shrink-0 text-[10px] text-muted-foreground">
+                                {entity.updated_at ? formatDateTimeTz(entity.updated_at, { placeholder: entity.updated_at }) : ""}
+                              </div>
+                            </div>
+                            {truncated ? <div className="text-xs leading-5 text-slate-300">{truncated}</div> : null}
+                            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                              {entity.confidence ? (
+                                <span className={`rounded-full border bg-white/5 px-2 py-0.5 text-[10px] ${confidenceColor}`}>
+                                  {entity.confidence}
+                                </span>
+                              ) : null}
+                              <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] text-slate-200">
+                                {asNumber(entity.source_count)} {asNumber(entity.source_count) === 1 ? "source" : "sources"}
+                              </span>
+                              {entity.has_demos ? (
+                                <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-100">
+                                  has demos
+                                </span>
+                              ) : null}
+                              {(entity.tags || [])
+                                .filter((tag) => !asText(tag).toLowerCase().startsWith("kind:"))
+                                .slice(0, 3)
+                                .map((tag) => (
+                                  <span key={`${entity.path}-${tag}`} className="rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-cyan-200/90">
+                                    {tag}
+                                  </span>
+                                ))}
+                            </div>
+                          </a>
+                        );
+                      })}
+                    </div>
+                  </details>
+                );
+              });
+            })()}
+          </div>
+        </section>
+
+        {/* ── Vault browser: concepts (flat list) ───────────────────── */}
+        <section className="rounded-[28px] border border-border/40 bg-card/20 p-5 backdrop-blur-xl">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Knowledge Base</div>
+              <h2 className="mt-1 text-lg font-semibold text-slate-100">Concepts</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Cross-cutting ideas synthesized from multiple sources — context engineering, evaluation, agent loops.
+              </p>
+            </div>
+            <div className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-slate-300">
+              {vaultLoading ? "…" : vaultConcepts.length}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {vaultLoading && !vaultConcepts.length ? (
+              <div className="text-sm text-muted-foreground">Loading vault concepts…</div>
+            ) : null}
+            {!vaultLoading && !vaultConcepts.length ? (
+              <div className="rounded-2xl border border-dashed border-border/40 p-4 text-sm text-muted-foreground">
+                No concept pages found in the vault yet.
+              </div>
+            ) : null}
+            {vaultConcepts.map((concept) => {
+              const summary = asText(concept.summary);
+              const truncated = summary.length > 200 ? `${summary.slice(0, 200)}…` : summary;
+              return (
+                <a
+                  key={asText(concept.path)}
+                  href={asText(concept.storage_href) || asText(concept.api_url)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="flex flex-col gap-2 rounded-2xl border border-white/8 bg-white/[0.04] p-3 transition hover:bg-white/[0.07]"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="text-sm font-medium text-slate-100">{concept.title || concept.path}</div>
+                    <div className="shrink-0 text-[10px] text-muted-foreground">
+                      {concept.updated_at ? formatDateTimeTz(concept.updated_at, { placeholder: concept.updated_at }) : ""}
+                    </div>
+                  </div>
+                  {truncated ? <div className="text-xs leading-5 text-slate-300">{truncated}</div> : null}
+                  <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                    <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] text-slate-200">
+                      {asNumber(concept.source_count)} {asNumber(concept.source_count) === 1 ? "source" : "sources"}
+                    </span>
+                    {(concept.tags || [])
+                      .filter((tag) => !asText(tag).toLowerCase().startsWith("kind:"))
+                      .slice(0, 4)
+                      .map((tag) => (
+                        <span key={`${concept.path}-${tag}`} className="rounded-full border border-white/8 px-2 py-0.5 text-[10px] text-cyan-200/90">
+                          {tag}
+                        </span>
+                      ))}
+                  </div>
+                </a>
+              );
+            })}
+          </div>
+        </section>
+
+        {/* ── Demo workspaces (built by Cody, cross-referenced against entity pages) ── */}
+        <section className="rounded-[28px] border border-border/40 bg-card/20 p-5 backdrop-blur-xl">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Workspaces</div>
+              <h2 className="mt-1 text-lg font-semibold text-slate-100">Demos</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Built demo workspaces under /opt/ua_demos. Linked demos are referenced from their entity page's Demos section; orphans aren&apos;t.
+              </p>
+            </div>
+            <div className="rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-slate-300">
+              {vaultLoading ? "…" : vaultDemos.length}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {vaultLoading && !vaultDemos.length ? (
+              <div className="text-sm text-muted-foreground">Loading demos…</div>
+            ) : null}
+            {!vaultLoading && !vaultDemos.length ? (
+              <div className="rounded-2xl border border-dashed border-border/40 p-4 text-sm text-muted-foreground">
+                No demo workspaces found under /opt/ua_demos.
+              </div>
+            ) : null}
+            {vaultDemos.map((demo) => {
+              const endpoint = asText(demo.endpoint_hit);
+              const isAnthropic = endpoint === "anthropic_native" || endpoint === "api.anthropic.com";
+              const endpointBadge = isAnthropic
+                ? "border-emerald-400/30 bg-emerald-500/10 text-emerald-200"
+                : "border-white/12 bg-white/5 text-slate-200";
+              // Look up the entity page for this slug so the "View" link
+              // takes the operator to the canonical markdown page.
+              const slug = asText(demo.entity_slug);
+              const entityPage = slug
+                ? vaultEntities.find((e) => {
+                    const p = asText(e.path).toLowerCase();
+                    return p === `entities/${slug.toLowerCase()}.md`;
+                  })
+                : undefined;
+              const viewHref = entityPage ? asText(entityPage.storage_href) || asText(entityPage.api_url) : "";
+              return (
+                <div
+                  key={asText(demo.demo_id)}
+                  className="flex flex-col gap-2 rounded-2xl border border-white/8 bg-white/[0.04] p-3"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="text-sm font-medium text-slate-100">{demo.feature || demo.demo_id}</div>
+                    <div className="shrink-0 text-[10px] text-muted-foreground">
+                      {demo.timestamp ? formatDateTimeTz(demo.timestamp, { placeholder: demo.timestamp }) : ""}
+                    </div>
+                  </div>
+                  <div className="text-[11px] text-muted-foreground">{demo.demo_id}</div>
+                  <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                    {endpoint ? (
+                      <span className={`rounded-full border px-2 py-0.5 text-[10px] ${endpointBadge}`}>{endpoint}</span>
+                    ) : null}
+                    {demo.marker_verified ? (
+                      <span className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] text-emerald-200">
+                        marker verified
+                      </span>
+                    ) : null}
+                    {demo.linked_from_entity && slug ? (
+                      <span className="rounded-full border border-cyan-400/30 bg-cyan-400/10 px-2 py-0.5 text-[10px] text-cyan-100">
+                        linked → {slug}
+                      </span>
+                    ) : slug ? (
+                      <span className="rounded-full border border-amber-400/30 bg-amber-500/10 px-2 py-0.5 text-[10px] text-amber-100">
+                        orphan
+                      </span>
+                    ) : null}
+                  </div>
+                  {viewHref ? (
+                    <a
+                      href={viewHref}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="mt-1 inline-flex w-fit items-center gap-1 rounded-full border border-cyan-400/25 bg-cyan-400/10 px-2.5 py-1 text-[11px] text-cyan-100 transition hover:bg-cyan-400/15"
+                    >
+                      View entity page
+                    </a>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </section>
 
         <section className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
           <div className="rounded-[28px] border border-border/40 bg-card/20 p-4 backdrop-blur-xl">


### PR DESCRIPTION
## Summary

The `/dashboard/claude-code-intel` tab previously rendered raw packets + the demo-triage drawer only. The 64 entity pages and 15 concept pages produced by the v2 synthesis pipeline, plus the demo workspaces built under `/opt/ua_demos`, were invisible to the operator. This PR closes the loop.

## What changes

**Backend (`src/universal_agent/gateway_server.py`)**
- `_claude_code_intel_knowledge_pages` now takes a `categories` tuple (default `("sources",)` keeps the existing dashboard endpoint behaviour). Each returned record is enriched with `kind` (parsed from `kind:<value>` tag or the frontmatter `kind` field), `source_count`, `confidence`, and `has_demos` (a regex check for a `## Demos` heading in the body).
- New helper `_claude_code_intel_demos` walks `/opt/ua_demos/<slug>__demo-N/` (env-overridable via `UA_DEMOS_ROOT`), parses each `manifest.json`, and cross-references entity pages' `## Demos` sections in a single pass to set `linked_from_entity`. Orphan demos still appear; they just don't get the linked badge.
- Three new ops-auth-gated GET endpoints:
  - `/api/v1/dashboard/claude-code-intel/vault/entities?limit=&kind=`
  - `/api/v1/dashboard/claude-code-intel/vault/concepts?limit=&kind=`
  - `/api/v1/dashboard/claude-code-intel/demos`

**Frontend (`web-ui/app/dashboard/claude-code-intel/page.tsx`)**
- Adds `VaultEntity` + `Demo` types, parallel fetch effect (`Promise.all`), and three new sections rendered between the header and the packet detail:
  - **Entities** — grouped by `kind` in collapsible `<details>` blocks (auto-open if a kind has ≤ 8 pages). Cards show title, truncated summary (~200 chars), confidence pill, source count, "has demos" badge, non-`kind:` tags, and timestamp. Click → opens the markdown via `storage_href`.
  - **Concepts** — flat grid sorted by `updated_at` desc; same card shape minus the kind pill.
  - **Demos** — workspace cards with feature, `demo_id`, an `endpoint_hit` badge (green for `anthropic_native` / `api.anthropic.com`), `marker_verified`, `linked → <slug>` vs `orphan` indicators, and a "View entity page" link that resolves through the cross-loaded entity list.

**Tests (`tests/unit/test_dashboard_vault_endpoints.py`)**
- 5 new unit tests covering: entities path enrichment, concepts category filter, sources-default regression (including the JS-disabled X.com summary filter), `_claude_code_intel_demos` linkage + orphan handling, missing-root tolerance.

## Behaviour preserved

- No change to `GET /api/v1/dashboard/claude-code-intel` shape — the default `categories=("sources",)` matches the prior behaviour byte-for-byte, including the JS-disabled-page filter (now scoped to `sources` only since synthesized pages don't have that failure mode).
- No change to the demo-triage flow or its endpoints.
- No SSE/websocket — plain `fetch`.

## Cross-references

Predecessor PRs #283 (pending demo-triage in briefing + vault-demo-attach) and #284 set up the data this tab now surfaces.

## Test plan

- [x] `uv run ruff check src/universal_agent/gateway_server.py tests/unit/test_dashboard_vault_endpoints.py` — clean (no new errors; pre-existing unrelated errors in gateway_server unchanged)
- [x] `uv run python -c "import py_compile; py_compile.compile('src/universal_agent/gateway_server.py', doraise=True)"` — OK
- [x] `uv run pytest tests/unit/test_dashboard_vault_endpoints.py tests/unit/test_claude_code_intel_dashboard_endpoint.py tests/unit/test_claude_code_intel_dashboard_page.py -x` — 11/11 pass
- [x] `npx tsc --noEmit -p tsconfig.json` (from `web-ui/`) — exit 0
- [ ] Operator smoke on VPS: hit `/api/v1/dashboard/claude-code-intel/vault/entities` and confirm `entities` array returned with non-empty `kind` / `source_count` fields; load `/dashboard/claude-code-intel` and verify the three new sections render with real vault content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)