### PR TITLE
ci(deploy): run csi_install_systemd_extras.sh on each deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -246,6 +246,19 @@ jobs:
             sudo bash "$PROD_DIR/scripts/install_vps_systemd_units.sh" --lane production --app-root "$PROD_DIR"
             echo "--> Installing canonical VP worker unit template from repo..."
             sudo bash "$PROD_DIR/scripts/install_vp_worker_services.sh" vp.coder.primary vp.general.primary
+            # Sync the CSI lane's systemd units (timers + services). Without
+            # this, edits to CSI_Ingester/development/deployment/systemd/*.{service,timer}
+            # land in the repo but never reach /etc/systemd/system/, so the
+            # timer keeps running the old unit file (e.g. the 2026-05-16
+            # YouTube-transcript outage: rss-semantic-enrich timer was
+            # disabled and the env-file fix never took effect). The install
+            # script is idempotent.
+            if [ -x "$PROD_DIR/CSI_Ingester/development/scripts/csi_install_systemd_extras.sh" ]; then
+              echo "--> Installing canonical CSI systemd units..."
+              sudo bash "$PROD_DIR/CSI_Ingester/development/scripts/csi_install_systemd_extras.sh" || echo "WARN: csi_install_systemd_extras.sh exited non-zero; investigate post-deploy"
+            else
+              echo "WARN: csi_install_systemd_extras.sh missing or not executable; CSI timers may drift"
+            fi
 
             # Capture discord-services state BEFORE the restart so the
             # post-restart health gate can distinguish "this deploy broke

--- a/CSI_Ingester/development/deployment/systemd/csi-rss-semantic-enrich.service
+++ b/CSI_Ingester/development/deployment/systemd/csi-rss-semantic-enrich.service
@@ -6,5 +6,7 @@ Wants=csi-ingester.service
 [Service]
 Type=oneshot
 WorkingDirectory=/opt/universal_agent/CSI_Ingester/development
+Environment=PYTHONPATH=/opt/universal_agent/src
+EnvironmentFile=-/opt/universal_agent/.env
 EnvironmentFile=/opt/universal_agent/CSI_Ingester/development/deployment/systemd/csi-ingester.env
 ExecStart=/opt/universal_agent/CSI_Ingester/development/scripts/csi_run.sh /opt/universal_agent/CSI_Ingester/development/.venv/bin/python /opt/universal_agent/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py --db-path /var/lib/universal-agent/csi/csi.db --max-events 12 --transcript-min-chars 20

--- a/CSI_Ingester/development/scripts/csi_purge_youtube_backlog.py
+++ b/CSI_Ingester/development/scripts/csi_purge_youtube_backlog.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Purge stale YouTube backlog from csi.db.
+
+Removes:
+  1. rss_event_analysis rows where transcript_status='failed' and transcript_ref
+     points at the local gateway (these come from the broken-auth era and carry
+     no real signal).
+  2. youtube_channel_rss events that have no surviving rss_event_analysis row
+     (the actual backlog the enrichment timer would otherwise chew through).
+
+Prints before/after counts. --dry-run shows what would be deleted without
+touching the DB. --confirm is required to actually delete.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sqlite3
+import sys
+
+STALE_REF_PATTERN = "%@127.0.0.1:8002"
+
+
+def _counts(conn: sqlite3.Connection) -> dict[str, int]:
+    cursor = conn.cursor()
+    out: dict[str, int] = {}
+    out["events_youtube_total"] = cursor.execute(
+        "SELECT COUNT(*) FROM events WHERE source='youtube_channel_rss'"
+    ).fetchone()[0]
+    out["rss_event_analysis_total"] = cursor.execute(
+        "SELECT COUNT(*) FROM rss_event_analysis"
+    ).fetchone()[0]
+    out["events_pending_analysis"] = cursor.execute(
+        """
+        SELECT COUNT(*) FROM events e
+        LEFT JOIN rss_event_analysis a ON a.event_id = e.event_id
+        WHERE e.source='youtube_channel_rss' AND a.event_id IS NULL
+        """
+    ).fetchone()[0]
+    out["analysis_stale_failed"] = cursor.execute(
+        """
+        SELECT COUNT(*) FROM rss_event_analysis
+        WHERE transcript_status='failed' AND transcript_ref LIKE ?
+        """,
+        (STALE_REF_PATTERN,),
+    ).fetchone()[0]
+    return out
+
+
+def _print_counts(label: str, counts: dict[str, int]) -> None:
+    print(f"--- {label} ---")
+    for key, value in counts.items():
+        print(f"{key}={value}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-path", default="/var/lib/universal-agent/csi/csi.db")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show counts and proposed deletes without modifying the DB.",
+    )
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Actually perform the deletes. Required unless --dry-run.",
+    )
+    args = parser.parse_args()
+
+    if not args.dry_run and not args.confirm:
+        print("Refusing to delete without --confirm. Re-run with --dry-run or --confirm.")
+        return 2
+
+    db_path = Path(args.db_path).expanduser()
+    if not db_path.exists():
+        print(f"DB not found: {db_path}")
+        return 2
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        before = _counts(conn)
+        _print_counts("before", before)
+
+        if args.dry_run:
+            print("--- dry-run: no changes applied ---")
+            return 0
+
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            DELETE FROM rss_event_analysis
+            WHERE transcript_status='failed' AND transcript_ref LIKE ?
+            """,
+            (STALE_REF_PATTERN,),
+        )
+        deleted_analysis = cursor.rowcount
+        cursor.execute(
+            """
+            DELETE FROM events
+            WHERE source='youtube_channel_rss'
+              AND event_id NOT IN (SELECT event_id FROM rss_event_analysis)
+            """
+        )
+        deleted_events = cursor.rowcount
+        conn.commit()
+
+        print(f"deleted_analysis_rows={deleted_analysis}")
+        print(f"deleted_event_rows={deleted_events}")
+        after = _counts(conn)
+        _print_counts("after", after)
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py
+++ b/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py
@@ -84,6 +84,25 @@ def _apply_env_defaults(path: Path) -> None:
         os.environ.setdefault(key, val)
 
 
+def _resolve_infisical_token(keys: list[str]) -> str:
+    try:
+        from universal_agent.infisical_loader import _fetch_infisical_secrets
+    except Exception as exc:
+        print(f"RSS_ENRICH_INFISICAL_IMPORT_FAIL detail={exc!r}")
+        return ""
+    try:
+        secrets = _fetch_infisical_secrets()
+    except Exception as exc:
+        print(f"RSS_ENRICH_INFISICAL_FETCH_FAIL detail={exc!r}")
+        return ""
+    for key in keys:
+        value = str(secrets.get(key) or "").strip()
+        if value:
+            print(f"RSS_ENRICH_INFISICAL_TOKEN_SOURCE={key}")
+            return value
+    return ""
+
+
 def _fetch_transcript_failover(
     *,
     endpoints: list[str],
@@ -414,6 +433,13 @@ def main() -> int:
         ["CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN", "UA_YOUTUBE_INGEST_TOKEN", "UA_INTERNAL_API_TOKEN"],
         merged_env_values,
     )
+    if not transcript_token:
+        # systemd does not wrap this unit in `infisical run`, and the env files
+        # only carry Infisical *bootstrap* creds, not the resolved secrets. Pull
+        # UA_INTERNAL_API_TOKEN directly so /api/v1/youtube/ingest auth succeeds.
+        transcript_token = _resolve_infisical_token(
+            ["UA_YOUTUBE_INGEST_TOKEN", "UA_INTERNAL_API_TOKEN"]
+        )
     transcript_timeout_seconds = _resolve_int_setting(
         ["CSI_RSS_ANALYSIS_TRANSCRIPT_TIMEOUT_SECONDS"],
         merged_env_values,


### PR DESCRIPTION
## Summary

Follow-up to #313. Wires `csi_install_systemd_extras.sh` into `deploy.yml` so changes to the CSI lane's systemd unit files (`CSI_Ingester/development/deployment/systemd/*.{service,timer}`) actually land in `/etc/systemd/system/` on each deploy.

Without this, the env-file + Infisical-fallback fix from #313 would sit dormant in the repo on the VPS — `/etc/systemd/system/csi-rss-semantic-enrich.service` was last updated 2026-03-05 and CI had no path to refresh it. Same drift caused the 2026-05-16 transcript outage: the rss-semantic-enrich timer was `disabled` and nothing in the deploy path re-enabled it.

The install script is idempotent and unconditionally `systemctl enable --now`s its managed timers, so wiring it into CI makes the CSI unit set self-healing.

## Test plan

- [ ] Deploy lands the new step.
- [ ] `/etc/systemd/system/csi-rss-semantic-enrich.service` mtime updates to today and contains `EnvironmentFile=-/opt/universal_agent/.env`.
- [ ] `systemctl is-enabled csi-rss-semantic-enrich.timer` reports `enabled`.
- [ ] Next timer fire writes at least one `transcript_status='ok'` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)