### PR TITLE
test: add unit tests for cli_io pure helpers and worker_exit_classifier

### DIFF
--- a/tests/unit/test_cli_io_pure.py
+++ b/tests/unit/test_cli_io_pure.py
@@ -1,0 +1,189 @@
+"""
+Unit tests for pure helper functions in src/universal_agent/cli_io.py
+
+Covers:
+- summarize_response: whitespace collapse, truncation, edge cases
+- _normalize_display_path: session path rewriting for display
+- list_workspace_artifacts: artifact file listing
+- collect_local_tool_trace_ids: trace ID extraction from run logs
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from universal_agent.cli_io import (
+    _normalize_display_path,
+    collect_local_tool_trace_ids,
+    list_workspace_artifacts,
+    summarize_response,
+)
+
+# -- summarize_response ------------------------------------------------
+
+
+class TestSummarizeResponse:
+    def test_empty_string(self):
+        assert summarize_response("") == ""
+
+
+    def test_short_text_unchanged(self):
+        text = "Hello world"
+        assert summarize_response(text) == text
+
+    def test_whitespace_collapsed(self):
+        text = "line one\n\n   line two\t\tline three"
+        result = summarize_response(text)
+        assert result == "line one line two line three"
+
+    def test_truncation_at_max_chars(self):
+        text = "x" * 1000
+        result = summarize_response(text, max_chars=100)
+        assert len(result) == 100
+        assert result.endswith("...")
+
+    def test_exact_max_chars_unchanged(self):
+        text = "a" * 50
+        result = summarize_response(text, max_chars=50)
+        assert result == text
+        assert not result.endswith("...")
+
+    def test_custom_max_chars(self):
+        text = "a" * 200
+        result = summarize_response(text, max_chars=50)
+        assert len(result) == 50
+        assert result.endswith("...")
+
+
+# -- _normalize_display_path -------------------------------------------
+
+
+class TestNormalizeDisplayPath:
+    def test_non_string_passthrough(self):
+        assert _normalize_display_path(42, "/ws") == 42
+
+    def test_empty_string_passthrough(self):
+        assert _normalize_display_path("", "/ws") == ""
+
+    def test_none_workspace_passthrough(self):
+        assert _normalize_display_path("/some/path", None) == "/some/path"
+
+    def test_non_session_path_passthrough(self):
+        path = "/opt/universal_agent/some_file.txt"
+        assert _normalize_display_path(path, "/ws") == path
+
+    def test_work_products_marker(self):
+        path = "/home/user/.claude/sessions/abc/work_products/report.html"
+        result = _normalize_display_path(path, "/workspace")
+        assert result == os.path.join("/workspace", "work_products", "report.html")
+
+    def test_search_results_marker(self):
+        path = "/home/user/.claude/sessions/abc/search_results/data.json"
+        result = _normalize_display_path(path, "/workspace")
+        assert result == os.path.join("/workspace", "search_results", "data.json")
+
+    def test_downloads_marker(self):
+        path = "/home/user/.claude/sessions/abc/downloads/file.pdf"
+        result = _normalize_display_path(path, "/workspace")
+        assert result == os.path.join("/workspace", "downloads", "file.pdf")
+
+    def test_search_results_filtered_best_marker(self):
+        path = "/home/user/.claude/sessions/abc/search_results_filtered_best/article.md"
+        result = _normalize_display_path(path, "/workspace")
+        assert result == os.path.join(
+            "/workspace", "search_results_filtered_best", "article.md"
+        )
+
+    def test_workbench_marker(self):
+        path = "/home/user/.claude/sessions/abc/workbench/output.csv"
+        result = _normalize_display_path(path, "/workspace")
+        assert result == os.path.join("/workspace", "workbench", "output.csv")
+
+    def test_no_marker_falls_back_to_work_products_basename(self):
+        path = "/home/user/.claude/sessions/abc/mystery_dir/file.txt"
+        result = _normalize_display_path(path, "/workspace")
+        assert result == os.path.join("/workspace", "work_products", "file.txt")
+
+
+# -- list_workspace_artifacts ------------------------------------------
+
+
+class TestListWorkspaceArtifacts:
+    def test_empty_dir(self, tmp_path: Path):
+        assert list_workspace_artifacts(str(tmp_path)) == []
+
+    def test_finds_html_pdf_pptx(self, tmp_path: Path):
+        (tmp_path / "report.html").write_text("<h1>hi</h1>")
+        (tmp_path / "slides.pdf").write_bytes(b"%PDF")
+        (tmp_path / "deck.pptx").write_bytes(b"PK")
+        result = list_workspace_artifacts(str(tmp_path))
+        assert sorted(result) == ["deck.pptx", "report.html", "slides.pdf"]
+
+    def test_ignores_other_extensions(self, tmp_path: Path):
+        (tmp_path / "data.json").write_text("{}")
+        (tmp_path / "image.png").write_bytes(b"\x89PNG")
+        assert list_workspace_artifacts(str(tmp_path)) == []
+
+    def test_nonexistent_dir(self):
+        assert list_workspace_artifacts("/no/such/dir") == []
+
+    def test_empty_string(self):
+        assert list_workspace_artifacts("") == []
+
+    def test_returns_sorted(self, tmp_path: Path):
+        (tmp_path / "z.html").write_text("z")
+        (tmp_path / "a.html").write_text("a")
+        result = list_workspace_artifacts(str(tmp_path))
+        assert result == ["a.html", "z.html"]
+
+
+# -- collect_local_tool_trace_ids --------------------------------------
+
+
+class TestCollectLocalToolTraceIds:
+    def test_empty_dir(self, tmp_path: Path):
+        assert collect_local_tool_trace_ids(str(tmp_path)) == []
+
+    def test_empty_string(self):
+        assert collect_local_tool_trace_ids("") == []
+
+    def test_no_log_file(self, tmp_path: Path):
+        assert collect_local_tool_trace_ids(str(tmp_path)) == []
+
+    def test_extracts_trace_ids(self, tmp_path: Path):
+        log = tmp_path / "run.log"
+        trace_id = "0123456789abcdef0123456789abcdef"
+        log.write_text(
+            f"Some log line\n[local-toolkit-trace-id: {trace_id}]\n"
+            f"Another line [local-toolkit-trace-id: {trace_id}]\n",
+            encoding="utf-8",
+        )
+        result = collect_local_tool_trace_ids(str(tmp_path))
+        assert result == [trace_id]  # deduplicated
+
+    def test_multiple_unique_ids(self, tmp_path: Path):
+        log = tmp_path / "run.log"
+        id_a = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        id_b = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        log.write_text(
+            f"[local-toolkit-trace-id: {id_a}]\n"
+            f"[local-toolkit-trace-id: {id_b}]\n",
+            encoding="utf-8",
+        )
+        result = collect_local_tool_trace_ids(str(tmp_path))
+        assert result == [id_a, id_b]  # sorted
+
+    def test_non_hex_32_not_matched(self, tmp_path: Path):
+        log = tmp_path / "run.log"
+        log.write_text("[local-toolkit-trace-id: not-a-valid-id]\n", encoding="utf-8")
+        result = collect_local_tool_trace_ids(str(tmp_path))
+        assert result == []
+
+    def test_malformed_log_returns_empty(self, tmp_path: Path):
+        log = tmp_path / "run.log"
+        log.write_text("just random text no pattern\n", encoding="utf-8")
+        result = collect_local_tool_trace_ids(str(tmp_path))
+        assert result == []

--- a/tests/unit/test_worker_exit_classifier.py
+++ b/tests/unit/test_worker_exit_classifier.py
@@ -1,0 +1,177 @@
+"""Unit tests for the pure classify_worker_exit function in worker_exit_classifier.py.
+
+Covers all six outcome buckets and the priority ordering of the
+classification decision tree:
+  cancelled_mid_run > timeout_killed > signaled > nonzero_exit >
+  clean_exit_zero | clean_exit_zero_no_disposition
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from universal_agent.services.worker_exit_classifier import (
+    PROTOCOL_VIOLATION_REASONS,
+    WorkerExit,
+    classify_worker_exit,
+)
+
+
+class TestClassifyWorkerExitCancelled:
+    """was_cancelled takes top priority regardless of other flags."""
+
+    def test_cancelled_only(self):
+        result = classify_worker_exit(return_code=0, was_cancelled=True)
+        assert result.outcome == "cancelled_mid_run"
+        assert result.is_failure is True
+        assert result.is_protocol_violation is False
+
+    def test_cancelled_nonzero_rc(self):
+        result = classify_worker_exit(return_code=1, was_cancelled=True)
+        assert result.outcome == "cancelled_mid_run"
+
+    def test_cancelled_with_timeout(self):
+        result = classify_worker_exit(
+            return_code=0, was_cancelled=True, was_timeout_killed=True,
+        )
+        assert result.outcome == "cancelled_mid_run"
+
+    def test_cancelled_with_signal(self):
+        result = classify_worker_exit(
+            return_code=None, was_cancelled=True, was_signaled=True,
+        )
+        assert result.outcome == "cancelled_mid_run"
+
+    def test_cancelled_task_not_closed(self):
+        result = classify_worker_exit(
+            return_code=0, was_cancelled=True, task_closed_normally=False,
+        )
+        assert result.outcome == "cancelled_mid_run"
+
+
+class TestClassifyWorkerExitTimeoutKilled:
+    """was_timeout_killed is second priority."""
+
+    def test_timeout_only(self):
+        result = classify_worker_exit(return_code=None, was_timeout_killed=True)
+        assert result.outcome == "timeout_killed"
+        assert result.is_failure is True
+        assert result.is_protocol_violation is False
+
+    def test_timeout_with_signal_flag(self):
+        result = classify_worker_exit(
+            return_code=0, was_timeout_killed=True, was_signaled=True,
+        )
+        assert result.outcome == "timeout_killed"
+
+    def test_timeout_task_not_closed(self):
+        result = classify_worker_exit(
+            return_code=0, was_timeout_killed=True, task_closed_normally=False,
+        )
+        assert result.outcome == "timeout_killed"
+
+
+class TestClassifyWorkerExitSignaled:
+    """was_signaled is third priority."""
+
+    def test_signaled_only(self):
+        result = classify_worker_exit(return_code=None, was_signaled=True)
+        assert result.outcome == "signaled"
+        assert result.is_failure is True
+        assert result.is_protocol_violation is False
+
+    def test_signaled_with_zero_rc(self):
+        result = classify_worker_exit(return_code=0, was_signaled=True)
+        assert result.outcome == "signaled"
+
+    def test_signaled_task_not_closed(self):
+        result = classify_worker_exit(
+            return_code=None, was_signaled=True, task_closed_normally=False,
+        )
+        assert result.outcome == "signaled"
+
+
+class TestClassifyWorkerExitNonzero:
+    """Non-zero return code is fourth priority."""
+
+    def test_rc_1(self):
+        result = classify_worker_exit(return_code=1)
+        assert result.outcome == "nonzero_exit"
+        assert result.is_failure is True
+        assert result.is_protocol_violation is False
+
+    def test_rc_negative(self):
+        result = classify_worker_exit(return_code=-1)
+        assert result.outcome == "nonzero_exit"
+
+    def test_rc_137(self):
+        result = classify_worker_exit(return_code=137)
+        assert result.outcome == "nonzero_exit"
+
+    def test_rc_none(self):
+        result = classify_worker_exit(return_code=None)
+        assert result.outcome == "nonzero_exit"
+
+    def test_rc_255(self):
+        result = classify_worker_exit(return_code=255)
+        assert result.outcome == "nonzero_exit"
+
+
+class TestClassifyWorkerExitClean:
+    """rc=0 splits into clean success vs protocol violation."""
+
+    def test_clean_exit_zero(self):
+        result = classify_worker_exit(return_code=0, task_closed_normally=True)
+        assert result.outcome == "clean_exit_zero"
+        assert result.is_failure is False
+        assert result.is_protocol_violation is False
+
+    def test_clean_exit_zero_no_disposition(self):
+        result = classify_worker_exit(return_code=0, task_closed_normally=False)
+        assert result.outcome == "clean_exit_zero_no_disposition"
+        assert result.is_failure is False
+        assert result.is_protocol_violation is True
+
+    def test_clean_exit_zero_default_closed(self):
+        """task_closed_normally defaults to True."""
+        result = classify_worker_exit(return_code=0)
+        assert result.outcome == "clean_exit_zero"
+
+
+class TestWorkerExitDataclass:
+    """WorkerExit frozen dataclass basics."""
+
+    def test_to_dict(self):
+        we = WorkerExit(
+            outcome="clean_exit_zero",
+            is_protocol_violation=False,
+            is_failure=False,
+        )
+        d = we.to_dict()
+        assert d == {
+            "outcome": "clean_exit_zero",
+            "is_protocol_violation": False,
+            "is_failure": False,
+        }
+
+    def test_frozen(self):
+        we = WorkerExit(outcome="signaled", is_protocol_violation=False, is_failure=True)
+        with pytest.raises(AttributeError):
+            we.outcome = "clean_exit_zero"
+
+    def test_equality(self):
+        a = WorkerExit(outcome="nonzero_exit", is_protocol_violation=False, is_failure=True)
+        b = WorkerExit(outcome="nonzero_exit", is_protocol_violation=False, is_failure=True)
+        assert a == b
+
+
+class TestProtocolViolationReasons:
+    """PROTOCOL_VIOLATION_REASONS constant sanity check."""
+
+    def test_has_expected_sites(self):
+        for site in ("cron", "vp_cli", "demo"):
+            assert site in PROTOCOL_VIOLATION_REASONS
+
+    def test_values_are_prefixed(self):
+        for key, value in PROTOCOL_VIOLATION_REASONS.items():
+            assert value.startswith("protocol_violation_")


### PR DESCRIPTION
## Summary

Adds focused unit tests for pure helper functions in `cli_io` and `worker_exit_classifier` modules:

- Pure function tests with no side effects — safe to run in any environment
- No behavioral changes, tests only

## Test plan
- [ ] `uv run pytest tests/unit/` should pass including the new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)