### PR TITLE
fix(gateway): pre-bind socket with SO_REUSEPORT to prevent orphan-socket wedge

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -33262,6 +33262,7 @@ async def websocket_stream(
 
 
 if __name__ == "__main__":
+    import socket
     import time
 
     import uvicorn
@@ -33279,20 +33280,51 @@ if __name__ == "__main__":
 ╚══════════════════════════════════════════════════════════════╝
     """)
 
-    # PR #293 added ``reuse_port=True`` to address restart-race port-bind
-    # failures, but uvicorn 0.46.0 (currently pinned in production) doesn't
-    # accept that keyword and the gateway crash-looped with TypeError. The
-    # restart-race issue is real, but the fix requires either bumping
-    # uvicorn or constructing the socket manually with SO_REUSEPORT before
-    # passing it to uvicorn.Config — not just a kwarg flip. Revert to the
-    # plain call for now; the retry-loop below already softens transient
-    # bind failures.
+    # Pre-bind the listen socket with SO_REUSEADDR + SO_REUSEPORT so that
+    # restart-race port-bind failures don't wedge the gateway.
+    #
+    # 2026-05-16 incident root cause: uvicorn 0.46.0's lifespan-then-bind
+    # ordering can leave a kernel-level orphan listen socket on :8002 after
+    # a bind failure or unclean shutdown. CLOSE-WAIT child connections
+    # anchor the socket in LISTEN state even after the owning process dies
+    # — no userspace fd holds it but the kernel keeps it alive. Every
+    # subsequent restart then hits EADDRINUSE. Recovery required a reboot
+    # because we had no root access to `ss -K` the orphan.
+    #
+    # PR #293 attempted ``reuse_port=True`` as a uvicorn.run() kwarg but
+    # uvicorn 0.46.0 doesn't accept that. The correct API is to construct
+    # the socket manually, set SO_REUSEPORT, and pass the fd via
+    # ``uvicorn.Config(fd=sock.fileno())``. With SO_REUSEPORT set on every
+    # gateway start, a future orphan socket carries the same flag, so the
+    # next start can co-bind alongside it. The orphan has no userspace
+    # accept loop, so the kernel routes incoming SYNs to whichever socket
+    # is actively accepting.
+    #
+    # SO_REUSEADDR alone is insufficient — it allows binding to a TIME_WAIT
+    # remnant but NOT to a port held by another LISTEN socket without
+    # matching REUSEPORT.
     max_retries = 5
     for attempt in range(max_retries):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
-            uvicorn.run(app, host=host, port=port, log_level="info")
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except (AttributeError, OSError):
+            # SO_REUSEPORT requires Linux 3.9+; degrade gracefully on
+            # platforms that don't expose it (e.g., older kernels, BSDs).
+            pass
+        try:
+            sock.bind((host, port))
+            sock.listen(2048)
+            sock.setblocking(False)
+            config = uvicorn.Config(app, fd=sock.fileno(), log_level="info")
+            uvicorn.Server(config).run()
             break
         except OSError as e:
+            try:
+                sock.close()
+            except OSError:
+                pass
             if "address already in use" in str(e).lower() or getattr(e, "errno", None) == 98:
                 print(f"Port {port} is in use. Retrying in 2 seconds... (Attempt {attempt + 1}/{max_retries})")
                 time.sleep(2)


### PR DESCRIPTION
## Summary

Permanent fix for the 2026-05-16 incident's deepest layer. PR #297 fixed the Infisical-loader symptom that surfaced through this incident; this PR fixes the actual mechanism that caused production gateway to be unrecoverable without a reboot.

**Root cause of the orphan socket:** uvicorn 0.46.0 binds the listen socket AFTER lifespan completes. When lifespan succeeds but bind fails (or when the process is killed mid-shutdown), the asyncio Server object can leave a kernel-level orphan listen socket on `:8002`. CLOSE-WAIT child connections anchor the socket in `LISTEN` state in the kernel TCP table even after the owning process dies — `ss -tlnpe` shows `uid:1001 ino:59213869 cgroup:/system.slice/universal-agent-gateway.service` with no userspace fd holder. Every subsequent gateway restart then hits `[Errno 98] address already in use` and recovery requires either `sudo ss -K state listening 'sport = :8002'` (root) or a reboot.

**The fix:** construct the listen socket manually with `SO_REUSEADDR + SO_REUSEPORT`, bind/listen explicitly, then pass the fd to `uvicorn.Config(fd=...)` instead of letting uvicorn do its own bind. With `SO_REUSEPORT` set on every gateway start, future orphan sockets carry the same flag, so the next start can co-bind alongside any orphan. The orphan has no userspace accept loop, so the kernel routes incoming SYNs to the actively-accepting socket.

This is the "PR #293 done right" — that PR tried `reuse_port=True` as a `uvicorn.run()` kwarg, which uvicorn 0.46.0 doesn't accept. The manual-socket-then-fd path is the correct API.

## Why SO_REUSEPORT and not just SO_REUSEADDR

`SO_REUSEADDR` allows binding to a `TIME_WAIT` remnant but **not** to a port held by another active `LISTEN` socket. `SO_REUSEPORT` is the Linux-3.9+ flag that allows multiple sockets to listen on the same port simultaneously — both must set it. By setting it on every gateway socket from now on, the gateway becomes immune to this class of failure.

Smoke-verified locally on Linux 6.17:

```python
s1 = socket.socket(...); s1.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1); s1.bind(('127.0.0.1', 0)); s1.listen()
s2 = socket.socket(...); s2.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1); s2.bind(('127.0.0.1', port)); s2.listen()
# both succeed; both visible in `ss -tlnpe` on the same port
```

## Verification

- [x] `uv run python -c "import py_compile; ..."` — compile clean
- [x] `uv run ruff check --select E9,F --ignore E402,F401,F541,F811,F841` (PR-Validate's exact flags) — all clean
- [x] SO_REUSEPORT smoke test confirms two sockets can co-bind on the same port
- [x] `uvicorn.Config(fd=...)` confirmed in uvicorn 0.46.0 API

## Operator action after this PR merges

The current production orphan socket carries no `SO_REUSEPORT` flag (it was bound by the old code), so even with this PR deployed, the NEXT gateway start will still hit `EADDRINUSE` from that orphan. To clear it, one of:

1. **Surgical:** `ssh ua@uaonvps "sudo ss -K state listening 'sport = :8002' && sudo systemctl restart universal-agent-gateway"`
2. **Nuclear (recommended):** `ssh ua@uaonvps "sudo reboot"` — clears all kernel TCP state. Service auto-starts with this PR's new code. From then on, gateway is immune to this failure mode.

After the reboot, every gateway socket from now on will have `SO_REUSEPORT` set, so any future orphan can be co-bound past instead of requiring a reboot to clear.

## Test plan

- [ ] PR-Validate gate passes
- [ ] auto-merge squashes to main
- [ ] deploy.yml runs and lays new code on `/opt/universal_agent/`
- [ ] Operator runs reboot (or sudo ss -K)
- [ ] Gateway starts cleanly: `journalctl -u universal-agent-gateway` shows "Started server process" → "Application startup complete" with NO "address already in use"
- [ ] `curl http://127.0.0.1:8002/api/v1/health` returns 200 within seconds
- [ ] `ss -tlnpe | grep 8002` shows the gateway's process owning the listen socket with a current PID

🤖 Generated with [Claude Code](https://claude.com/claude-code)