### PR TITLE
fix(gateway): spawn startup recovery sweep as background task

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -14338,44 +14338,66 @@ async def lifespan(app: FastAPI):
 
         # ── Startup Recovery: Release orphaned task assignments ──────────
         # When the gateway crashes, in-progress tasks with seized assignments
-        # are left orphaned. Release them here with a short stale threshold
-        # (5 minutes) since we KNOW the process was dead.
-        try:
-            from universal_agent import task_hub as _recovery_task_hub
-            from universal_agent.services.email_task_bridge import (
-                reconcile_terminal_email_task_mappings,
-            )
-            _recovery_conn = connect_runtime_db(get_activity_db_path())
-            _recovery_conn.row_factory = sqlite3.Row
-            _recovery_task_hub.ensure_schema(_recovery_conn)
-            _recovery_result = _recovery_task_hub.release_stale_assignments(
-                _recovery_conn,
-                agent_id_prefix=["heartbeat:", "todo:"],
-                stale_after_seconds=300,  # 5 minutes — short at startup since process was dead
-            )
-            _running_sessions = {
-                str(session.session_id or "").strip()
-                for session in _gateway_live_session_summaries()
-                if getattr(session, "session_id", None)
-            }
-            _reconciled = _recovery_task_hub.reconcile_task_lifecycle(
-                _recovery_conn,
-                running_session_ids=_running_sessions,
-            )
-            _email_mapping_reconciled = reconcile_terminal_email_task_mappings(_recovery_conn)
-            if int(_recovery_result.get("finalized") or 0) > 0:
-                logger.warning(
-                    "🔄 Startup recovery: released %d orphaned task assignment(s) (reopened=%d)",
-                    int(_recovery_result.get("finalized") or 0),
-                    int(_recovery_result.get("reopened") or 0),
+        # are left orphaned. We sweep them via release_stale_assignments,
+        # reconcile_task_lifecycle, and reconcile_terminal_email_task_mappings.
+        #
+        # ALWAYS spawn this as a background task so lifespan startup can
+        # complete promptly. On a production-sized activity_state.db (180MB+
+        # observed during the 2026-05-16 deploy hang) these synchronous
+        # SQLite queries blocked the FastAPI ``Application startup
+        # complete`` signal for >8 minutes, causing deploys to fail the
+        # gateway ``/api/v1/health`` window in deploy.yml. Recovery still
+        # runs within a few seconds of startup; the only consequence of
+        # deferring is that orphaned tasks remain pending for those few
+        # seconds.
+        async def _run_startup_recovery_sweep() -> None:
+            try:
+                from universal_agent import task_hub as _recovery_task_hub
+                from universal_agent.services.email_task_bridge import (
+                    reconcile_terminal_email_task_mappings,
                 )
-            if any(int(_reconciled.get(key) or 0) > 0 for key in ("reopened", "reviewed", "completion_flagged", "delegated_backfilled")):
-                logger.warning("Startup task lifecycle reconciliation: %s", _reconciled)
-            if any(int(_email_mapping_reconciled.get(key) or 0) > 0 for key in _email_mapping_reconciled):
-                logger.warning("Startup email mapping reconciliation: %s", _email_mapping_reconciled)
-            _recovery_conn.close()
-        except Exception as _recovery_exc:
-            logger.warning("Startup task recovery sweep failed (non-fatal): %s", _recovery_exc)
+                _recovery_conn = connect_runtime_db(get_activity_db_path())
+                _recovery_conn.row_factory = sqlite3.Row
+                _recovery_task_hub.ensure_schema(_recovery_conn)
+                _recovery_result = _recovery_task_hub.release_stale_assignments(
+                    _recovery_conn,
+                    agent_id_prefix=["heartbeat:", "todo:"],
+                    stale_after_seconds=300,  # 5 minutes — short at startup since process was dead
+                )
+                _running_sessions = {
+                    str(session.session_id or "").strip()
+                    for session in _gateway_live_session_summaries()
+                    if getattr(session, "session_id", None)
+                }
+                _reconciled = _recovery_task_hub.reconcile_task_lifecycle(
+                    _recovery_conn,
+                    running_session_ids=_running_sessions,
+                )
+                _email_mapping_reconciled = reconcile_terminal_email_task_mappings(_recovery_conn)
+                if int(_recovery_result.get("finalized") or 0) > 0:
+                    logger.warning(
+                        "🔄 Startup recovery: released %d orphaned task assignment(s) (reopened=%d)",
+                        int(_recovery_result.get("finalized") or 0),
+                        int(_recovery_result.get("reopened") or 0),
+                    )
+                if any(int(_reconciled.get(key) or 0) > 0 for key in ("reopened", "reviewed", "completion_flagged", "delegated_backfilled")):
+                    logger.warning("Startup task lifecycle reconciliation: %s", _reconciled)
+                if any(int(_email_mapping_reconciled.get(key) or 0) > 0 for key in _email_mapping_reconciled):
+                    logger.warning("Startup email mapping reconciliation: %s", _email_mapping_reconciled)
+                _recovery_conn.close()
+            except Exception as _recovery_exc:
+                logger.warning("Startup task recovery sweep failed (non-fatal): %s", _recovery_exc)
+
+        if _deployment_window_active():
+            _spawn_background_task(
+                _run_after_deployment_window("startup_recovery", _run_startup_recovery_sweep),
+                task_name="startup_recovery_sweep",
+            )
+        else:
+            _spawn_background_task(
+                _run_startup_recovery_sweep(),
+                task_name="startup_recovery_sweep",
+            )
     else:
         logger.info("💤 Heartbeat System DISABLED (feature flag)")
 


### PR DESCRIPTION
## Summary — PRODUCTION INCIDENT FIX

**B1 (#284) and B2 (#286) deploys both failed tonight** because the gateway never became healthy. The 8-minute polling window in `deploy.yml` expired before `/api/v1/health` responded.

## Diagnosis

From the production systemd journal at 2026-05-16:

```
03:18:54  python[1640517]: INFO: 🧹 Cleaned up 2 old daemon workspace archives
(8+ minutes of silence — gateway never reaches Application startup complete)
```

The next expected log was `"⏱️ Chron Service ENABLED"` at `gateway_server.py:14389`. Between those two lines sits the synchronous **Startup Recovery block** which:

1. Opens `activity_state.db` (**181 MB on production**)
2. Runs `task_hub.release_stale_assignments(...)` — full scan with WHERE clauses
3. Runs `task_hub.reconcile_task_lifecycle(...)` — another scan
4. Runs `reconcile_terminal_email_task_mappings(...)` — another scan

Synchronous SQLite work on a 180MB+ DB **blocks the asyncio event loop**, so the gateway can't answer `/api/v1/health` until the sweep finishes. Both B1 and B2 deploys watched their fresh gateway PIDs hang at this exact point — same WCHAN, same symptom, **same code path** (PR #284 and #286 changes are not invoked at startup; the regression is the DB simply being larger than it used to be).

## Fix

Wrap the recovery body in `async def _run_startup_recovery_sweep` and dispatch it via `_spawn_background_task` — matching the pattern already used for `heartbeat_service` (lines 14303-14309), `todo_dispatch_service` (lines 14331-14337), and `cron_service` (lines 14398-14404).

Lifespan startup completes immediately; recovery still runs within seconds, just after the gateway is serving traffic.

## Trade-off

Orphaned tasks remain in their pre-recovery state for those few extra seconds while the gateway is up. `release_stale_assignments` uses a 5-minute stale threshold — a few-second delay before the sweep is a negligible widening of that window.

## Test plan

- [x] `ruff check src/universal_agent/gateway_server.py` — only pre-existing unrelated errors (lines 12764, 12765, 16666, 21778, 24036 — none touched by this PR)
- [x] `python -c "import py_compile; py_compile.compile('.../gateway_server.py')"` — OK
- [ ] **Production smoke (post-deploy):** new gateway PID's journal should show `Application startup complete` followed by `⏱️ Chron Service ENABLED` within seconds. The recovery warning logs (`🔄 Startup recovery: released N orphaned task assignment(s)`) should still appear, just a few seconds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)