### PR TITLE
fix(csi): unbreak RSS semantic enrichment — wire Infisical token + add backlog purge

### DIFF
--- a/CSI_Ingester/development/deployment/systemd/csi-rss-semantic-enrich.service
+++ b/CSI_Ingester/development/deployment/systemd/csi-rss-semantic-enrich.service
@@ -6,5 +6,7 @@ Wants=csi-ingester.service
 [Service]
 Type=oneshot
 WorkingDirectory=/opt/universal_agent/CSI_Ingester/development
+Environment=PYTHONPATH=/opt/universal_agent/src
+EnvironmentFile=-/opt/universal_agent/.env
 EnvironmentFile=/opt/universal_agent/CSI_Ingester/development/deployment/systemd/csi-ingester.env
 ExecStart=/opt/universal_agent/CSI_Ingester/development/scripts/csi_run.sh /opt/universal_agent/CSI_Ingester/development/.venv/bin/python /opt/universal_agent/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py --db-path /var/lib/universal-agent/csi/csi.db --max-events 12 --transcript-min-chars 20

--- a/CSI_Ingester/development/scripts/csi_purge_youtube_backlog.py
+++ b/CSI_Ingester/development/scripts/csi_purge_youtube_backlog.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Purge stale YouTube backlog from csi.db.
+
+Removes:
+  1. rss_event_analysis rows where transcript_status='failed' and transcript_ref
+     points at the local gateway (these come from the broken-auth era and carry
+     no real signal).
+  2. youtube_channel_rss events that have no surviving rss_event_analysis row
+     (the actual backlog the enrichment timer would otherwise chew through).
+
+Prints before/after counts. --dry-run shows what would be deleted without
+touching the DB. --confirm is required to actually delete.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sqlite3
+import sys
+
+STALE_REF_PATTERN = "%@127.0.0.1:8002"
+
+
+def _counts(conn: sqlite3.Connection) -> dict[str, int]:
+    cursor = conn.cursor()
+    out: dict[str, int] = {}
+    out["events_youtube_total"] = cursor.execute(
+        "SELECT COUNT(*) FROM events WHERE source='youtube_channel_rss'"
+    ).fetchone()[0]
+    out["rss_event_analysis_total"] = cursor.execute(
+        "SELECT COUNT(*) FROM rss_event_analysis"
+    ).fetchone()[0]
+    out["events_pending_analysis"] = cursor.execute(
+        """
+        SELECT COUNT(*) FROM events e
+        LEFT JOIN rss_event_analysis a ON a.event_id = e.event_id
+        WHERE e.source='youtube_channel_rss' AND a.event_id IS NULL
+        """
+    ).fetchone()[0]
+    out["analysis_stale_failed"] = cursor.execute(
+        """
+        SELECT COUNT(*) FROM rss_event_analysis
+        WHERE transcript_status='failed' AND transcript_ref LIKE ?
+        """,
+        (STALE_REF_PATTERN,),
+    ).fetchone()[0]
+    return out
+
+
+def _print_counts(label: str, counts: dict[str, int]) -> None:
+    print(f"--- {label} ---")
+    for key, value in counts.items():
+        print(f"{key}={value}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", default="/var/lib/universal-agent/csi/csi.db")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show counts and proposed deletes without modifying the DB.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Actually perform the deletes. Required unless --dry-run.",
+    )
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.confirm:
+        print("Refusing to delete without --confirm. Re-run with --dry-run or --confirm.")
+        return 2
+
+    db_path = Path(args.db_path).expanduser()
+    if not db_path.exists():
+        print(f"DB not found: {db_path}")
+        return 2
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        before = _counts(conn)
+        _print_counts("before", before)
+
+        if args.dry_run:
+            print("--- dry-run: no changes applied ---")
+            return 0
+
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            DELETE FROM rss_event_analysis
+            WHERE transcript_status='failed' AND transcript_ref LIKE ?
+            """,
+            (STALE_REF_PATTERN,),
+        )
+        deleted_analysis = cursor.rowcount
+        cursor.execute(
+            """
+            DELETE FROM events
+            WHERE source='youtube_channel_rss'
+              AND event_id NOT IN (SELECT event_id FROM rss_event_analysis)
+            """
+        )
+        deleted_events = cursor.rowcount
+        conn.commit()
+
+        print(f"deleted_analysis_rows={deleted_analysis}")
+        print(f"deleted_event_rows={deleted_events}")
+        after = _counts(conn)
+        _print_counts("after", after)
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py
+++ b/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py
@@ -84,6 +84,25 @@ def _apply_env_defaults(path: Path) -> None:
         os.environ.setdefault(key, val)
 
 
+def _resolve_infisical_token(keys: list[str]) -> str:
+    try:
+        from universal_agent.infisical_loader import _fetch_infisical_secrets
+    except Exception as exc:
+        print(f"RSS_ENRICH_INFISICAL_IMPORT_FAIL detail={exc!r}")
+        return ""
+    try:
+        secrets = _fetch_infisical_secrets()
+    except Exception as exc:
+        print(f"RSS_ENRICH_INFISICAL_FETCH_FAIL detail={exc!r}")
+        return ""
+    for key in keys:
+        value = str(secrets.get(key) or "").strip()
+        if value:
+            print(f"RSS_ENRICH_INFISICAL_TOKEN_SOURCE={key}")
+            return value
+    return ""
+
+
 def _fetch_transcript_failover(
     *,
     endpoints: list[str],
@@ -414,6 +433,13 @@ def main() -> int:
         ["CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN", "UA_YOUTUBE_INGEST_TOKEN", "UA_INTERNAL_API_TOKEN"],
         merged_env_values,
     )
+    if not transcript_token:
+        # systemd does not wrap this unit in `infisical run`, and the env files
+        # only carry Infisical *bootstrap* creds, not the resolved secrets. Pull
+        # UA_INTERNAL_API_TOKEN directly so /api/v1/youtube/ingest auth succeeds.
+        transcript_token = _resolve_infisical_token(
+            ["UA_YOUTUBE_INGEST_TOKEN", "UA_INTERNAL_API_TOKEN"]
+        )
     transcript_timeout_seconds = _resolve_int_setting(
         ["CSI_RSS_ANALYSIS_TRANSCRIPT_TIMEOUT_SECONDS"],
         merged_env_values,


### PR DESCRIPTION
## Summary

- **Auth fix:** `csi_rss_semantic_enrich.py` falls back to Infisical for `UA_YOUTUBE_INGEST_TOKEN` / `UA_INTERNAL_API_TOKEN` when the env-file value is empty. Unit file now loads `/opt/universal_agent/.env` (Infisical bootstrap creds) and sets `PYTHONPATH=/opt/universal_agent/src` so the script can `import universal_agent.infisical_loader`.
- **Backlog purge:** new `csi_purge_youtube_backlog.py` — wipes the ~4,744 broken-auth-era `transcript_status='failed' / transcript_ref='*@127.0.0.1:8002'` rows in `rss_event_analysis` plus the ~9,381 `youtube_channel_rss` events with no surviving analysis row. `--dry-run` for inspection; `--confirm` required to mutate. To be run once on the VPS after merge.

## Root cause

`csi-rss-semantic-enrich.timer` is the systemd timer that drives `csi_rss_semantic_enrich.py`. The script POSTs to `/api/v1/youtube/ingest` with an Authorization header sourced from `CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN` / `UA_YOUTUBE_INGEST_TOKEN` / `UA_INTERNAL_API_TOKEN`. All three are empty in the systemd unit's environment — `csi-ingester.env` only carries CSI-lane settings, not resolved API tokens, and the unit didn't load `/opt/universal_agent/.env`. Every gateway call 401'd; every result row got `transcript_status='failed' / transcript_ref='http_error@127.0.0.1:8002'`. The proactive-signals YouTube cards consequently rendered without transcripts.

The handful of historical `transcript_status='ok'` rows (122 of them, all with `transcript_ref='desktop_worker_*'`) came from `desktop_transcript_worker.py`, deleted on 2026-04-14 in `c069fda7`. No working source of "ok" transcripts has existed on the VPS side since the auth broke.

I verified the gateway endpoint itself works: hitting `/api/v1/youtube/ingest` with a valid `UA_INTERNAL_API_TOKEN` pulled from Infisical successfully fetched transcripts for 5/5 currently-queued CSI videos (3.5k–18k chars each). Only the auth wiring was broken.

## Post-merge operator steps (will run after deploy)

```bash
# 1. Re-install + re-enable the timer (it was disabled on the VPS).
sudo /opt/universal_agent/CSI_Ingester/development/scripts/csi_install_systemd_extras.sh
# (or, minimally:)
# sudo systemctl daemon-reload
# sudo systemctl enable --now csi-rss-semantic-enrich.timer

# 2. Inspect the backlog purge before applying.
/opt/universal_agent/CSI_Ingester/development/.venv/bin/python \
  /opt/universal_agent/CSI_Ingester/development/scripts/csi_purge_youtube_backlog.py --dry-run

# 3. Apply.
/opt/universal_agent/CSI_Ingester/development/.venv/bin/python \
  /opt/universal_agent/CSI_Ingester/development/scripts/csi_purge_youtube_backlog.py --confirm

# 4. Watch the next timer fire write transcript_status='ok' rows.
```

## Test plan

- [x] `python3 -c "import ast; ast.parse(...)"` on both modified scripts.
- [x] `ruff check` clean.
- [x] Hand-verified `/api/v1/youtube/ingest` returns transcripts when called with a real `UA_INTERNAL_API_TOKEN`.
- [ ] Post-deploy: `csi-rss-semantic-enrich.service` invoked manually on the VPS writes at least one `transcript_status='ok'` row.
- [ ] Post-purge: `events` + `rss_event_analysis` counts match the dry-run prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)