### PR TITLE
fix(deploy): SSH keepalive + heartbeat during silent install steps

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,15 @@ jobs:
 
           rm -f /tmp/ssh_preflight.out /tmp/ssh_preflight.err
           
-          timeout 30m ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o BatchMode=yes "$SSH_USER@$SSH_HOST" << 'EOF'
+          # ServerAliveInterval+CountMax keep the SSH session alive during long
+          # silent remote steps (systemd daemon-reload + enable --now on a busy
+          # VPS can take minutes with no output). Without these, an intermediate
+          # idle-timeout-killer drops the TCP connection and the workflow exits
+          # 255 even when the actual deploy work completes. See
+          # docs/operations/2026-05-16_deploy_ssh_timeout_plan.md (Option A).
+          # 30s keepalive × 120 max = up to 60 min of pure idle tolerance,
+          # inside the outer `timeout 30m` envelope.
+          timeout 30m ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o BatchMode=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=120 "$SSH_USER@$SSH_HOST" << 'EOF'
             # Exit immediately on error
             set -euo pipefail
             PROD_DIR="/opt/universal_agent"

--- a/docs/operations/2026-05-16_deploy_ssh_timeout_plan.md
+++ b/docs/operations/2026-05-16_deploy_ssh_timeout_plan.md
@@ -1,6 +1,6 @@
 # Deploy Workflow SSH-Timeout False-Failure — Remediation Plan
 
-> **Status:** Plan only — no code changes shipped. Awaiting operator approval before implementing.
+> **Status (2026-05-16 PM update):** **Options A + B shipped.** Option C deferred per operator decision pending ~5-deploy observation window. See § 10 for implementation pointers.
 > **Author:** Claude Opus 4.7 via PR drafting session 2026-05-16.
 > **Triggering incident:** PR #300 deploy (run `25967376397`) reported `failure` exit 255 at 16:47:43, but VPS verification confirmed services restarted at 16:52:10 with the correct merged SHA `2225d48c`. Identical pattern observed on PR #297 and #299 in the same week.
 
@@ -129,9 +129,42 @@ If 3 consecutive deploys are green and code reaches the VPS, mark the issue clos
 
 ## 9. Open questions for operator review
 
-1. **Approve Option A as the immediate fix?** If yes, I'll prepare a 1-line PR.
-2. **Approve Option B as a follow-up?** If yes, I'll prepare a separate PR after Option A is validated.
-3. **Any reason to skip straight to Option C?** (E.g. known additional fragility in the deploy chain that fire-and-poll would address.)
+1. **Approve Option A as the immediate fix?** ✅ Approved 2026-05-16 PM.
+2. **Approve Option B as a follow-up?** ✅ Approved 2026-05-16 PM (shipped together with A in same PR).
+3. **Any reason to skip straight to Option C?** ❌ No — defer C unless A+B prove insufficient over ~5 deploys.
+
+---
+
+## 10. Implementation (2026-05-16 PM)
+
+Options A + B shipped together. Code anchors:
+
+| Option | File | Change |
+|---|---|---|
+| A — SSH keepalive flags | `.github/workflows/deploy.yml` (around line 97) | Added `-o ServerAliveInterval=30 -o ServerAliveCountMax=120` to the deploy `ssh` invocation. Keepalive every 30s, tolerate up to 60 min of pure idle, inside the outer `timeout 30m` envelope. |
+| B — heartbeat during silent steps | `scripts/install_vps_systemd_units.sh` | Background `( while true; printf heartbeat; sleep 30; done )` loop started before `systemctl daemon-reload` + `systemctl enable`, killed via `trap EXIT`. |
+| B — heartbeat during silent steps | `scripts/install_vp_worker_services.sh` | Same pattern as above, started before `systemctl daemon-reload` + `systemctl enable --now`. |
+
+Each heartbeat emits a line like:
+
+```
+[heartbeat install_vps_systemd_units] 2026-05-16T17:45:30+00:00
+[heartbeat install_vps_systemd_units] 2026-05-16T17:46:00+00:00
+```
+
+Combined effect: Option A keeps the SSH TCP connection alive regardless of remote-side silence (defense at the connection layer); Option B makes remote-side silence shorter and gives operators visible progress in the workflow log (defense at the application layer).
+
+### Verification plan (active)
+
+Watch the next 5 production deploys after this PR merges. Per § 6, success criteria:
+
+- Workflow exit code `success` (0)
+- No more than ~2 minutes of true silence between log lines (heartbeats fill any longer gap)
+- `/api/v1/version` SHA still matches merged SHA (Rule A — should continue working regardless)
+
+If 5 consecutive green deploys: close this issue, mark the 2026-05-11 PM `Documentation_Status.md` concurrency-caveat entry as fully resolved (concurrency guard was already shipped in PR #233; this addresses the orthogonal SSH-timeout class).
+
+If even one false-failure recurs with the same signature (long silent gap + `Terminated`): escalate to Option C and open a follow-up issue.
 
 ---
 

--- a/scripts/install_vp_worker_services.sh
+++ b/scripts/install_vp_worker_services.sh
@@ -24,6 +24,16 @@ mkdir -p "$APP_ROOT/logs" "$APP_ROOT/AGENT_RUN_WORKSPACES"
 chown -R ua:ua "$APP_ROOT/logs" "$APP_ROOT/AGENT_RUN_WORKSPACES" 2>/dev/null || true
 
 install -m 0644 "$UNIT_TEMPLATE_SRC" "$SYSTEMD_DIR/$UNIT_TEMPLATE_NAME"
+
+# Heartbeat during daemon-reload + enable --now so the parent SSH session sees
+# periodic output and any intermediate idle-timeout-killer doesn't drop the
+# connection mid-step. See docs/operations/2026-05-16_deploy_ssh_timeout_plan.md.
+( while true; do printf '[heartbeat install_vp_worker_services] %s\n' "$(date -Iseconds)"; sleep 30; done ) &
+HB_PID=$!
+# shellcheck disable=SC2064
+trap "kill $HB_PID 2>/dev/null || true; wait $HB_PID 2>/dev/null || true" EXIT
+
+echo "--> systemctl daemon-reload..."
 systemctl daemon-reload
 
 if [[ $# -gt 0 ]]; then

--- a/scripts/install_vps_systemd_units.sh
+++ b/scripts/install_vps_systemd_units.sh
@@ -198,5 +198,19 @@ if ! command -v systemctl >/dev/null 2>&1; then
   exit 0
 fi
 
+# Heartbeat during the systemd reload/enable step so the parent SSH session sees
+# periodic output. On a busy production VPS this section can stay silent for
+# minutes (observed ~3 min in the 2026-05-16 incident); an idle SSH connection
+# in that window gets pruned by an intermediate keepalive-killer, which makes
+# the deploy workflow exit 255 even though the actual work completed. See
+# docs/operations/2026-05-16_deploy_ssh_timeout_plan.md for the full diagnosis.
+( while true; do printf '[heartbeat install_vps_systemd_units] %s\n' "$(date -Iseconds)"; sleep 30; done ) &
+HB_PID=$!
+# shellcheck disable=SC2064
+trap "kill $HB_PID 2>/dev/null || true; wait $HB_PID 2>/dev/null || true" EXIT
+
+echo "--> systemctl daemon-reload..."
 systemctl daemon-reload
+echo "--> systemctl enable units..."
 systemctl enable "${units_to_enable[@]}"
+echo "--> install_vps_systemd_units done"


### PR DESCRIPTION
## Summary
Implements **Options A + B** from [`docs/operations/2026-05-16_deploy_ssh_timeout_plan.md`](https://github.com/Kjdragan/universal_agent/blob/main/docs/operations/2026-05-16_deploy_ssh_timeout_plan.md). Option C deferred per operator decision pending ~5-deploy observation window.

Fixes the recurring `deploy.yml` exit-255 false-failure observed across PRs #297, #299, #300 — all reported failed by GHA but production was live with the correct merged SHA.

## Root cause
~3-minute silent gap during `install_vps_systemd_units.sh` and `install_vp_worker_services.sh` (their `systemctl daemon-reload` + `systemctl enable` steps emit no output). An intermediate idle-timeout-killer on the GHA-runner → Tailscale → VPS path drops the SSH TCP connection mid-step. The deploy work itself completes on the VPS; the GHA workflow just sees a dead connection and exits 255.

## Two defenses, layered

### Option A — connection-layer keepalive (`.github/workflows/deploy.yml`)
Added `-o ServerAliveInterval=30 -o ServerAliveCountMax=120` to the deploy `ssh` invocation. Sends a keepalive packet every 30s, tolerates up to 60 min of pure idle (inside the outer `timeout 30m` envelope). Prevents any layer's idle pruner from firing.

### Option B — application-layer visibility (`scripts/install_*.sh`)
Background `( while true; printf heartbeat; sleep 30; done )` loop started before each script's `systemctl daemon-reload`, killed via `trap EXIT`. Cleanup verified on both success and failure (`set -e`) paths — no leaked child processes. Operators now see periodic `[heartbeat install_vps_systemd_units] <iso>` lines in the workflow log.

## Why both, not just A
- **A alone** would fix the symptom (workflow stops dying), but operators still couldn't tell whether a silent stretch was healthy progress or a real hang.
- **B alone** would give visibility but wouldn't help if the keepalive layer was already broken (heartbeat output flowing doesn't prove the upstream layer hasn't already pruned).
- Together: A keeps the connection alive at the TCP layer regardless of remote silence; B makes remote silence shorter and visible at the application layer.

## Verification

- [x] `bash -n` on both edited scripts (clean)
- [x] `python -c "yaml.safe_load(...)"` on deploy.yml (clean)
- [x] Heartbeat smoke test — verified cleanup on success path AND failure path (`set -e` trip), no leaked child processes either way
- [ ] **Post-merge:** Watch next 5 production deploys for green workflow exits. If all green → close out. If even one recurs with same signature → escalate to Option C (fire-and-poll refactor).

## Plan doc updated
[`docs/operations/2026-05-16_deploy_ssh_timeout_plan.md`](https://github.com/Kjdragan/universal_agent/blob/claude/deploy-ssh-keepalive-and-heartbeat/docs/operations/2026-05-16_deploy_ssh_timeout_plan.md) status banner updated, § 10 added with implementation pointers + active verification plan, open questions § 9 marked resolved.

## Risk
**Near-zero.** Option A's flags only affect how SSH handles idle connections (no behavior change when output flows). Option B's heartbeat is informational stdout only. Both have explicit rollback paths in the plan doc § 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)