### PR TITLE
fix(gateway): run startup recovery sync sqlite work in thread executor

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -14341,39 +14341,53 @@ async def lifespan(app: FastAPI):
         # are left orphaned. We sweep them via release_stale_assignments,
         # reconcile_task_lifecycle, and reconcile_terminal_email_task_mappings.
         #
-        # ALWAYS spawn this as a background task so lifespan startup can
-        # complete promptly. On a production-sized activity_state.db (180MB+
-        # observed during the 2026-05-16 deploy hang) these synchronous
-        # SQLite queries blocked the FastAPI ``Application startup
-        # complete`` signal for >8 minutes, causing deploys to fail the
-        # gateway ``/api/v1/health`` window in deploy.yml. Recovery still
-        # runs within a few seconds of startup; the only consequence of
-        # deferring is that orphaned tasks remain pending for those few
-        # seconds.
+        # Spawn as a background task so lifespan startup completes promptly
+        # (see 2026-05-16 incident: lifespan was synchronously running these
+        # queries against a 180MB activity_state.db and blocking the FastAPI
+        # ``Application startup complete`` signal).
+        #
+        # CRITICAL: the body of this background task does SYNCHRONOUS SQLite
+        # work. Running sync code inside an ``async def`` blocks the asyncio
+        # event loop, which means HTTP requests cannot be served while the
+        # sweep runs (~minutes on a 180MB DB) — production-broken even
+        # after the gateway "started". Wrap the sync portion in
+        # ``asyncio.to_thread`` so it runs in the default executor without
+        # blocking the loop. See PR #289 (first attempt) → PR for this
+        # follow-up.
         async def _run_startup_recovery_sweep() -> None:
             try:
-                from universal_agent import task_hub as _recovery_task_hub
-                from universal_agent.services.email_task_bridge import (
-                    reconcile_terminal_email_task_mappings,
-                )
-                _recovery_conn = connect_runtime_db(get_activity_db_path())
-                _recovery_conn.row_factory = sqlite3.Row
-                _recovery_task_hub.ensure_schema(_recovery_conn)
-                _recovery_result = _recovery_task_hub.release_stale_assignments(
-                    _recovery_conn,
-                    agent_id_prefix=["heartbeat:", "todo:"],
-                    stale_after_seconds=300,  # 5 minutes — short at startup since process was dead
-                )
-                _running_sessions = {
+                running_sessions = {
                     str(session.session_id or "").strip()
                     for session in _gateway_live_session_summaries()
                     if getattr(session, "session_id", None)
                 }
-                _reconciled = _recovery_task_hub.reconcile_task_lifecycle(
-                    _recovery_conn,
-                    running_session_ids=_running_sessions,
+
+                def _sync_recovery_work() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+                    from universal_agent import task_hub as _recovery_task_hub
+                    from universal_agent.services.email_task_bridge import (
+                        reconcile_terminal_email_task_mappings,
+                    )
+                    _recovery_conn = connect_runtime_db(get_activity_db_path())
+                    _recovery_conn.row_factory = sqlite3.Row
+                    try:
+                        _recovery_task_hub.ensure_schema(_recovery_conn)
+                        result = _recovery_task_hub.release_stale_assignments(
+                            _recovery_conn,
+                            agent_id_prefix=["heartbeat:", "todo:"],
+                            stale_after_seconds=300,  # 5 minutes — short at startup since process was dead
+                        )
+                        reconciled = _recovery_task_hub.reconcile_task_lifecycle(
+                            _recovery_conn,
+                            running_session_ids=running_sessions,
+                        )
+                        email_mapping_reconciled = reconcile_terminal_email_task_mappings(_recovery_conn)
+                    finally:
+                        _recovery_conn.close()
+                    return result, reconciled, email_mapping_reconciled
+
+                _recovery_result, _reconciled, _email_mapping_reconciled = await asyncio.to_thread(
+                    _sync_recovery_work,
                 )
-                _email_mapping_reconciled = reconcile_terminal_email_task_mappings(_recovery_conn)
                 if int(_recovery_result.get("finalized") or 0) > 0:
                     logger.warning(
                         "🔄 Startup recovery: released %d orphaned task assignment(s) (reopened=%d)",
@@ -14384,7 +14398,6 @@ async def lifespan(app: FastAPI):
                     logger.warning("Startup task lifecycle reconciliation: %s", _reconciled)
                 if any(int(_email_mapping_reconciled.get(key) or 0) > 0 for key in _email_mapping_reconciled):
                     logger.warning("Startup email mapping reconciliation: %s", _email_mapping_reconciled)
-                _recovery_conn.close()
             except Exception as _recovery_exc:
                 logger.warning("Startup task recovery sweep failed (non-fatal): %s", _recovery_exc)
 


### PR DESCRIPTION
## Summary — follow-up to PR #289

**PR #289 didn't fully fix the production hang.** Production restart confirms it: lifespan now completes promptly (`Application startup complete` within seconds, my logs show the deferred services starting on schedule), the gateway binds 8002, but **HTTP requests still hang** — port shows `LISTEN` with Recv-Q growing as connections accept but never get answered.

## Root cause

PR #289 moved the recovery block into an `async def _run_startup_recovery_sweep()` background task. But the body of that async function still contained **synchronous SQLite calls** (`task_hub.release_stale_assignments(...)`, `task_hub.reconcile_task_lifecycle(...)`, `reconcile_terminal_email_task_mappings(...)`).

Sync code in an async function runs on the asyncio event loop and **blocks everything else, including incoming HTTP requests**. So lifespan completed, uvicorn started accepting connections, then the background recovery task got scheduled and immediately hogged the event loop while it ran SQLite queries against the 180MB activity_state.db. Clients see `LISTEN` + Recv-Q queueing but never get HTTP responses.

## Fix

Wrap the sync SQLite portion in `asyncio.to_thread()`. The thread executor runs the DB work concurrently with HTTP serving, so the event loop stays free.

The async-context bits (gathering `running_sessions` from `_gateway_live_session_summaries()`) stay on the loop and are passed into the sync helper as plain data.

## Verification

- `py_compile` OK
- `ruff` clean in my range (only pre-existing unrelated errors)
- **Production smoke after deploy:** new gateway PID should accept connections AND respond to `/api/v1/health` within seconds, even while the recovery sweep is still running in the background thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)