### PR TITLE
fix(infisical): make Infisical authoritative over pre-existing os.environ

### DIFF
--- a/docs/deployment/secrets_and_environments.md
+++ b/docs/deployment/secrets_and_environments.md
@@ -53,6 +53,8 @@ Process starts
 
 The gateway uses `src/universal_agent/infisical_loader.py` to load secrets at startup. This is the preferred approach — secrets are fetched live, never stored on disk.
 
+**Authoritative-overwrite semantics (2026-05-16):** `_inject_environment_values()` defaults to `overwrite=False` for safety (used by the dotenv fallback path), but `initialize_runtime_secrets()` calls it with `overwrite=True` so Infisical values **win over any pre-existing `os.environ` entries** (systemd `Environment=`, bootstrap `.env`, Python module-import side effects). A small whitelist of bootstrap identity keys is preserved via `_BOOTSTRAP_IDENTITY_KEYS` — `FACTORY_ROLE`, `UA_RUNTIME_STAGE`, `UA_MACHINE_SLUG`, `UA_DEPLOYMENT_PROFILE`, `INFISICAL_*`, etc. — so a machine's role/stage cannot be moved by remote config. Operator-flippable feature flags (`UA_ATLAS_DIRECT_DISPATCH_ENABLED`, `UA_CRON_BACKFILL_ON_RESTART`, etc.) flow from Infisical → `os.environ` reliably even when those keys also happen to be set by the systemd unit. Regression test: `tests/unit/test_infisical_loader.py::test_initialize_runtime_secrets_overwrites_preexisting_env_for_non_identity_keys`.
+
 ### Next.js Web UI (deploy-time rendering)
 
 ```

--- a/src/universal_agent/infisical_loader.py
+++ b/src/universal_agent/infisical_loader.py
@@ -22,6 +22,39 @@ _LEGACY_INFISICAL_ENV_ALIASES = {
 _BOOTSTRAP_LOCK = threading.Lock()
 _BOOTSTRAP_RESULT: SecretBootstrapResult | None = None
 
+# Keys that represent the runtime's bootstrap identity. When already set in
+# the process environment (typically by systemd Environment= directives or
+# the bootstrap .env), we preserve the pre-set value even if Infisical
+# returns a different one. Everything else is treated as application
+# configuration where Infisical is authoritative.
+#
+# Why this exists: previously _inject_environment_values defaulted to
+# overwrite=False, which meant ANY key already in os.environ was silently
+# skipped — including new Infisical-managed feature flags. On the VPS,
+# systemd + bootstrap .env + module-import side effects pre-populate ~37
+# keys before bootstrap runs, so any of those that overlap with Infisical
+# secrets stayed at their bootstrap values forever. Operator-flippable
+# disables like UA_ATLAS_DIRECT_DISPATCH_ENABLED were unreachable from
+# Infisical. The fix is to make Infisical authoritative by default, with
+# this small carve-out for true identity keys that must not be moved by
+# remote config.
+_BOOTSTRAP_IDENTITY_KEYS: frozenset[str] = frozenset({
+    "INFISICAL_CLIENT_ID",
+    "INFISICAL_CLIENT_SECRET",
+    "INFISICAL_PROJECT_ID",
+    "INFISICAL_API_URL",
+    "INFISICAL_ENVIRONMENT",
+    "INFISICAL_SECRET_PATH",
+    "UA_RUNTIME_STAGE",
+    "UA_MACHINE_SLUG",
+    "UA_DEPLOYMENT_PROFILE",
+    "FACTORY_ROLE",
+    "UA_INFISICAL_ENABLED",
+    "UA_INFISICAL_STRICT",
+    "UA_INFISICAL_ALLOW_DOTENV_FALLBACK",
+    "UA_DOTENV_PATH",
+})
+
 
 @dataclass(frozen=True)
 class SecretBootstrapResult:
@@ -93,6 +126,7 @@ def _inject_environment_values(
     *,
     overwrite: bool = False,
     exclude_prefixes: tuple[str, ...] = (),
+    preserve_keys: frozenset[str] = frozenset(),
 ) -> int:
     inserted = 0
     for key, value in values.items():
@@ -100,6 +134,10 @@ def _inject_environment_values(
         if not clean_key:
             continue
         if exclude_prefixes and any(clean_key.startswith(p) for p in exclude_prefixes):
+            continue
+        # Bootstrap identity keys win over remote config when pre-set,
+        # even if overwrite=True for everything else.
+        if clean_key in preserve_keys and clean_key in os.environ:
             continue
         if not overwrite and clean_key in os.environ:
             continue
@@ -404,10 +442,17 @@ def initialize_runtime_secrets(
         if infisical_enabled:
             try:
                 secret_values = _fetch_infisical_secrets()
+                # Infisical is single source of truth for application config.
+                # We pass overwrite=True so values from the vault win over any
+                # pre-existing os.environ entries (systemd Environment=, .env
+                # bootstrap, module-import side effects). Bootstrap identity
+                # keys are exempted via preserve_keys so the machine's
+                # role/stage/slug can never be moved by remote config.
                 loaded_count = _inject_environment_values(
                     secret_values,
-                    overwrite=False,
+                    overwrite=True,
                     exclude_prefixes=exclude_prefixes,
+                    preserve_keys=_BOOTSTRAP_IDENTITY_KEYS,
                 )
                 source = "infisical"
                 normalized_environment = _normalize_infisical_environment(os.getenv("INFISICAL_ENVIRONMENT"))

--- a/tests/unit/test_infisical_loader.py
+++ b/tests/unit/test_infisical_loader.py
@@ -187,6 +187,39 @@ def test_initialize_runtime_secrets_preserves_bootstrap_identity_over_infisical(
     assert infisical_loader.os.getenv("UA_MACHINE_SLUG") == "kevins-desktop"
     assert infisical_loader.os.getenv("UA_OPS_TOKEN") == "token"
 
+def test_initialize_runtime_secrets_overwrites_preexisting_env_for_non_identity_keys(monkeypatch):
+    """Regression: 2026-05-16 incident — operator set
+    UA_ATLAS_DIRECT_DISPATCH_ENABLED=0 in Infisical to disable a runaway cron,
+    but the loader silently skipped it because the key was already present in
+    os.environ (set by systemd / .env / module-import side effects). Infisical
+    is the single source of truth for application config — its values MUST
+    win over pre-existing env entries for any key that isn't a bootstrap
+    identity key.
+    """
+    monkeypatch.setenv("UA_DEPLOYMENT_PROFILE", "local_workstation")
+    monkeypatch.setenv("UA_INFISICAL_ENABLED", "1")
+    monkeypatch.setenv("INFISICAL_CLIENT_ID", "client")
+    monkeypatch.setenv("INFISICAL_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("INFISICAL_PROJECT_ID", "project")
+    # Simulate systemd/.env pre-populating the env with a stale value.
+    monkeypatch.setenv("UA_ATLAS_DIRECT_DISPATCH_ENABLED", "1")
+    monkeypatch.setenv("UA_SOME_FEATURE_FLAG", "old")
+    monkeypatch.setattr(
+        infisical_loader,
+        "_fetch_infisical_secrets",
+        lambda: {
+            "UA_ATLAS_DIRECT_DISPATCH_ENABLED": "0",
+            "UA_SOME_FEATURE_FLAG": "new",
+        },
+    )
+
+    result = infisical_loader.initialize_runtime_secrets(force_reload=True)
+
+    assert result.ok is True
+    assert infisical_loader.os.getenv("UA_ATLAS_DIRECT_DISPATCH_ENABLED") == "0"
+    assert infisical_loader.os.getenv("UA_SOME_FEATURE_FLAG") == "new"
+
+
 def test_initialize_runtime_secrets_aliases_zai_api_key(monkeypatch):
     monkeypatch.setenv("UA_DEPLOYMENT_PROFILE", "local_workstation")
     monkeypatch.setenv("UA_INFISICAL_ENABLED", "1")


### PR DESCRIPTION
## Summary

Real fix for the 2026-05-16 gateway-wedge incident root cause. The Infisical loader was silently dropping any vault secret whose key was already set in `os.environ` (~37 keys on the VPS, pre-populated by systemd `Environment=` directives, the bootstrap `.env`, and Python module-import side effects). This meant the three operator-supplied disable flags added to Infisical Production yesterday (`UA_ATLAS_DIRECT_DISPATCH_ENABLED=0`, `UA_SIMONE_CHAT_AUTO_COMPLETE_ENABLED=0`, `UA_CRON_BACKFILL_ON_RESTART=0`) never made it into the running gateway's environment — the loader kept the stale bootstrap-layer defaults instead.

Per `CLAUDE.md`, Infisical is the single source of truth for application secrets/config. Its values must win.

## Changes

- `_inject_environment_values()` keeps its `overwrite=False` default (used by the dotenv fallback path — sane behavior there) but gains a `preserve_keys` parameter
- New `_BOOTSTRAP_IDENTITY_KEYS` whitelist: `FACTORY_ROLE`, `UA_RUNTIME_STAGE`, `UA_MACHINE_SLUG`, `UA_DEPLOYMENT_PROFILE`, `INFISICAL_*`, the `UA_INFISICAL_*` toggles, and `UA_DOTENV_PATH`. These are *machine identity* — they must never be moved by remote config
- `initialize_runtime_secrets()` now calls inject with `overwrite=True, preserve_keys=_BOOTSTRAP_IDENTITY_KEYS` — vault wins for all application config, identity is preserved
- `exclude_prefixes` for the `ANTHROPIC_*` OAuth carve-out (interactive Claude launcher) still works exactly as before
- Regression test added to lock in the new behavior
- Existing `test_initialize_runtime_secrets_preserves_bootstrap_identity_over_infisical` still passes — `FACTORY_ROLE`/stage/slug from systemd still beat vault overrides

## Verification

- [x] `uv run pytest tests/unit/test_infisical_loader.py` — 10/10 pass (1 new, 9 existing)
- [x] `uv run pytest tests/unit/test_render_service_env_from_infisical.py tests/unit/test_infisical_manage_stage_env.py` — 5/5 pass
- [x] `uv run ruff check` on touched files — clean
- [x] `py_compile` on the loader — clean
- [x] Canonical doc updated: `docs/deployment/secrets_and_environments.md` § Python Gateway and API (runtime loading) now documents the authoritative-overwrite semantics

## Post-Deploy Expectation

Once this lands on `main` and deploy.yml runs:

1. The gateway will pick up `UA_ATLAS_DIRECT_DISPATCH_ENABLED=0` from Infisical at startup
2. `_ensure_simone_chat_autocomplete_cron_job()` will see `UA_SIMONE_CHAT_AUTO_COMPLETE_ENABLED=0` and register Simone's cron as `enabled=False` instead of re-enabling it on every restart
3. `UA_CRON_BACKFILL_ON_RESTART=0` will prevent the queued-backfill replay storm we saw on each restart attempt

These three together should let the gateway boot, stay healthy, and start serving HTTP without the event-loop blockage that wedged it overnight.

## Test plan

- [ ] Watch deploy.yml succeed on this PR's merge to main
- [ ] On the VPS, `journalctl -u universal-agent.service` should show `loaded=272` (or close to it — the gap should drop from 37 to ~2 ZAI aliases)
- [ ] `curl http://127.0.0.1:8002/api/v1/health` returns 200 within the deploy's 8-min health check window
- [ ] Confirm cron registration log shows Simone's `enabled=False` at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)