### PR TITLE
style(services): auto-fix ruff D-rule formatting violations

### DIFF
--- a/src/universal_agent/services/agent_router.py
+++ b/src/universal_agent/services/agent_router.py
@@ -1,5 +1,4 @@
-"""
-agent_router.py — Simone-First Orchestration Router.
+"""agent_router.py — Simone-First Orchestration Router.
 
 All tasks route to Simone. She decides delegation via batch triage
 during her heartbeat cycle, using her full capabilities, skills, MCPs,

--- a/src/universal_agent/services/agentmail_service.py
+++ b/src/universal_agent/services/agentmail_service.py
@@ -659,6 +659,7 @@ class AgentMailService:
 
         Returns:
             Dict with message_id/draft_id and status.
+
         """
         self._assert_ready()
 

--- a/src/universal_agent/services/atlas_direct_dispatch.py
+++ b/src/universal_agent/services/atlas_direct_dispatch.py
@@ -204,6 +204,7 @@ async def dispatch_atlas_candidates_once(
 
     Returns: ``{"dispatched": N, "skipped": M, "remaining_slots_at_start":
         K, "reason": <string when no dispatch>}``.
+
     """
     if dispatch_fn is None:
         from universal_agent.tools.vp_orchestration import dispatch_vp_mission

--- a/src/universal_agent/services/capacity_governor.py
+++ b/src/universal_agent/services/capacity_governor.py
@@ -1,5 +1,4 @@
-"""
-Capacity Governor — system-level rate limiting for agent dispatch.
+"""Capacity Governor — system-level rate limiting for agent dispatch.
 
 Sits between the dispatch pipeline and agent execution to prevent
 overloading the LLM provider API. Tracks:
@@ -57,6 +56,7 @@ DEFAULT_COOLDOWN_AFTER_429_SECONDS = 60.0
 @dataclass
 class CapacitySnapshot:
     """Point-in-time view of capacity governor state."""
+
     max_concurrent: int
     active_slots: int
     available_slots: int

--- a/src/universal_agent/services/cody_mode.py
+++ b/src/universal_agent/services/cody_mode.py
@@ -81,6 +81,7 @@ def resolve_cody_mode(
 
     Returns:
         Either ``"zai"`` or ``"anthropic"``.
+
     """
     if task:
         per_task = _normalize(task.get("cody_mode"))

--- a/src/universal_agent/services/cody_token_tracking.py
+++ b/src/universal_agent/services/cody_token_tracking.py
@@ -81,6 +81,7 @@ def record_token_usage(
                 * ``cache_read_input_tokens``
                 * ``cost_usd`` / ``total_cost_usd``
                 * ``duration_ms``
+
     """
     try:
         normalized_mode = str(cody_mode or "").strip().lower()
@@ -194,6 +195,7 @@ def summarize_window(
                                   "total_cost_usd": float}, ...],
             "cody_mode_filter": str | None,
         }
+
     """
     window = get_window_state(conn)
     reset_at = window["reset_at"]

--- a/src/universal_agent/services/csi_intelligence_pass.py
+++ b/src/universal_agent/services/csi_intelligence_pass.py
@@ -519,6 +519,7 @@ def analyze_action(
         ``RuntimeError`` if no Anthropic-compatible API key is configured.
         ``pydantic.ValidationError`` if the LLM emits malformed JSON.
         SDK exceptions on network / model errors after exhausting retries.
+
     """
     user_msg = _build_user_message(
         action=action,

--- a/src/universal_agent/services/csi_intelligence_persistence.py
+++ b/src/universal_agent/services/csi_intelligence_persistence.py
@@ -504,6 +504,7 @@ def apply_vault_delta_to_vault(
     Never raises on a single VaultAction error — collects per-action
     errors in ``errors`` so the caller can decide whether the partial
     write is acceptable.
+
     """
     applied: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []

--- a/src/universal_agent/services/daemon_sessions.py
+++ b/src/universal_agent/services/daemon_sessions.py
@@ -130,6 +130,7 @@ class DaemonSessionManager:
     agent_names : list[str] | None
         Names of agents to create daemon sessions for.
         Defaults to ``configured_daemon_agents()``.
+
     """
 
     def __init__(

--- a/src/universal_agent/services/dag_governor.py
+++ b/src/universal_agent/services/dag_governor.py
@@ -1,5 +1,4 @@
-"""
-DAG Concurrency Governor — manages global concurrency limits for ZAI DAG executions.
+"""DAG Concurrency Governor — manages global concurrency limits for ZAI DAG executions.
 """
 
 import asyncio

--- a/src/universal_agent/services/dag_handlers.py
+++ b/src/universal_agent/services/dag_handlers.py
@@ -97,6 +97,7 @@ def make_llm_binary_classifier_handler(
     Args:
         llm_call: An async function ``async (prompt_text) -> response_text``
             that sends a prompt to ZAI/Claude and returns the raw text response.
+
     """
 
     async def _handler(node: Dict[str, Any], state: DagState) -> Dict[str, Any]:

--- a/src/universal_agent/services/dag_loader.py
+++ b/src/universal_agent/services/dag_loader.py
@@ -31,6 +31,7 @@ def load_workflow(path: Path) -> Dict[str, Any]:
     Raises:
         FileNotFoundError: If *path* does not exist.
         WorkflowValidationError: If the file is malformed or missing required keys.
+
     """
     import yaml  # lazy import — only needed when loading YAML files
 
@@ -62,6 +63,7 @@ def validate_workflow_dict(workflow: Dict[str, Any]) -> None:
 
     Raises:
         WorkflowValidationError: If the dict is missing required keys.
+
     """
     _validate_schema(workflow, source="inline")
 

--- a/src/universal_agent/services/dag_runner.py
+++ b/src/universal_agent/services/dag_runner.py
@@ -22,6 +22,7 @@ STATUS_ERROR = "error"
 @dataclass
 class DagState:
     """State of a DAG execution."""
+
     status: str = STATUS_PENDING  # pending, running, completed, waiting_on_human, failed
     current_node: Optional[str] = None
     context: Dict[str, Any] = field(default_factory=dict)

--- a/src/universal_agent/services/email_task_bridge.py
+++ b/src/universal_agent/services/email_task_bridge.py
@@ -106,7 +106,6 @@ def parse_email_triage_brief(raw: Any, *, sender_trusted: bool) -> dict[str, Any
     Returns a dict with keys: raw_text, safety_status, routing_decision,
     classification, priority, subject_summary.
     """
-
     text = str(raw or "").strip()
     parsed: dict[str, Any] = {
         "raw_text": text,
@@ -714,7 +713,6 @@ class EmailTaskBridge:
 
         Returns the mapping dict or None if no row matches.
         """
-
         row = self._conn.execute(
             "SELECT * FROM email_task_mappings WHERE task_id = ? ORDER BY updated_at DESC LIMIT 1",
             (str(task_id or "").strip(),),
@@ -729,7 +727,6 @@ class EmailTaskBridge:
 
         Returns the mapping dict or None.
         """
-
         key = str(session_key or "").strip()
         if not key:
             return None
@@ -766,7 +763,6 @@ class EmailTaskBridge:
 
     def has_ack_outbound(self, thread_id: str) -> bool:
         """Return True if an acknowledgement email was already sent for this thread."""
-
         mapping = self._get_mapping(thread_id)
         if not mapping:
             return False
@@ -777,7 +773,6 @@ class EmailTaskBridge:
 
     def has_final_outbound(self, thread_id: str) -> bool:
         """Return True if a final response email was already sent for this thread."""
-
         mapping = self._get_mapping(thread_id)
         if not mapping:
             return False
@@ -791,7 +786,6 @@ class EmailTaskBridge:
 
         Fields are set only once (idempotent re-calls do not overwrite).
         """
-
         now = _now_iso()
         self._conn.execute(
             """
@@ -821,7 +815,6 @@ class EmailTaskBridge:
         Sets final_email_sent_at, final_message_id, final_draft_id, and
         email_sent_at (idempotent — existing values are preserved).
         """
-
         now = _now_iso()
         self._conn.execute(
             """
@@ -903,7 +896,6 @@ class EmailTaskBridge:
         Clears any quarantine security_classification and relabels the
         corresponding Task Hub entry as ``open`` with ``agent-ready``.
         """
-
         thread = str(thread_id or "").strip()
         if not thread:
             return False
@@ -940,7 +932,6 @@ class EmailTaskBridge:
         ``needs_review`` on the Task Hub entry with the
         ``review-required`` label appended.
         """
-
         thread = str(thread_id or "").strip()
         if not thread:
             return False
@@ -982,7 +973,6 @@ class EmailTaskBridge:
         ``quarantine``, and updates the Task Hub entry to ``blocked``
         with the ``quarantined`` label.
         """
-
         thread = str(thread_id or "").strip()
         if not thread:
             return False
@@ -1038,6 +1028,7 @@ class EmailTaskBridge:
         Returns:
             The email thread_id if cleared, or None if the row didn't
             exist / wasn't a quarantined email / wasn't an email at all.
+
         """
         tid = str(task_id or "").strip()
         if not tid:
@@ -1217,6 +1208,7 @@ class EmailTaskBridge:
             Starting status — defaults to ``open``.  The heartbeat's
             ``claim_next_dispatch_tasks`` atomically transitions to
             ``in_progress`` when it seizes the task for execution.
+
         """
         try:
             from universal_agent.task_hub import ensure_schema, upsert_item

--- a/src/universal_agent/services/gws_mcp_bridge.py
+++ b/src/universal_agent/services/gws_mcp_bridge.py
@@ -1,5 +1,4 @@
-"""
-Google Workspace CLI (gws) MCP Bridge.
+"""Google Workspace CLI (gws) MCP Bridge.
 
 Manages the `gws mcp` subprocess as a stdio MCP server, providing
 Google Workspace API access (Gmail, Calendar, Drive, Sheets, Docs)
@@ -35,8 +34,7 @@ _RETRY_CODES = {429, 500, 502, 503, 504}
 
 
 def classify_gws_error(error_payload: dict[str, Any]) -> str:
-    """
-    Classify a gws JSON error payload into a short category string.
+    """Classify a gws JSON error payload into a short category string.
 
     Returns one of: "auth", "scope", "rate_limit", "transient", "permanent".
     """
@@ -169,8 +167,7 @@ def is_gws_available(config: Optional[GwsMcpConfig] = None) -> bool:
 
 
 def build_gws_mcp_server_config(config: Optional[GwsMcpConfig] = None) -> Optional[dict[str, Any]]:
-    """
-    Build the MCP server configuration dict for the gws stdio server.
+    """Build the MCP server configuration dict for the gws stdio server.
 
     Returns None if:
     - The gws_cli_enabled() feature flag is False

--- a/src/universal_agent/services/health_evaluator.py
+++ b/src/universal_agent/services/health_evaluator.py
@@ -1,5 +1,4 @@
-"""
-health_evaluator.py — LLM-powered evaluator for the heartbeat proactive advisor cycle.
+"""health_evaluator.py — LLM-powered evaluator for the heartbeat proactive advisor cycle.
 
 This module intercepts the deterministic snapshot created by `build_morning_report()`,
 compares it against the `Health_Checks_Lessons_Learned.md` document, and distills
@@ -58,10 +57,11 @@ Respond ONLY with the raw JSON object. Do not wrap it in markdown block quotes (
 """
 
 async def evaluate_health_snapshot(raw_report_dict: dict[str, Any]) -> Dict[str, Any]:
-    """
-    Asynchronously evaluates the raw morning report using an LLM to produce structured directives.
+    """Asynchronously evaluates the raw morning report using an LLM to produce structured directives.
+
     Returns:
         dict with keys: ignore, simone_directives, human_escalations
+
     """
     raw_report_text = raw_report_dict.get("report_text", "")
     

--- a/src/universal_agent/services/idle_dispatch_loop.py
+++ b/src/universal_agent/services/idle_dispatch_loop.py
@@ -48,6 +48,7 @@ def nudge_dispatch(reason: str = "external") -> None:
     ----------
     reason : str
         Human-readable reason for the nudge (logged for observability).
+
     """
     global _nudge_event, _nudge_loop
     if _nudge_event is None:
@@ -94,6 +95,7 @@ async def idle_dispatch_loop(
         Returns dict of heartbeat-registered sessions (including daemon sessions).
         Used as a fallback when no WebSocket sessions exist — ensures daemon
         sessions are discoverable by the idle dispatch loop.
+
     """
     global _nudge_event, _nudge_loop
 

--- a/src/universal_agent/services/intelligence_emitter.py
+++ b/src/universal_agent/services/intelligence_emitter.py
@@ -52,7 +52,8 @@ _VALID_SEVERITIES = {
 def _activity_db_path() -> str:
     """Resolve the activity DB path the gateway uses. Lazy import to
     avoid pulling the heavy gateway/heartbeat module surface into
-    workers that just want to write a single row."""
+    workers that just want to write a single row.
+    """
     from universal_agent.durable.db import get_activity_db_path
     return get_activity_db_path()
 
@@ -61,7 +62,8 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
     """Create the activity_events table if it doesn't exist. CREATE
     TABLE IF NOT EXISTS is cheap; we run it on every emit so a service
     pointed at a fresh DB still gets the schema. (No process-level
-    cache — that fails when tests use multiple tmp DBs.)"""
+    cache — that fails when tests use multiple tmp DBs.)
+    """
     conn.executescript(
         """
         CREATE TABLE IF NOT EXISTS activity_events (

--- a/src/universal_agent/services/link_card_tokens.py
+++ b/src/universal_agent/services/link_card_tokens.py
@@ -113,6 +113,7 @@ def consume(token: str) -> dict[str, Any]:
     Returns:
       {"ok": True, "spend_request_id": "...", "expires_at": ..., "issued_at": ...}
       {"ok": False, "code": "not_found" | "expired" | "already_consumed", "message": "..."}
+
     """
     if not token or not isinstance(token, str):
         return {"ok": False, "code": "not_found", "message": "Token missing or invalid."}

--- a/src/universal_agent/services/mission_control_event_titles.py
+++ b/src/universal_agent/services/mission_control_event_titles.py
@@ -337,7 +337,8 @@ def _metadata_shape_summary(metadata: Any) -> dict[str, str]:
 
 def _sanitize_template(text: str) -> str:
     """Strip code-fences, line wrapping, and any sentence wrappers the
-    LLM might have included despite instructions."""
+    LLM might have included despite instructions.
+    """
     cleaned = text.strip()
     if cleaned.startswith("```"):
         # Strip leading + trailing fence

--- a/src/universal_agent/services/mission_control_intelligence_sweeper.py
+++ b/src/universal_agent/services/mission_control_intelligence_sweeper.py
@@ -287,7 +287,8 @@ class MissionControlSweeper:
 
     def _run_tier2(self, result: SweepResult) -> None:
         """Sync marker; real tier-2 synthesis lands in
-        `_run_tier2_async` (Phase 3)."""
+        `_run_tier2_async` (Phase 3).
+        """
         result.tier2_evaluated = True
 
     # ── Async tiers (LLM-driven; gateway loop awaits these) ────────────

--- a/src/universal_agent/services/priority_classifier.py
+++ b/src/universal_agent/services/priority_classifier.py
@@ -87,6 +87,7 @@ def classify_email_priority(
     classification : str
         The email-handler triage classification
         (instruction, feedback_approval, feedback_correction, status_update, etc.).
+
     """
     text = f"{subject} {body_snippet}"
 

--- a/src/universal_agent/services/proactive_advisor.py
+++ b/src/universal_agent/services/proactive_advisor.py
@@ -1,5 +1,4 @@
-"""
-proactive_advisor.py — Deterministic morning-report builder for the heartbeat cycle.
+"""proactive_advisor.py — Deterministic morning-report builder for the heartbeat cycle.
 
 This module assembles a structured snapshot of Task Hub state for the heartbeat
 agent.  All logic is pure Python (no LLM calls) — the LLM only sees the

--- a/src/universal_agent/services/proactive_artifacts.py
+++ b/src/universal_agent/services/proactive_artifacts.py
@@ -248,7 +248,6 @@ def upsert_artifact(
 
 def get_artifact(conn: sqlite3.Connection, artifact_id: str) -> Optional[dict[str, Any]]:
     """Fetch a single artifact row by ID, returning None if not found."""
-
     ensure_schema(conn)
     row = conn.execute(
         "SELECT * FROM proactive_artifacts WHERE artifact_id = ? LIMIT 1",
@@ -265,7 +264,6 @@ def list_artifacts(
     limit: int = 50,
 ) -> list[dict[str, Any]]:
     """Query artifacts with optional status and delivery_state filters, ordered by priority."""
-
     ensure_schema(conn)
     clauses: list[str] = []
     params: list[Any] = []
@@ -430,7 +428,6 @@ def find_artifact_for_reply(
     message_id: str = "",
 ) -> Optional[dict[str, Any]]:
     """Locate an artifact by matching email thread_id, message_id, or artifact ID in subject."""
-
     ensure_schema(conn)
     clean_thread = str(thread_id or "").strip()
     if clean_thread:

--- a/src/universal_agent/services/proactive_budget.py
+++ b/src/universal_agent/services/proactive_budget.py
@@ -1,5 +1,4 @@
-"""
-proactive_budget.py — Shared daily budget for the autonomous proactive pipeline.
+"""proactive_budget.py — Shared daily budget for the autonomous proactive pipeline.
 
 Both the Signal Curator (Track 1) and the Reflection Engine (Track 2) share
 a single daily budget counter.  Only tasks with source_kind in

--- a/src/universal_agent/services/proactive_intelligence_report.py
+++ b/src/universal_agent/services/proactive_intelligence_report.py
@@ -1,5 +1,4 @@
-"""
-proactive_intelligence_report.py — 3x daily hybrid intelligence reports.
+"""proactive_intelligence_report.py — 3x daily hybrid intelligence reports.
 
 Combines deterministic Python data gathering (pipeline stats, budget, utilization)
 with an LLM reasoning pass that interprets results and provides actionable
@@ -511,6 +510,7 @@ def get_utilization_stats(conn: sqlite3.Connection, *, window_hours: int = 24) -
 
     Returns:
         dict with: sample_count, avg_occupancy_pct, peak_occupancy_slots, avg_queue_depth
+
     """
     ensure_report_schema(conn)
     cutoff = (datetime.now(timezone.utc) - timedelta(hours=window_hours)).isoformat()

--- a/src/universal_agent/services/proactive_preferences.py
+++ b/src/universal_agent/services/proactive_preferences.py
@@ -256,6 +256,7 @@ def should_block_proactive_task(
     Returns:
         (should_block, reason) — ``should_block`` is True when the task
         should be silently dropped, and ``reason`` explains why.
+
     """
     ensure_schema(conn)
     model = get_preference_snapshot(conn)

--- a/src/universal_agent/services/proactive_topic_tracker.py
+++ b/src/universal_agent/services/proactive_topic_tracker.py
@@ -1,5 +1,4 @@
-"""
-proactive_topic_tracker.py — Prevent heartbeat from repeating the same proactive investigations.
+"""proactive_topic_tracker.py — Prevent heartbeat from repeating the same proactive investigations.
 
 When the heartbeat has no Task Hub claims and enters proactive mode, the LLM
 independently decides what to investigate using the static checklist in HEARTBEAT.md.

--- a/src/universal_agent/services/reflection_engine.py
+++ b/src/universal_agent/services/reflection_engine.py
@@ -1,5 +1,4 @@
-"""
-reflection_engine.py — 24/7 autonomous ideation engine for idle agents.
+"""reflection_engine.py — 24/7 autonomous ideation engine for idle agents.
 
 When the Task Hub dispatch queue is empty and the agent would otherwise idle,
 this engine provides an "ideation" prompt that asks the agent to:

--- a/src/universal_agent/services/session_dossier.py
+++ b/src/universal_agent/services/session_dossier.py
@@ -224,6 +224,7 @@ async def generate_session_dossier(
 
     Raises:
         RuntimeError: If the LLM call fails or no API key is available.
+
     """
     if metadata is None:
         metadata = {}
@@ -315,6 +316,7 @@ async def backfill_missing_dossiers(
 
     Returns:
         Count of sessions that were successfully backfilled.
+
     """
     workspaces_dir = Path(workspaces_dir).resolve()
     if not workspaces_dir.is_dir():

--- a/src/universal_agent/services/signal_curator.py
+++ b/src/universal_agent/services/signal_curator.py
@@ -1,5 +1,4 @@
-"""
-signal_curator.py — LLM-driven curator for proactive signal cards (Track 1).
+"""signal_curator.py — LLM-driven curator for proactive signal cards (Track 1).
 
 Evaluates pending signal cards using agent reasoning (not scoring heuristics)
 and promotes the best candidates to Task Hub items for autonomous execution.
@@ -146,6 +145,7 @@ def promote_cards_to_tasks(
 
     Returns:
         List of created task_ids.
+
     """
     task_hub.ensure_schema(conn)
     proactive_signals.ensure_schema(conn)

--- a/src/universal_agent/services/system_load_guard.py
+++ b/src/universal_agent/services/system_load_guard.py
@@ -156,6 +156,7 @@ def is_system_healthy(
     Returns
     -------
     SystemHealthStatus with healthy=True/False and reason.
+
     """
     # Resolve thresholds
     if max_process_count <= 0:

--- a/src/universal_agent/services/telegram_send.py
+++ b/src/universal_agent/services/telegram_send.py
@@ -156,6 +156,7 @@ def telegram_send_sync(
     Returns:
         (True, "ok") on success.
         (False, error_description) on failure.
+
     """
     ok, _payload, err = telegram_send_with_response_sync(
         chat_id, text,
@@ -253,6 +254,7 @@ async def telegram_send_async(
     Returns:
         (True, "ok") on success.
         (False, error_description) on failure.
+
     """
     token = _resolve_token(bot_token)
     url = _api_url(token, "sendMessage")

--- a/src/universal_agent/services/todo_dispatch_service.py
+++ b/src/universal_agent/services/todo_dispatch_service.py
@@ -95,7 +95,6 @@ def _attach_continuation_workspace_reference(
     templates over the previous directory.  It writes a manifest into the new
     run workspace and creates a symlink when the filesystem allows it.
     """
-
     metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
     continuation = metadata.get("proactive_continuation") if isinstance(metadata.get("proactive_continuation"), dict) else {}
     previous_workspace_raw = str(continuation.get("previous_workspace_dir") or "").strip()

--- a/src/universal_agent/services/vp_mission_pr_reconciler.py
+++ b/src/universal_agent/services/vp_mission_pr_reconciler.py
@@ -73,7 +73,8 @@ def _gh_token() -> str:
     """Resolve the GitHub token. Reads `GITHUB_TOKEN` directly — this is
     populated at service-startup by `initialize_runtime_secrets()` from
     Infisical. Never reads from `.env` directly per CLAUDE.md secrets
-    policy."""
+    policy.
+    """
     return (os.getenv("GITHUB_TOKEN") or "").strip()
 
 
@@ -196,7 +197,8 @@ def record_mission_pr(
 def _list_candidates(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     """Find vp_mission tasks that are non-terminal and have a recorded
     PR. Bounded by `_SCAN_WINDOW_DAYS` to keep the scan O(small) even as
-    the task_hub grows."""
+    the task_hub grows.
+    """
     placeholders = ",".join("?" * len(_NON_TERMINAL_STATUSES))
     rows = conn.execute(
         f"""
@@ -283,7 +285,8 @@ def _close_mission_as_merged(
 
     We use `upsert_item` directly for this reason: it does NOT enforce
     the verification gate, and the same pathway already covers happy-path
-    completion via `worker_loop.py:464`."""
+    completion via `worker_loop.py:464`.
+    """
     merged_at = pr_response.get("merged_at")
     merge_commit_sha = pr_response.get("merge_commit_sha")
     head_branch = (pr_response.get("head") or {}).get("ref")
@@ -331,7 +334,8 @@ def _mark_pr_deleted(
     """A previously-recorded PR is no longer fetchable (404). Mark the
     record so we don't keep querying it, but leave the task open — the
     operator decides via the Mark Complete card button whether the work
-    really shipped or was abandoned."""
+    really shipped or was abandoned.
+    """
     dispatch = dict(metadata.get("dispatch") or {})
     pr_meta = dict(dispatch.get("pr") or {})
     pr_meta.update({"deleted": True, "deleted_observed_at": _utc_now_iso()})

--- a/src/universal_agent/services/worker_exit_classifier.py
+++ b/src/universal_agent/services/worker_exit_classifier.py
@@ -71,6 +71,7 @@ class WorkerExit:
             counter. Excludes ``clean_exit_zero`` and protocol violations
             (the latter is handled by F.3's needs_review path, not the
             normal retry budget).
+
     """
 
     outcome: WorkerOutcome
@@ -122,6 +123,7 @@ def classify_worker_exit(
 
     Returns:
         A ``WorkerExit`` record.
+
     """
     if was_cancelled:
         return WorkerExit(
@@ -219,6 +221,7 @@ def park_task_for_protocol_violation(
         ``perform_task_action`` failure). Best-effort by design — F.3
         is observability + recovery routing; it must never raise into the
         spawn site's happy path.
+
     """
     tid = str(task_id or "").strip()
     if not tid:


### PR DESCRIPTION
## Summary
Pre-existing local commit on `claude/docstring-backfill-services` (authored 2026-05-16 by Kevin, co-authored Sonnet 4.6) — ruff auto-fixes for D-rule docstring formatting violations across `src/universal_agent/services/`. Found unshipped during the 2026-05-16 PR #300 follow-up session; opening as a routine ship.

From the original commit message:
- D212: multi-line docstring summary to first line
- D205: blank line after summary
- D413/D209/D202/D204: blank-line spacing around sections
- D200: single-line docstring format
- 68 violations cleared; 289 (missing docstrings) require manual authoring — out of scope.

## Risk
Near-zero. Pure formatting — no behavior changes. `pr-validate.yml` will run `py_compile` + `ruff check` + `pytest tests/unit` as the gate; if those pass, this is safe to merge.

## Test plan
- [ ] PR-validate green
- [ ] Auto-merge fires (matches `claude/*`)
- [ ] Deploy succeeds (or reports false-failure per the recurring SSH-timeout pattern; Rule A verification will confirm code is live)

🤖 Routine ship via Claude Code