### PR TITLE
feat(csi): Phase C follow-ups — vault-lint cron + lane-aware task payload (PRs 13 + 17)

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -14457,6 +14457,7 @@ async def lifespan(app: FastAPI):
                 _ensure_hackernews_snapshot_cron_job()
                 _ensure_atlas_direct_dispatch_cron_job()
                 _ensure_simone_chat_autocomplete_cron_job()
+                _ensure_vault_lint_contradictions_cron_job()
             except Exception as exc:
                 logger.warning("Failed ensuring autonomous cron jobs: %s", exc)
         else:
@@ -18557,6 +18558,25 @@ def _ensure_morning_briefing_cron_job() -> Optional[dict[str, Any]]:
         # Declare it so the Phase 5 pre-flight surfaces a structured
         # cron_run_failed notification instead of a generic exit code.
         required_secrets=["UA_OPS_TOKEN"],
+    )
+
+
+def _ensure_vault_lint_contradictions_cron_job() -> Optional[dict[str, Any]]:
+    # PR 13 — monthly vault contradiction sweep. Report-only (never modifies
+    # pages). LLM cost is bounded by candidate-pair filtering before the
+    # analysis pass. Schedule: 1st of month at 07:00 Central (inside the
+    # 6 AM – 9 PM Houston active window per docs/operations/operating_hours_dormancy.md
+    # since this is content-generation, not infrastructure-event handling).
+    return _register_system_cron_job(
+        system_job="vault_lint_contradictions",
+        default_cron="0 7 1 * *",
+        default_timezone="America/Chicago",
+        command="!script universal_agent.scripts.vault_contradiction_lint",
+        description="Monthly vault contradictions sweep across every enabled intel lane (report-only).",
+        timeout_seconds=1800,
+        enabled=_proactive_cron_enabled("UA_VAULT_LINT_CONTRADICTIONS_ENABLED"),
+        cron_env_var="UA_VAULT_LINT_CONTRADICTIONS_CRON",
+        timezone_env_var="UA_VAULT_LINT_CONTRADICTIONS_TIMEZONE",
     )
 
 

--- a/src/universal_agent/services/claude_code_intel.py
+++ b/src/universal_agent/services/claude_code_intel.py
@@ -426,7 +426,7 @@ def run_sync(
             if conn is not None:
                 artifact_id = register_packet_artifact(conn, packet_dir=packet_dir, handle=cfg.handle, actions=actions, new_posts=new_posts)
                 if cfg.queue_task_hub:
-                    queued += queue_follow_up_tasks(conn, handle=cfg.handle, packet_dir=packet_dir, actions=chunk_actions)
+                    queued += queue_follow_up_tasks(conn, handle=cfg.handle, packet_dir=packet_dir, actions=chunk_actions, lane_slug=cfg.lane_slug)
                     
             # Checkpoint the state forward
             current_state = _next_state(
@@ -926,6 +926,24 @@ def _direct_demo_fallback_enabled() -> bool:
     return os.getenv("UA_CSI_DIRECT_DEMO_FALLBACK", "0").strip().lower() in _TRUTHY
 
 
+def _vault_slug_for_lane(lane_slug: str) -> str:
+    """Look up the vault_slug for a given intel lane.
+
+    PR 17 — Falls back to the hardcoded ``KB_SLUG`` if the lane config is
+    unreachable (defensive: tests, broken yaml, etc.). For the single
+    ``claude-code-intelligence`` lane this is a no-op (yaml + constant
+    happen to match). The indirection earns its weight only when a second
+    lane (e.g. Codex / Gemini intel) gets added.
+    """
+    try:
+        from universal_agent.services.intel_lanes import get_lane
+
+        lane = get_lane(lane_slug)
+    except Exception:
+        return KB_SLUG
+    return str(getattr(lane, "vault_slug", "") or KB_SLUG)
+
+
 def _build_followup_task_payload(
     *,
     handle: str,
@@ -933,6 +951,7 @@ def _build_followup_task_payload(
     action: dict[str, Any],
     tier: int,
     post_id: str,
+    lane_slug: str = "claude-code-intelligence",
 ) -> dict[str, Any]:
     """Build the canonical Task Hub upsert dict for a tier 3+ CSI action.
 
@@ -946,6 +965,11 @@ def _build_followup_task_payload(
     moves from "auto-queued in v1" to "operator-approved in v2" lands on
     the same downstream agent with the same metadata. Do NOT inline this
     logic anywhere else.
+
+    PR 17 — ``lane_slug`` resolves the vault and KB slug from
+    ``intel_lanes.yaml`` so a future Codex / Gemini intel lane lands tasks
+    targeting its own vault instead of the hardcoded ``claude-code-intelligence``.
+    Defaults preserve current single-lane behavior.
     """
     if tier == 3:
         source_kind = SOURCE_KIND_SCAFFOLD_REQUEST
@@ -962,7 +986,7 @@ def _build_followup_task_payload(
             if post_snippet
             else f"Scaffold Claude Code demo from @{handle} update"
         )
-        description = _scaffold_task_description(handle=handle, packet_dir=packet_dir, action=action)
+        description = _scaffold_task_description(handle=handle, packet_dir=packet_dir, action=action, lane_slug=lane_slug)
         labels = ["agent-ready", "claude-code-intel", "x-api", "simone-scaffold"]
         preferred_vp = "simone_direct"
         workflow_kind = "scaffold_demo_workspace"
@@ -998,8 +1022,8 @@ def _build_followup_task_payload(
             "action_type": action.get("action_type") or "",
             "links": action.get("links") or [],
             "preferred_vp": preferred_vp,
-            "knowledge_base_slug": KB_SLUG,
-            "vault_slug": KB_SLUG,
+            "knowledge_base_slug": _vault_slug_for_lane(lane_slug),
+            "vault_slug": _vault_slug_for_lane(lane_slug),
             "workflow_manifest": {
                 "workflow_kind": workflow_kind,
                 "delivery_mode": "interactive_chat",
@@ -1018,6 +1042,7 @@ def queue_follow_up_tasks(
     handle: str,
     packet_dir: Path,
     actions: list[dict[str, Any]],
+    lane_slug: str = "claude-code-intelligence",
 ) -> int:
     task_hub.ensure_schema(conn)
     queued = 0
@@ -1043,6 +1068,7 @@ def queue_follow_up_tasks(
             action=action,
             tier=tier,
             post_id=post_id,
+            lane_slug=lane_slug,
         )
         task_id = payload["task_id"]
         source_kind = payload["source_kind"]
@@ -1083,7 +1109,7 @@ def queue_follow_up_tasks(
                         "action_type": action.get("action_type") or "",
                         "links": action.get("links") or [],
                         "preferred_vp": "vp.coder.primary",
-                        "knowledge_base_slug": KB_SLUG,
+                        "knowledge_base_slug": _vault_slug_for_lane(lane_slug),
                         "fallback_for_scaffold_request": task_id,
                         "workflow_manifest": {
                             "workflow_kind": "code_change",
@@ -1309,7 +1335,13 @@ def write_reference_kb_update(
     return index_path
 
 
-def _scaffold_task_description(*, handle: str, packet_dir: Path, action: dict[str, Any]) -> str:
+def _scaffold_task_description(
+    *,
+    handle: str,
+    packet_dir: Path,
+    action: dict[str, Any],
+    lane_slug: str = "claude-code-intelligence",
+) -> str:
     """Phase-2 brief for Simone: scaffold a demo workspace from a vault entity.
 
     The task references a tier-3 post that should already have a
@@ -1342,7 +1374,7 @@ def _scaffold_task_description(*, handle: str, packet_dir: Path, action: dict[st
             links,
             "",
             "Workflow (cody-scaffold-builder skill):",
-            f"  1. Locate the vault entity in <UA_ARTIFACTS_DIR>/knowledge-vaults/{KB_SLUG}/entities/",
+            f"  1. Locate the vault entity in <UA_ARTIFACTS_DIR>/knowledge-vaults/{_vault_slug_for_lane(lane_slug)}/entities/",
             f"     whose source_ids include `x_post_{post_id}` (or whose body cites this post).",
             "  2. Decide if the entity is demo-worthy (briefing_status=pending AND endpoint",
             "     is satisfiable AND business_relevance is non-trivial). If not, mark this task",

--- a/src/universal_agent/services/claude_code_intel_replay.py
+++ b/src/universal_agent/services/claude_code_intel_replay.py
@@ -99,6 +99,7 @@ def replay_packet(
                 handle=handle,
                 packet_dir=packet_dir,
                 actions=actions,
+                lane_slug=config.lane_slug,
             )
 
     linked_sources_path = write_linked_sources(packet_dir=packet_dir, actions=actions)

--- a/src/universal_agent/services/claude_code_intel_replay.py
+++ b/src/universal_agent/services/claude_code_intel_replay.py
@@ -47,6 +47,10 @@ class ClaudeCodeIntelReplayConfig:
     expand_sources: bool = True
     artifacts_root: Path | None = None
     work_product_dir: Path | None = None
+    # PR 17 — passed through to queue_follow_up_tasks so the task-hub
+    # metadata resolves vault_slug/knowledge_base_slug from the right
+    # intel lane. Default preserves single-lane back-compat.
+    lane_slug: str = "claude-code-intelligence"
 
 
 def resolve_lane_root(artifacts_root: Path | None = None) -> Path:


### PR DESCRIPTION
## Summary

Closes out two of the Phase C follow-ups from `docs/proactive_signals/claudedevs_intel_v2_remaining_work.md`. PR 6c (auto-trigger upgrade actuator) is already shipped — `claude_code_intel_run_report.py:344-379` calls `auto_apply_release_triggers` after each report. PR 13 and PR 17 both had their primary code shipped earlier but had wiring gaps that this PR closes.

## Commit 1 — PR 13: register monthly vault-lint contradictions cron

The vault contradictions sweep code was on disk (`services/vault_lint_contradictions.py` + `scripts/vault_contradiction_lint.py`) but never registered as a cron. This adds the registration:

- `system_job=vault_lint_contradictions`
- Schedule: `0 7 1 * *` (first of month, 07:00 America/Chicago — inside the 6 AM – 9 PM Houston active window)
- Command: `!script universal_agent.scripts.vault_contradiction_lint`
- Timeout: 1800s (30 min)
- Enable gate: `UA_VAULT_LINT_CONTRADICTIONS_ENABLED` (defaults ON)

Report-only — the script writes `lint/contradictions-YYYY-MM-DD.md` and never mutates entity/concept pages. Dormancy guard test (`test_cron_dormancy_defaults.py`) passes — hour 7 is inside the active window.

## Commit 2 — PR 17: thread lane_slug into task-payload helpers

PR 11 added `intel_lanes.yaml` + the loader. The handle-resolution half of PR 17 landed earlier (`ClaudeCodeIntelConfig.from_env`/`all_handles_from_env` both read from `get_lane`). But task-payload metadata still hardcoded `KB_SLUG = "claude-code-intelligence"`, so any future second lane (Codex / Gemini intel) would land Task Hub rows pointing at the wrong vault.

This commit finishes the refactor:
- New `_vault_slug_for_lane(lane_slug)` helper resolves vault_slug from the lane config, defensively falling back to `KB_SLUG`.
- `_build_followup_task_payload`, `_scaffold_task_description`, and `queue_follow_up_tasks` all gain a `lane_slug` parameter (defaults to `"claude-code-intelligence"`).
- Both callers of `queue_follow_up_tasks` (`claude_code_intel.py:429`, `claude_code_intel_replay.py:97`) pass their config's `lane_slug`.
- `knowledge_base_slug` and `vault_slug` fields in task metadata now resolve per-lane, including the `UA_CSI_DIRECT_DEMO_FALLBACK` path.
- The Simone-directed prompt template uses the lane's `vault_slug` so a future Gemini lane's Simone instance gets pointed at `/knowledge-vaults/gemini-intelligence/entities/` instead of the hardcoded `claude-code-intelligence` path.

For the currently-only `claude-code-intelligence` lane this is a no-op (yaml + KB_SLUG happen to match). Behavior changes only when a second lane ships.

`csi_demo_triage.approve_candidate` still passes the default lane — adding `lane_slug` to `TriageCandidate` is a separate refactor not needed until a second lane actually exists.

## Verification

- [x] `py_compile` clean on all 3 changed files
- [x] `ruff check` with PR-Validate's flags (`--select E9,F --ignore E402,F401,F541,F811,F841`) — clean
- [x] `tests/unit/test_cron_dormancy_defaults.py` — 10/10 pass (validates the new cron's hour-of-day is in the active window)
- [x] `tests/unit/test_claude_code_intel_cleanup.py` + `tests/unit/test_csi_demo_triage_ranker.py` — 16/16 pass (existing tests, no regression from the lane_slug parameter addition)

## Test plan

- [ ] PR-Validate passes
- [ ] Auto-merge squashes to main
- [ ] Deploy runs cleanly (now that gateway is healthy post-PRs #297/#299)
- [ ] On the VPS after deploy, `cron_jobs.json` should carry a new entry with `system_job=vault_lint_contradictions`, `enabled=true`
- [ ] First fire on 1st of next month at 07:00 Central will produce `lint/contradictions-YYYY-MM-DD.md` in the vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)