### PR TITLE
docs(delegation): add missing docstrings to public functions and classes

### DIFF
--- a/src/universal_agent/delegation/bridge_main.py
+++ b/src/universal_agent/delegation/bridge_main.py
@@ -156,6 +156,11 @@ def _shutdown(
 
 
 def main() -> int:
+    """CLI entry point for the Redis↔VP bridge process.
+
+    Parses arguments, sets up logging, and runs the inbound/outbound
+    bridge loops with heartbeat reporting.  Returns 0 on clean exit.
+    """
     parser = argparse.ArgumentParser(
         description="Redis→VP SQLite bridge for cross-machine mission delegation.",
     )

--- a/src/universal_agent/delegation/heartbeat.py
+++ b/src/universal_agent/delegation/heartbeat.py
@@ -137,17 +137,21 @@ class FactoryHeartbeat:
 
     @property
     def is_healthy(self) -> bool:
+        """True when fewer than 3 consecutive heartbeat failures have occurred."""
         return self._consecutive_failures < 3
 
     @property
     def last_sent_at(self) -> float:
+        """Unix timestamp of the most recent successful heartbeat, or 0.0."""
         return self._last_sent_at
 
     @property
     def consecutive_failures(self) -> int:
+        """Number of heartbeat sends that failed in a row."""
         return self._consecutive_failures
 
     def stop(self) -> None:
+        """Signal the heartbeat loop to exit gracefully."""
         self._stopped.set()
 
     def _effective_interval(self) -> float:

--- a/src/universal_agent/delegation/heartbeat.py
+++ b/src/universal_agent/delegation/heartbeat.py
@@ -15,7 +15,7 @@ import os
 import platform
 import socket
 import time
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import httpx
 

--- a/src/universal_agent/delegation/redis_bus.py
+++ b/src/universal_agent/delegation/redis_bus.py
@@ -12,14 +12,31 @@ MISSION_DLQ_STREAM = "ua:missions:dlq"
 
 
 class RedisLikeClient(Protocol):
-    def xgroup_create(self, *args: Any, **kwargs: Any) -> Any: ...
-    def xadd(self, *args: Any, **kwargs: Any) -> Any: ...
-    def xreadgroup(self, *args: Any, **kwargs: Any) -> Any: ...
-    def xack(self, *args: Any, **kwargs: Any) -> Any: ...
+    """Minimal Redis client protocol required by :class:`RedisMissionBus`.
+
+    Only the stream operations used by the bus are declared.
+    """
+
+    def xgroup_create(self, *args: Any, **kwargs: Any) -> Any:
+        """Create a consumer group on a stream (no-op if already exists)."""
+        ...
+
+    def xadd(self, *args: Any, **kwargs: Any) -> Any:
+        """Append a message to a stream and return its ID."""
+        ...
+
+    def xreadgroup(self, *args: Any, **kwargs: Any) -> Any:
+        """Read messages from a stream via consumer group."""
+        ...
+
+    def xack(self, *args: Any, **kwargs: Any) -> Any:
+        """Acknowledge a stream message as processed."""
+        ...
 
 
 @dataclass(frozen=True)
 class ConsumedMission:
+    """A mission message consumed from a Redis stream, ready for processing."""
     stream: str
     message_id: str
     envelope: MissionEnvelope
@@ -27,6 +44,12 @@ class ConsumedMission:
 
 
 class RedisMissionBus:
+    """Redis Streams-backed message bus for cross-machine mission delegation.
+
+    Provides publish/subscribe semantics over Redis consumer groups so that
+    HQ gateways can dispatch missions to remote factories.
+    """
+
     def __init__(
         self,
         client: RedisLikeClient,
@@ -49,6 +72,7 @@ class RedisMissionBus:
         consumer_group: str = MISSION_CONSUMER_GROUP,
         dlq_stream: str = MISSION_DLQ_STREAM,
     ) -> "RedisMissionBus":
+        """Create a bus from a Redis connection URL string."""
         try:
             import redis  # type: ignore
         except Exception as exc:  # pragma: no cover - runtime environment specific
@@ -58,6 +82,7 @@ class RedisMissionBus:
         return cls(client, stream_name=stream_name, consumer_group=consumer_group, dlq_stream=dlq_stream)
 
     def ensure_group(self) -> None:
+        """Create the consumer group if it does not already exist."""
         try:
             self._client.xgroup_create(
                 name=self.stream_name,
@@ -71,6 +96,7 @@ class RedisMissionBus:
                 raise
 
     def publish_mission(self, envelope: MissionEnvelope) -> str:
+        """Publish a mission envelope to the delegation stream. Returns the Redis message ID."""
         payload = envelope.model_dump(mode="json")
         return str(
             self._client.xadd(
@@ -84,6 +110,7 @@ class RedisMissionBus:
         )
 
     def publish_result(self, result: MissionResultEnvelope) -> str:
+        """Publish a mission result to the results stream. Returns the Redis message ID."""
         payload = result.model_dump(mode="json")
         return str(
             self._client.xadd(
@@ -104,6 +131,17 @@ class RedisMissionBus:
         block_ms: int = 1000,
         stream_id: str = ">",
     ) -> list[ConsumedMission]:
+        """Read and deserialize pending missions from the consumer group.
+
+        Args:
+            consumer_name: Unique name for this consumer within the group.
+            count: Maximum number of messages to fetch per call.
+            block_ms: Milliseconds to block waiting for new messages.
+            stream_id: Stream offset; ">" means only unread messages.
+
+        Returns:
+            List of :class:`ConsumedMission` instances.
+        """
         rows = self._client.xreadgroup(
             groupname=self.consumer_group,
             consumername=consumer_name,
@@ -134,6 +172,7 @@ class RedisMissionBus:
         return consumed
 
     def ack(self, message_id: str) -> int:
+        """Acknowledge a message as successfully processed."""
         return int(self._client.xack(self.stream_name, self.consumer_group, message_id))
 
     def fail_and_maybe_dlq(
@@ -143,6 +182,14 @@ class RedisMissionBus:
         failure_error: str,
         retry_count: int,
     ) -> bool:
+        """Handle a processing failure by sending to DLQ or allowing retry.
+
+        If *retry_count* >= the envelope max_retries, the mission is published
+        to the dead-letter queue stream and acknowledged.
+
+        Returns:
+            True if the mission was sent to the DLQ.
+        """
         max_retries = max(0, int(consumed.envelope.max_retries))
         should_dlq = int(retry_count) >= max_retries
         if should_dlq:

--- a/src/universal_agent/delegation/redis_vp_bridge.py
+++ b/src/universal_agent/delegation/redis_vp_bridge.py
@@ -62,6 +62,7 @@ class BridgeConfig:
     default_vp_id: str = "vp.general.primary"
 
     def resolve_consumer_name(self, factory_id: str = "") -> str:
+        """Return a sanitised consumer name, falling back to *factory_id* or a random suffix."""
         if self.consumer_name:
             return self.consumer_name
         base = factory_id or f"bridge-{uuid.uuid4().hex[:8]}"
@@ -100,14 +101,17 @@ class RedisVpBridge:
 
     @property
     def metrics(self) -> dict[str, Any]:
+        """Snapshot of bridge operational counters (consumed, inserted, skipped, errors)."""
         return dict(self._metrics)
 
     @property
     def restart_requested(self) -> bool:
+        """True if a system mission requested a bridge restart."""
         return self._restart_requested
 
     @property
     def paused(self) -> bool:
+        """True if mission consumption is paused (system missions still process)."""
         return self._paused
 
     def pause(self) -> None:
@@ -121,6 +125,7 @@ class RedisVpBridge:
         logger.info("RedisVpBridge resumed")
 
     def stop(self) -> None:
+        """Signal the bridge loop to exit gracefully."""
         self._stopped.set()
 
     async def run(self, *, once: bool = False) -> int:

--- a/src/universal_agent/delegation/redis_vp_result_bridge.py
+++ b/src/universal_agent/delegation/redis_vp_result_bridge.py
@@ -48,9 +48,11 @@ class RedisVpResultBridge:
 
     @property
     def metrics(self) -> dict[str, Any]:
+        """Snapshot of result-bridge operational counters (published, errors)."""
         return dict(self._metrics)
 
     def stop(self) -> None:
+        """Signal the result-bridge loop to exit gracefully."""
         self._stopped.set()
 
     async def run(self) -> None:

--- a/src/universal_agent/delegation/schema.py
+++ b/src/universal_agent/delegation/schema.py
@@ -6,11 +6,19 @@ from pydantic import BaseModel, Field
 
 
 class MissionPayload(BaseModel):
+    """Task description and execution context for a delegated mission."""
+
     task: str = Field(min_length=1)
     context: dict[str, Any] = Field(default_factory=dict)
 
 
 class MissionEnvelope(BaseModel):
+    """Wire format for a mission travelling over the Redis delegation bus.
+
+    Carries routing metadata (priority, timeout, retries) alongside the
+    :class:`MissionPayload`.
+    """
+
     job_id: str = Field(min_length=1)
     idempotency_key: str = Field(min_length=1)
     priority: int = Field(default=1)
@@ -20,6 +28,8 @@ class MissionEnvelope(BaseModel):
 
 
 class MissionResultEnvelope(BaseModel):
+    """Wire format for the outcome of a completed mission."""
+
     job_id: str = Field(min_length=1)
     status: Literal["SUCCESS", "FAILED"]
     result: Optional[Any] = None


### PR DESCRIPTION
## Summary

Adds concise docstrings to every public function, class, and protocol in the delegation module — no behavioral changes:

- `redis_bus.py`: RedisLikeClient protocol methods, RedisMissionBus class and all public methods (publish, consume, ack, fail/DLQ), ConsumedMission
- `schema.py`: MissionPayload, MissionEnvelope, MissionResultEnvelope
- `heartbeat.py`: FactoryHeartbeat properties and stop()
- `redis_vp_bridge.py`: BridgeConfig.resolve_consumer_name, RedisVpBridge properties and stop()
- `redis_vp_result_bridge.py`: RedisVpResultBridge.metrics and stop()
- `bridge_main.py`: main() entry point

78 existing tests all pass.

## Test plan
- [ ] `uv run pytest tests/unit/` should pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)