### PR TITLE
feat(cleanup): auto-prune merged worktrees + restore IDE to main on session end

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/scripts/end_session_cleanup.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/justfile
+++ b/justfile
@@ -10,6 +10,16 @@
 default:
     @just --list
 
+# Reset the IDE checkout to clean main + remove any merged worktrees.
+#
+# Same script the Stop hook runs at session end (see .claude/settings.json).
+# Safe to run any time — refuses to touch unmerged work, uncommitted
+# changes, or the worktree it's running in. Use this when the IDE
+# source-control panel is showing phantom state and you just want to be
+# back on a clean main.
+cleanup:
+    @bash scripts/end_session_cleanup.sh
+
 # ---------------------------------------------------------------------------
 # Local development environment
 # ---------------------------------------------------------------------------

--- a/scripts/end_session_cleanup.sh
+++ b/scripts/end_session_cleanup.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Session-end cleanup for Claude Code agent sessions.
+#
+# Runs from the project root via a `Stop` hook in .claude/settings.json,
+# or manually via `just cleanup`.
+#
+# What it does:
+#   1. Detect stale worktrees under `.claude/worktrees/` whose branch is
+#      squash-merged into origin/main, and remove them. The squashed
+#      content lives on main; leaving the worktree behind strands the
+#      IDE on a dead branch.
+#   2. If the parent checkout is on a branch other than main AND that
+#      branch is squash-merged into origin/main, switch the parent to
+#      main and fast-forward pull.
+#
+# Safety rails:
+#   - NEVER removes the worktree the script is currently executing IN
+#     (would yank the cwd out from under itself mid-run; learned this
+#     the hard way in PR #321's first dry-run).
+#   - NEVER touches a branch with unmerged commits.
+#   - NEVER force-pushes, never deletes remote refs, never discards
+#     uncommitted files.
+#   - NEVER removes a worktree with zero commits beyond main — that's
+#     a brand-new worktree with work still in flight.
+#
+# Designed to be idempotent and safe to invoke any number of times.
+set -euo pipefail
+
+log() { echo "CLEANUP: $*"; }
+
+# Resolve the parent checkout. `git worktree list --porcelain` lists the
+# main worktree first.
+START_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+if ! git -C "$START_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+  log "not in a git repo (start_dir=$START_DIR) — nothing to do"
+  exit 0
+fi
+REPO_ROOT="$(git -C "$START_DIR" worktree list --porcelain | awk '/^worktree / {print $2; exit}')"
+if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT" ]; then
+  log "could not resolve main worktree from $START_DIR — bailing"
+  exit 0
+fi
+
+# Identify the worktree the script itself is running in, so we can skip it.
+SELF_WORKTREE="$(git -C "$START_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+cd "$REPO_ROOT"
+
+# Refresh origin/main BEFORE deciding what's merged.
+git fetch origin main --quiet 2>/dev/null || log "git fetch failed (continuing offline)"
+
+# ---------------------------------------------------------------------------
+# Step 1 — prune worktrees whose branches are squash-merged into origin/main
+# ---------------------------------------------------------------------------
+prune_worktree() {
+  local worktree_path="$1"
+  local branch
+  branch=$(git -C "$worktree_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+    log "worktree $worktree_path on detached HEAD — skipping"
+    return
+  fi
+
+  # Refuse to touch the worktree the script itself is executing in.
+  if [ "$worktree_path" = "$SELF_WORKTREE" ]; then
+    log "worktree $worktree_path is the active session — skipping"
+    return
+  fi
+
+  # Don't remove a worktree that has uncommitted work — operator might
+  # be in the middle of something the agent doesn't know about.
+  if [ -n "$(git -C "$worktree_path" status --porcelain 2>/dev/null)" ]; then
+    log "worktree $worktree_path has uncommitted changes — keeping"
+    return
+  fi
+
+  # How many commits does this branch have that aren't on origin/main?
+  # `git rev-list --count` covers both fresh branches (0 commits) and
+  # branches with unsquashed commits. For squash-merged branches, the
+  # commit count will be > 0 even after merge, BUT `git cherry`'s
+  # patch-id matching reports 0 "+" lines because the squashed
+  # equivalent IS on main. So we use BOTH: count for "is it new" and
+  # cherry for "is it merged".
+  local commit_count
+  commit_count=$(git -C "$worktree_path" rev-list --count HEAD ^origin/main 2>/dev/null || echo 0)
+  if [ "$commit_count" -eq 0 ]; then
+    # Fresh worktree, no commits yet. Keep — operator may be about to
+    # start work here.
+    log "worktree $worktree_path branch=$branch has no commits beyond main — keeping (fresh)"
+    return
+  fi
+
+  local unmerged
+  unmerged=$(git -C "$worktree_path" cherry origin/main HEAD 2>/dev/null | grep -c '^+' || true)
+  if [ "$unmerged" -gt 0 ]; then
+    log "worktree $worktree_path branch=$branch has $unmerged unmerged commits — keeping"
+    return
+  fi
+
+  log "worktree $worktree_path branch=$branch fully merged ($commit_count commits squashed) — removing"
+  git worktree remove --force "$worktree_path" 2>&1 | sed 's/^/  /' || true
+}
+
+if [ -d "$REPO_ROOT/.claude/worktrees" ]; then
+  for wt in "$REPO_ROOT"/.claude/worktrees/*/; do
+    [ -d "$wt" ] || continue
+    prune_worktree "${wt%/}"
+  done
+fi
+git worktree prune
+
+# ---------------------------------------------------------------------------
+# Step 2 — get the parent checkout back on main if its branch is merged
+# ---------------------------------------------------------------------------
+current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+if [ "$current_branch" = "main" ]; then
+  log "parent checkout already on main — pulling"
+  git pull --ff-only origin main 2>&1 | sed 's/^/  /' || true
+elif [ -z "$current_branch" ] || [ "$current_branch" = "HEAD" ]; then
+  log "parent checkout on detached HEAD — leaving alone"
+else
+  if [ -n "$(git status --porcelain 2>/dev/null)" ]; then
+    log "parent checkout has uncommitted changes — staying on $current_branch"
+  else
+    unmerged=$(git cherry origin/main HEAD 2>/dev/null | grep -c '^+' || true)
+    if [ "$unmerged" -gt 0 ]; then
+      log "branch=$current_branch has $unmerged unmerged commits — keeping IDE checkout here"
+    else
+      log "branch=$current_branch fully merged into origin/main — switching IDE checkout to main"
+      git checkout main 2>&1 | sed 's/^/  /'
+      git pull --ff-only origin main 2>&1 | sed 's/^/  /'
+    fi
+  fi
+fi
+
+log "done"


### PR DESCRIPTION
## Why

Agent sessions create worktrees under `.claude/worktrees/<name>/`, push their branch, merge it via squash, and exit — but until now nothing automatically:

- removed the now-orphan worktree directory
- switched the IDE's checkout back to main
- pulled origin/main

Operators returning to the IDE see the Source Control panel reporting tens of thousands of phantom changes and the IDE stranded on some `claude/*` branch they don't recognize. Today's case: IDE was on `claude/fix-automerge-worktree-branches` with 5 squash-merged commits, showing "5 ahead / 5 behind" main and a 100k-file source-control flood that was actually IDE cache, not git state.

## What

Three pieces, single PR.

### 1. `scripts/end_session_cleanup.sh`

Idempotent cleanup. Fetches origin/main, then for each `.claude/worktrees/<name>/`:

- **skips** the worktree the script is running in (self-protection — the first dry-run blew away its own cwd mid-execution; lesson learned),
- **skips** worktrees with uncommitted changes,
- **skips** brand-new worktrees with zero commits beyond main,
- **skips** branches with unmerged commits (uses `git cherry` patch-id matching so squash-merged branches ARE correctly detected as merged),
- **otherwise** `git worktree remove --force`.

Then for the parent checkout: if on a fully-merged non-main branch with clean working tree, `git checkout main && git pull --ff-only`.

### 2. `Stop` hook in `.claude/settings.json`

Calls the script every time a Claude Code session ends. Hooks are documented at [docs.anthropic.com/claude-code/hooks](https://docs.anthropic.com/en/docs/claude-code/hooks).

### 3. `just cleanup` recipe

Same script, on-demand. For when a session ended ungracefully (network blip, crash) and the hook didn't fire, or when the IDE source-control panel is showing stale state and the operator just wants to be back on clean main.

## Test plan

- [x] `bash -n` clean on the script.
- [x] JSON valid for settings.json.
- [x] Dry-run from inside a worktree correctly skipped self, kept worktrees with unmerged commits and a fresh worktree, and pulled main.
- [ ] Post-merge: this session's Stop hook fires and removes the `claude+session-end-cleanup-v2` worktree on its own.
- [ ] Subsequent sessions auto-clean without operator intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)