### PR TITLE
fix(tutorial-build): harden CSI auto-route against news/empty-plan misroutes

### DIFF
--- a/src/universal_agent/services/proactive_tutorial_builds.py
+++ b/src/universal_agent/services/proactive_tutorial_builds.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import os
 from pathlib import Path
+import re
 import sqlite3
 from typing import Any
+
+import yaml
 
 from universal_agent.services.proactive_artifacts import (
     ARTIFACT_STATUS_CANDIDATE,
@@ -15,6 +19,67 @@ from universal_agent.services.proactive_artifacts import (
     upsert_artifact,
 )
 from universal_agent.services.proactive_task_builder import queue_proactive_task
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_DENYLIST_FILE = _REPO_ROOT / "state" / "tutorial_build_denylist.yaml"
+
+# Categories CSI assigns that should never auto-route into tutorial-build.
+_BLOCKED_CATEGORIES = frozenset(
+    {
+        "news",
+        "politics",
+        "geopolitics",
+        "current_events",
+        "current-events",
+        "sports",
+        "music",
+        "gaming",
+        "vlog",
+        "comedy",
+        "entertainment",
+        "reaction",
+        "podcast",
+    }
+)
+
+# Word-boundary tokens. Substring matching previously tripped on "api" inside
+# "rapid" / "Apia", letting news clips through.
+_POSITIVE_TITLE_TOKENS = frozenset(
+    {
+        "tutorial",
+        "walkthrough",
+        "build",
+        "building",
+        "hands-on",
+        "code",
+        "coding",
+        "python",
+        "typescript",
+        "javascript",
+        "github",
+        "repo",
+        "mcp",
+        "sdk",
+        "api",
+        "docker",
+        "agent",
+        "agents",
+    }
+)
+
+_NEGATIVE_TOKENS = frozenset(
+    {
+        "reaction",
+        "drama",
+        "podcast",
+        "vlog",
+        "news",
+    }
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9+\-]*")
 
 
 def queue_tutorial_build_task(
@@ -275,35 +340,114 @@ def _build_artifact_summary(metadata: dict[str, Any]) -> str:
 
 
 def _looks_build_oriented(*, subject: dict[str, Any], analysis: dict[str, Any], category: str, summary: str) -> bool:
-    """Check whether a video subject matches build-oriented keyword signals."""
-    text = " ".join(
-        [
-            str(subject.get("title") or ""),
-            str(subject.get("description") or ""),
-            str(category or ""),
-            str(summary or ""),
-            json.dumps(analysis, ensure_ascii=True),
-        ]
-    ).lower()
-    positive = (
-        "tutorial",
-        "build",
-        "walkthrough",
-        "hands-on",
-        "code",
-        "coding",
-        "python",
-        "typescript",
-        "javascript",
-        "github",
-        "repo",
-        "mcp",
-        "sdk",
-        "api",
-        "docker",
-    )
-    negative = ("reaction", "drama", "news roundup", "podcast")
-    return any(token in text for token in positive) and not any(token in text for token in negative)
+    """Decide whether a CSI video should auto-route into tutorial-build.
+
+    Multi-gate filter (any gate failing rejects):
+      1. Category denylist (news/politics/etc).
+      2. Channel denylist (self-learned from prior misroute parks).
+      3. Extraction plan must not be structurally empty (nothing to build).
+      4. No negative tokens (word-boundary) in title/description.
+      5. Positive token must appear in the TITLE — description noise alone
+         is too weak a signal and was the source of false positives.
+    """
+    cat = str(category or analysis.get("category") or "").strip().lower().replace(" ", "_")
+    if cat in _BLOCKED_CATEGORIES:
+        return False
+
+    channel = str(subject.get("channel_name") or subject.get("author_name") or "").strip()
+    if channel and _channel_in_denylist(channel):
+        return False
+
+    if _extraction_plan_is_empty(analysis):
+        return False
+
+    title_tokens = _tokenize(str(subject.get("title") or ""))
+    description_tokens = _tokenize(str(subject.get("description") or ""))
+    summary_tokens = _tokenize(str(summary or ""))
+    all_tokens = title_tokens | description_tokens | summary_tokens
+
+    if all_tokens & _NEGATIVE_TOKENS:
+        return False
+
+    return bool(title_tokens & _POSITIVE_TITLE_TOKENS)
+
+
+def _tokenize(text: str) -> set[str]:
+    """Return word-boundary lowercase tokens — avoids substring false positives."""
+    return set(_TOKEN_RE.findall((text or "").lower()))
+
+
+def _extraction_plan_is_empty(analysis: dict[str, Any]) -> bool:
+    """True when CSI produced no usable build signal (nothing to implement)."""
+    if not isinstance(analysis, dict) or not analysis:
+        return True
+    language = str(analysis.get("language") or analysis.get("primary_language") or "").strip().lower()
+    deps = analysis.get("dependencies")
+    steps = analysis.get("implementation_steps")
+    has_deps = isinstance(deps, list) and len(deps) > 0
+    has_steps = isinstance(steps, list) and len(steps) > 0
+    if language in {"", "unknown", "n/a", "none"} and not has_deps and not has_steps:
+        return True
+    return False
+
+
+def _load_denylist_channels() -> list[str]:
+    """Load the channel denylist YAML, swallowing IO/parse errors."""
+    if not _DENYLIST_FILE.exists():
+        return []
+    try:
+        data = yaml.safe_load(_DENYLIST_FILE.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("tutorial-build denylist load failed: %s", exc)
+        return []
+    if not isinstance(data, dict):
+        return []
+    channels = data.get("channels")
+    if not isinstance(channels, list):
+        return []
+    return [str(c).strip() for c in channels if str(c or "").strip()]
+
+
+def _channel_in_denylist(channel: str) -> bool:
+    """Case-insensitive substring match against the denylist."""
+    if not channel:
+        return False
+    needle = channel.lower()
+    for entry in _load_denylist_channels():
+        e = entry.lower()
+        if e and (e in needle or needle in e):
+            return True
+    return False
+
+
+def record_channel_denylist_entry(channel_name: str, *, reason: str = "") -> bool:
+    """Append a channel to the tutorial-build denylist. Idempotent.
+
+    Call this when parking a tutorial-build task as a non-code misroute so the
+    same channel never re-routes. Returns True if the entry was added (or
+    already present), False on IO error.
+    """
+    clean = str(channel_name or "").strip()
+    if not clean:
+        return False
+    try:
+        _DENYLIST_FILE.parent.mkdir(parents=True, exist_ok=True)
+        existing = _load_denylist_channels()
+        if any(clean.lower() == e.lower() for e in existing):
+            return True
+        existing.append(clean)
+        header = (
+            "# Channels that have produced misrouted tutorial-build tasks.\n"
+            "# Appended automatically when Simone parks a tutorial_build task as\n"
+            "# a non-code misroute. Match is case-insensitive substring.\n"
+        )
+        body = "channels:\n" + "".join(f"  - {json.dumps(c)}\n" for c in existing)
+        _DENYLIST_FILE.write_text(header + body, encoding="utf-8")
+        logger.info("Added %s to tutorial-build denylist (reason=%s)", clean, reason or "unspecified")
+        return True
+    except OSError as exc:
+        logger.warning("Failed to write tutorial-build denylist: %s", exc)
+        return False
 
 
 def _extraction_plan_from_analysis(*, analysis: dict[str, Any], row: Any) -> dict[str, Any]:

--- a/src/universal_agent/services/proactive_tutorial_builds.py
+++ b/src/universal_agent/services/proactive_tutorial_builds.py
@@ -378,17 +378,26 @@ def _tokenize(text: str) -> set[str]:
 
 
 def _extraction_plan_is_empty(analysis: dict[str, Any]) -> bool:
-    """True when CSI produced no usable build signal (nothing to implement)."""
-    if not isinstance(analysis, dict) or not analysis:
-        return True
+    """True when CSI tried to extract a build plan and got nothing.
+
+    Only fires when ``language`` / ``primary_language`` is *explicitly* present
+    and set to a degenerate value (e.g. ``"unknown"``) AND there are no
+    dependencies AND no implementation steps. If those keys are simply absent
+    from the analysis (e.g. the analyzer hasn't been run on this video, or a
+    different analysis schema is in use), we don't penalize — other gates
+    (category, channel, title tokens) carry the load.
+    """
+    if not isinstance(analysis, dict):
+        return False
+    has_language_key = "language" in analysis or "primary_language" in analysis
+    if not has_language_key:
+        return False
     language = str(analysis.get("language") or analysis.get("primary_language") or "").strip().lower()
     deps = analysis.get("dependencies")
     steps = analysis.get("implementation_steps")
     has_deps = isinstance(deps, list) and len(deps) > 0
     has_steps = isinstance(steps, list) and len(steps) > 0
-    if language in {"", "unknown", "n/a", "none"} and not has_deps and not has_steps:
-        return True
-    return False
+    return language in {"", "unknown", "n/a", "none"} and not has_deps and not has_steps
 
 
 def _load_denylist_channels() -> list[str]:

--- a/state/tutorial_build_denylist.yaml
+++ b/state/tutorial_build_denylist.yaml
@@ -1,0 +1,13 @@
+# Channels that have produced misrouted tutorial-build tasks.
+#
+# When Simone parks a `tutorial_build` task as "not_code_tutorial", the channel
+# name is appended here via record_channel_denylist_entry(). Subsequent videos
+# from the same channel are blocked at the CSI auto-route gate
+# (`_looks_build_oriented` in services/proactive_tutorial_builds.py).
+#
+# Match is case-insensitive substring. Keep entries narrow and specific
+# (channel names, not generic words like "news").
+#
+# To remove an entry, delete the line. To add manually, append below.
+channels:
+  - "Kanal13"

--- a/tests/unit/test_tutorial_build_route_guard.py
+++ b/tests/unit/test_tutorial_build_route_guard.py
@@ -1,0 +1,172 @@
+"""Guards against tutorial-build misroutes (e.g. news clips reaching CODIE).
+
+Real-world failure that motivated these tests: a Kanal13 geopolitical news
+clip "Israeli strikes hit southern Lebanon..." was auto-routed into the
+tutorial-build lane because substring `"api"` matched inside an unrelated
+word, and there was no category/channel/extraction-plan gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from universal_agent.services import proactive_tutorial_builds as ptb
+from universal_agent.services.proactive_tutorial_builds import (
+    _looks_build_oriented,
+    record_channel_denylist_entry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_denylist(tmp_path, monkeypatch):
+    """Point the denylist file at a tmp path for the test, restore after."""
+    denylist = tmp_path / "tutorial_build_denylist.yaml"
+    monkeypatch.setattr(ptb, "_DENYLIST_FILE", denylist)
+    yield denylist
+
+
+def _kanal13_subject() -> dict:
+    return {
+        "title": "Israeli strikes hit southern Lebanon areas despite ceasefire extension",
+        "description": "Kanal13 news report on the latest geopolitical developments.",
+        "channel_name": "Kanal13",
+        "video_id": "uFWp5Dv8ggU",
+        "url": "https://www.youtube.com/watch?v=uFWp5Dv8ggU",
+    }
+
+
+def _empty_analysis() -> dict:
+    return {
+        "language": "unknown",
+        "dependencies": [],
+        "implementation_steps": [],
+    }
+
+
+def test_news_category_blocks_route():
+    """Hard block when CSI category indicates non-code content."""
+    assert not _looks_build_oriented(
+        subject=_kanal13_subject(),
+        analysis={"language": "python", "dependencies": ["fastapi"], "implementation_steps": [{"step_number": 1}]},
+        category="news",
+        summary="Geopolitical news clip.",
+    )
+
+
+def test_empty_extraction_plan_blocks_route():
+    """If CSI produced nothing to build, do not route — regardless of keywords."""
+    subject = {
+        "title": "Build a Python API tutorial",  # has positive tokens
+        "description": "",
+        "channel_name": "Some Channel",
+    }
+    assert not _looks_build_oriented(
+        subject=subject,
+        analysis=_empty_analysis(),
+        category="education",
+        summary="",
+    )
+
+
+def test_kanal13_substring_false_positive_no_longer_routes():
+    """The original bug: substring 'api' inside 'rapid' / 'Apia' tripped the gate."""
+    subject = {
+        "title": "Israeli strikes hit southern Lebanon areas despite ceasefire extension",
+        "description": "Rapid escalation, capital cities affected.",
+        "channel_name": "Kanal13",
+    }
+    assert not _looks_build_oriented(
+        subject=subject,
+        analysis=_empty_analysis(),
+        category="",  # even with no category signal, must not route
+        summary="",
+    )
+
+
+def test_channel_denylist_blocks_route(_isolated_denylist):
+    """Once a channel is denylisted, no subsequent video routes — even codey ones."""
+    assert record_channel_denylist_entry("Kanal13", reason="not_code_tutorial")
+    subject = {
+        "title": "Build an MCP server in Python",  # would otherwise pass
+        "description": "Walkthrough of an SDK tutorial.",
+        "channel_name": "Kanal13",
+    }
+    analysis = {
+        "language": "python",
+        "dependencies": ["mcp"],
+        "implementation_steps": [{"step_number": 1, "description": "scaffold"}],
+    }
+    assert not _looks_build_oriented(
+        subject=subject,
+        analysis=analysis,
+        category="education",
+        summary="",
+    )
+
+
+def test_record_denylist_is_idempotent(_isolated_denylist):
+    assert record_channel_denylist_entry("ExampleChannel")
+    assert record_channel_denylist_entry("examplechannel")  # case-insensitive dedup
+    contents = Path(_isolated_denylist).read_text(encoding="utf-8")
+    assert contents.lower().count("examplechannel") == 1
+
+
+def test_negative_token_in_title_blocks_route():
+    subject = {
+        "title": "Drama reaction to the new Python API",
+        "description": "",
+        "channel_name": "Some Channel",
+    }
+    analysis = {
+        "language": "python",
+        "dependencies": ["x"],
+        "implementation_steps": [{"step_number": 1}],
+    }
+    assert not _looks_build_oriented(
+        subject=subject,
+        analysis=analysis,
+        category="entertainment",
+        summary="",
+    )
+
+
+def test_positive_signal_must_be_in_title():
+    """Description-only positive tokens are too weak — must appear in title."""
+    subject = {
+        "title": "My day in the city",
+        "description": "Also I mentioned Python and Docker briefly.",
+        "channel_name": "Vlogger",
+    }
+    analysis = {
+        "language": "python",
+        "dependencies": ["x"],
+        "implementation_steps": [{"step_number": 1}],
+    }
+    assert not _looks_build_oriented(
+        subject=subject,
+        analysis=analysis,
+        category="vlog",  # also category-blocked, but this asserts the title rule
+        summary="",
+    )
+
+
+def test_happy_path_still_routes():
+    """A genuine coding tutorial with a real plan and clean signals still routes."""
+    subject = {
+        "title": "Build an MCP server in Python — full tutorial",
+        "description": "Step-by-step walkthrough.",
+        "channel_name": "AI Builder",
+    }
+    analysis = {
+        "language": "python",
+        "dependencies": ["mcp", "fastapi"],
+        "implementation_steps": [{"step_number": 1, "description": "scaffold"}],
+    }
+    assert _looks_build_oriented(
+        subject=subject,
+        analysis=analysis,
+        category="education",
+        summary="Builds an MCP server end-to-end.",
+    )


### PR DESCRIPTION
## Summary

Stops the tutorial-build lane from queueing CODIE work on videos that are not coding tutorials. Motivated by a real misroute: a Kanal13 geopolitical news clip ("Israeli strikes hit southern Lebanon...") was auto-routed because substring `"api"` matched inside unrelated words and there were no upstream gates.

## Root cause

`_looks_build_oriented` in `services/proactive_tutorial_builds.py`:
- Substring matching of positive tokens across title + description + category + summary + analysis JSON — `"api" in "rapid"` is True.
- No hard block on `category == "news"`.
- No rejection when CSI's extraction plan is structurally empty (`language=unknown`, no deps, no steps — literally nothing to build).
- No channel-level allow/denylist, so the same news channel can keep tripping the gate.

## Fix (layered defense — all must pass)

1. **Category gate.** CSI categories `news`, `politics`, `geopolitics`, `current_events`, `sports`, `music`, `gaming`, `vlog`, `comedy`, `entertainment`, `reaction`, `podcast` are hard-rejected.
2. **Channel denylist.** New `state/tutorial_build_denylist.yaml`. Case-insensitive substring match. Seeded with `Kanal13`.
3. **Empty-plan gate.** If `language` is empty/unknown AND `dependencies=[]` AND `implementation_steps=[]`, reject.
4. **Negative tokens.** Word-boundary match for `news`, `drama`, `reaction`, `podcast`, `vlog` anywhere.
5. **Positive signal must be in TITLE.** Description noise alone is too weak.
6. **Word-boundary tokenization.** Replaces substring matching — `"api"` no longer matches "rapid"/"Apia".

## Self-learning denylist

New `record_channel_denylist_entry(channel_name, *, reason="")` helper. The intent is for Simone to call this when parking a `tutorial_build` task as a non-code misroute, so the channel never re-routes. Idempotent + case-insensitive.

## Out of scope (operator approval needed)

Updating `memory/HEARTBEAT.md` so Simone:
- Calls `record_channel_denylist_entry(channel_name, reason="not_code_tutorial")` on park.
- Batches these misroute notifications into the existing daily proactive digest instead of emailing per incident (the "noise cleanup" half of the operator ask).

Both are prompt/policy changes that should be applied with operator review rather than unilaterally in this PR.

## Tests

`tests/unit/test_tutorial_build_route_guard.py` (8 new) — covers:
- News category blocks route.
- Empty extraction plan blocks route.
- Original Kanal13 substring false-positive ("rapid", "capital") no longer routes.
- Channel denylist blocks otherwise-valid signals.
- Denylist writes are idempotent + case-insensitive.
- Negative tokens block route.
- Positive signal must be in title.
- Happy path still routes (genuine "Build an MCP server in Python — full tutorial").

Existing `tests/unit/test_proactive_tutorial_builds.py` (4) still passes.

## Test plan

- [x] `uv run pytest tests/unit/test_tutorial_build_route_guard.py tests/unit/test_proactive_tutorial_builds.py` — 12/12 green
- [x] `uv run ruff check src/universal_agent/services/proactive_tutorial_builds.py tests/unit/test_tutorial_build_route_guard.py` — clean
- [x] `uv run python -m py_compile` on touched files — clean
- [ ] Operator: confirm the HEARTBEAT.md update for Simone (post-merge follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)