### PR TITLE
fix(cody): short-circuit retries on Claude CLI 401 auth failure

### DIFF
--- a/src/universal_agent/vp/clients/claude_cli_client.py
+++ b/src/universal_agent/vp/clients/claude_cli_client.py
@@ -52,6 +52,48 @@ STALL_TIMEOUT_SECONDS = 300
 # Maximum retries for failed CLI sessions
 MAX_RETRIES = 2
 
+# Substrings that indicate the CLI rejected our credentials. Retrying with
+# the same env is pointless — the OAuth access token has expired or the
+# API key is invalid, and only an operator re-auth can fix it. Matching is
+# case-insensitive. Keep these phrases tight to avoid false positives on
+# unrelated 401s mentioned inside generated content.
+_AUTH_FAILURE_MARKERS = (
+    "invalid authentication credentials",
+    "failed to authenticate",
+    "invalid x-api-key",
+    "authentication_error",
+)
+
+_AUTH_FAILURE_OPERATOR_HINT = (
+    "Claude CLI authentication failed (401). The Anthropic OAuth access "
+    "token on this host has likely expired and headless `claude --print` "
+    "does not refresh it. Re-auth on the VPS as the runtime user: run "
+    "`claude setup-token` (long-lived token, recommended for headless) or "
+    "`claude` to drive the interactive browser OAuth flow."
+)
+
+
+def _is_auth_failure(outcome: "MissionOutcome") -> bool:
+    """Return True if the CLI exit looks like an authentication failure.
+
+    We inspect both the top-level ``message`` (e.g. stderr summary) and the
+    ``payload.final_text`` (where the CLI's own error string lands when it
+    exits cleanly with code 1 from an auth rejection). One match in either
+    field is enough — auth failures are deterministic and not worth a
+    fuzzy threshold.
+    """
+    haystack_parts: list[str] = []
+    if outcome.message:
+        haystack_parts.append(str(outcome.message))
+    payload = outcome.payload or {}
+    final_text = payload.get("final_text")
+    if final_text:
+        haystack_parts.append(str(final_text))
+    haystack = " ".join(haystack_parts).lower()
+    if not haystack:
+        return False
+    return any(marker in haystack for marker in _AUTH_FAILURE_MARKERS)
+
 
 class ClaudeCodeCLIClient(VpClient):
     """VP client that directs Claude Code CLI sessions.
@@ -185,6 +227,27 @@ class ClaudeCodeCLIClient(VpClient):
                         cody_mode=cody_mode,
                     )
                     return outcome
+
+                # Short-circuit retries on credential failure — the same
+                # env will produce the same 401, and burning two more
+                # retries delays the operator-visible signal.
+                if _is_auth_failure(outcome):
+                    logger.error(
+                        "CLI mission %s aborted: authentication rejected by "
+                        "Anthropic API (cody_mode=%s, attempt=%d). %s",
+                        mission_id, cody_mode, attempt,
+                        _AUTH_FAILURE_OPERATOR_HINT,
+                    )
+                    enriched_payload = dict(outcome.payload or {})
+                    enriched_payload["auth_failure"] = True
+                    enriched_payload["operator_hint"] = _AUTH_FAILURE_OPERATOR_HINT
+                    return MissionOutcome(
+                        status="failed",
+                        result_ref=outcome.result_ref,
+                        message=f"{_AUTH_FAILURE_OPERATOR_HINT} "
+                                f"(original CLI error: {outcome.message})",
+                        payload=enriched_payload,
+                    )
 
                 last_outcome = outcome
                 if attempt > max_retries:

--- a/tests/unit/test_claude_cli_client.py
+++ b/tests/unit/test_claude_cli_client.py
@@ -23,6 +23,7 @@ from universal_agent.vp.clients.base import MissionOutcome, VpClient
 from universal_agent.vp.clients.claude_cli_client import (
     ClaudeCodeCLIClient,
     _build_cli_prompt,
+    _is_auth_failure,
     _parse_payload,
 )
 
@@ -133,6 +134,101 @@ async def test_cli_client_retries_on_failure(tmp_path: Path):
     assert outcome.status == "failed"
     # With max_retries=1, we get initial attempt + 1 retry = 2 calls
     assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 4b. _is_auth_failure pattern matching
+# ---------------------------------------------------------------------------
+def test_is_auth_failure_matches_final_text_401():
+    """The real failure mode: CLI exits with code 1 and 401 lands in final_text."""
+    outcome = MissionOutcome(
+        status="failed",
+        message="CLI exited with code 1",
+        payload={
+            "exit_code": 1,
+            "tool_calls": 0,
+            "final_text": "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        },
+    )
+    assert _is_auth_failure(outcome) is True
+
+
+def test_is_auth_failure_matches_message():
+    outcome = MissionOutcome(
+        status="failed",
+        message="invalid x-api-key from upstream",
+        payload={},
+    )
+    assert _is_auth_failure(outcome) is True
+
+
+def test_is_auth_failure_is_case_insensitive():
+    outcome = MissionOutcome(
+        status="failed",
+        message="",
+        payload={"final_text": "FAILED TO AUTHENTICATE"},
+    )
+    assert _is_auth_failure(outcome) is True
+
+
+def test_is_auth_failure_no_match_on_unrelated_error():
+    outcome = MissionOutcome(
+        status="failed",
+        message="CLI session timed out after 1800s",
+        payload={"final_text": "partial response..."},
+    )
+    assert _is_auth_failure(outcome) is False
+
+
+def test_is_auth_failure_handles_empty_outcome():
+    outcome = MissionOutcome(status="failed", message="", payload={})
+    assert _is_auth_failure(outcome) is False
+
+
+# ---------------------------------------------------------------------------
+# 4c. Auth failure short-circuits retries with operator-friendly message
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_cli_client_auth_failure_short_circuits_retries(tmp_path: Path):
+    """An auth-rejection 401 must NOT trigger the retry loop — same env
+    will produce the same failure, and we want the operator to see the
+    real reason without three rounds of identical retries first."""
+    client = ClaudeCodeCLIClient()
+    mission: dict[str, Any] = {
+        "mission_id": "test-mission-auth-401",
+        "objective": "Build something",
+        "payload_json": json.dumps({"timeout_seconds": 30, "max_retries": 2}),
+    }
+
+    auth_outcome = MissionOutcome(
+        status="failed",
+        message="CLI exited with code 1",
+        result_ref=f"workspace://{tmp_path}",
+        payload={
+            "exit_code": 1,
+            "tool_calls": 0,
+            "final_text": "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+        },
+    )
+
+    call_count = 0
+
+    async def mock_execute_cli_session(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        return auth_outcome
+
+    with patch(
+        "universal_agent.vp.clients.claude_cli_client._execute_cli_session",
+        side_effect=mock_execute_cli_session,
+    ):
+        outcome = await client.run_mission(mission=mission, workspace_root=tmp_path)
+
+    assert outcome.status == "failed"
+    assert call_count == 1, "auth failure must short-circuit before any retry"
+    assert outcome.payload.get("auth_failure") is True
+    assert "setup-token" in (outcome.message or "")
+    assert "401" in (outcome.message or "") or "OAuth" in (outcome.message or "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Detect Anthropic CLI authentication failures (401 / "Invalid authentication credentials" / "Failed to authenticate" / "Invalid x-api-key") and short-circuit the retry loop instead of burning all 3 retries on identical 401s.
- Replace the opaque "CLI exited with code 1" surface with an operator-friendly message pointing to `claude setup-token` as the fix.
- Mark `outcome.payload.auth_failure = True` so dashboards/UIs can distinguish credential failures from generic exit-1 failures.

## Background
Discovered while diagnosing failed mission `vp-mission-cc2885c5503ad74b52152c95` (Simone-dispatched Grok-tutorial build, 2026-05-17 04:03 UTC):

- Cody mission ran with `cody_mode="anthropic"`. `_build_cli_env` correctly scrubbed `ANTHROPIC_*` vars.
- `claude --print` exited code 1 in ~4s with `final_text: "Failed to authenticate. API Error: 401 Invalid authentication credentials"` — 3 times in a row.
- Root cause: `/home/ua/.claude/.credentials.json` `claudeAiOauth.expiresAt = 1778923529644` (2026-05-16 09:25:29 UTC). Mission ran **18.5h after token expiry**. Headless `claude --print` does NOT auto-refresh the OAuth token before making the API call; it just 401s.
- Net effect: Simone got a useless "CLI exited with code 1" failure receipt and built the demo manually as a fallback. Three retries delayed signal, consumed a session budget slot, and hid the actual remediation step.

This PR is the **code-side** half of the fix. The **operator-side** half is `claude setup-token` (or interactive `claude` re-auth) as `ua` on the VPS — that part requires a tap-approve on the Max account and is not automatable from here.

## Test plan
- [x] `uv run pytest tests/unit/test_claude_cli_client.py` — 22 passed (16 existing + 6 new).
- [x] New tests cover: positive matches on `final_text` 401, message `invalid x-api-key`, case-insensitive variants; negative match on timeout / unrelated errors; end-to-end short-circuit assertion (3-retry budget consumed once, not three times).
- [x] `uv run ruff check` on changed files — no new findings (1 pre-existing F541 at line 963 untouched).
- [ ] Production smoke deferred to next Cody-anthropic mission after operator runs `claude setup-token`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)