### PR TITLE
fix(vp): park SDK missions after N consecutive ProcessTurnAdapter timeouts

### DIFF
--- a/src/universal_agent/services/sdk_timeout_park.py
+++ b/src/universal_agent/services/sdk_timeout_park.py
@@ -1,0 +1,293 @@
+"""Park SDK-path VP missions after N consecutive wall-clock timeouts.
+
+Context
+-------
+VP missions executed through ``ProcessTurnAdapter`` (the Claude Agent SDK
+path in ``claude_code_client.py`` / ``claude_generalist_client.py``) are
+subject to a wall-clock cap enforced in ``execution_engine.py``. When the
+cap fires (``ProcessTurnAdapter timed out after Xs``) the adapter
+cancels the engine task but the SDK's bundled ``claude`` subprocess
+and its MCP children are not always reaped cleanly. Over the lifetime of
+one worker run, the resulting orphan PIDs / memory drift trip the systemd
+cgroup limits (``pids.max=256`` on this deployment) and the worker dies.
+``Restart=always`` brings a new worker up; the dispatch sweep re-claims
+the same mission; the cycle repeats — observed in production at
+~6m44s per cycle, hammering the same ``vp-mission-<id>`` indefinitely.
+
+This module breaks the loop by gating on **consecutive** timeouts for a
+given Task Hub task. The counter lives in ``task_hub_items.metadata_json``
+under ``sdk_consecutive_timeouts`` so it survives worker restarts. On the
+Nth consecutive timeout (default 3, override via
+``UA_SDK_TIMEOUT_POISON_THRESHOLD``) the task is parked into
+``needs_review`` via ``perform_task_action(action="review", ...)`` and the
+dispatch sweep stops re-claiming it. A non-timeout outcome on the same
+task resets the counter.
+
+Design constraints
+------------------
+* **Best-effort.** All public helpers swallow exceptions and log at
+  ``debug``. They must never raise into the mission code path — SDK
+  timeout is already an error route; a secondary failure here must not
+  obscure or replace the original failure.
+* **No new schema.** Reuses the existing ``metadata_json`` JSON blob on
+  ``task_hub_items`` (per the established pattern in ``perform_task_action``
+  for ``last_reject_reason``, etc.).
+* **Shared by both SDK clients.** ``ClaudeCodeClient`` (vp.coder.primary)
+  and ``ClaudeGeneralistClient`` (vp.general.primary) both call into
+  these helpers — the CLI path (``ClaudeCodeCLIClient``) uses a different
+  mechanism (the F.1/F.3 ``classify_worker_exit`` flow in
+  ``claude_cli_client._classify_and_route_cli_exit``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Phrases that indicate the ProcessTurnAdapter wall-clock cap fired.
+# Match the ERROR event emitted in ``execution_engine.py`` around
+# ``ProcessTurnAdapter timed out after %.1fs`` — the message field on the
+# yielded ERROR event reads ``"Execution timed out after {N}s"``.
+_SDK_TIMEOUT_MARKERS: tuple[str, ...] = (
+    "execution timed out after",
+    "processturnadapter timed out after",
+)
+
+_DEFAULT_THRESHOLD = 3
+_COUNTER_KEY = "sdk_consecutive_timeouts"
+_LAST_REASON_KEY = "sdk_last_timeout_reason"
+
+_PARK_REASON_PREFIX = "sdk_timeout_poison_pill"
+
+
+def _resolve_threshold() -> int:
+    raw = os.getenv("UA_SDK_TIMEOUT_POISON_THRESHOLD", "").strip()
+    if not raw:
+        return _DEFAULT_THRESHOLD
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "UA_SDK_TIMEOUT_POISON_THRESHOLD=%r is not an integer; using default %d",
+            raw, _DEFAULT_THRESHOLD,
+        )
+        return _DEFAULT_THRESHOLD
+    if value < 1:
+        logger.warning(
+            "UA_SDK_TIMEOUT_POISON_THRESHOLD=%d must be >=1; using default %d",
+            value, _DEFAULT_THRESHOLD,
+        )
+        return _DEFAULT_THRESHOLD
+    return value
+
+
+def is_sdk_timeout(error_text: Optional[str]) -> bool:
+    """Return True if ``error_text`` looks like a ProcessTurnAdapter timeout.
+
+    Matches against the ``Execution timed out after ...`` message yielded
+    by the SDK wall-clock cap path. Case-insensitive, substring match.
+    """
+    if not error_text:
+        return False
+    haystack = str(error_text).lower()
+    return any(marker in haystack for marker in _SDK_TIMEOUT_MARKERS)
+
+
+def record_sdk_timeout_and_maybe_park(
+    *,
+    task_id: str,
+    mission_id: str,
+    error_text: str,
+    threshold: Optional[int] = None,
+) -> tuple[bool, int]:
+    """Record an SDK timeout for a task and park it if the threshold is reached.
+
+    Args:
+        task_id: Task Hub item id from the mission payload. Empty/missing
+            ⇒ no-op (returns ``(False, 0)``).
+        mission_id: VP mission id, used only for log grep-ability.
+        error_text: The ERROR-event message from the SDK adapter. The
+            caller should still pass this even if it's already certain
+            it's a timeout — the helper double-checks via
+            :func:`is_sdk_timeout` to avoid mis-incrementing on
+            non-timeout failures.
+        threshold: Override the env-driven default (mainly for tests).
+
+    Returns:
+        ``(parked, count)`` where ``count`` is the updated consecutive
+        timeout count, and ``parked`` is True iff this call routed the
+        task to ``needs_review``. Best-effort: returns ``(False, 0)`` on
+        any DB error or if ``error_text`` isn't a timeout.
+    """
+    tid = str(task_id or "").strip()
+    if not tid:
+        return False, 0
+    if not is_sdk_timeout(error_text):
+        return False, 0
+
+    limit = int(threshold) if threshold is not None else _resolve_threshold()
+
+    try:
+        from universal_agent import task_hub as _th
+        from universal_agent.gateway_server import (
+            _task_hub_open_conn as _open_conn,
+        )
+    except Exception as exc:
+        logger.debug(
+            "SDK timeout parking imports failed for mission %s: %s",
+            mission_id, exc,
+        )
+        return False, 0
+
+    try:
+        conn = _open_conn()
+    except Exception as exc:
+        logger.debug(
+            "SDK timeout parking: could not open task_hub conn for mission %s: %s",
+            mission_id, exc,
+        )
+        return False, 0
+
+    try:
+        item = _th.get_item(conn, tid)
+        if not item:
+            logger.debug(
+                "SDK timeout parking: task %s not found (mission %s)",
+                tid, mission_id,
+            )
+            return False, 0
+
+        metadata = dict(item.get("metadata") or {})
+        current = int(metadata.get(_COUNTER_KEY) or 0)
+        new_count = current + 1
+        metadata[_COUNTER_KEY] = new_count
+        # Store a short summary of the last timeout so the operator can
+        # see *which* mission's failure tipped the parking decision
+        # without needing to grep logs.
+        metadata[_LAST_REASON_KEY] = (
+            f"mission={mission_id} message={str(error_text)[:200]}"
+        )
+
+        if new_count >= limit:
+            summary = (
+                f"{new_count} consecutive SDK wall-clock timeouts "
+                f"(last mission={mission_id})"
+            )
+            try:
+                _th.perform_task_action(
+                    conn,
+                    task_id=tid,
+                    action="review",
+                    reason=f"{_PARK_REASON_PREFIX}: {summary}",
+                    agent_id="sdk_timeout_park",
+                )
+                conn.commit()
+                logger.error(
+                    "SDK timeout parking: task %s parked to needs_review after "
+                    "%d consecutive timeouts (mission %s)",
+                    tid, new_count, mission_id,
+                )
+                return True, new_count
+            except Exception as exc:
+                logger.warning(
+                    "SDK timeout parking: perform_task_action(review) failed for "
+                    "task %s (mission %s): %s",
+                    tid, mission_id, exc,
+                )
+                return False, new_count
+
+        # Below threshold — persist the bumped counter so the next
+        # worker (after a restart) sees the accurate count.
+        from universal_agent.task_hub import _json_dumps, _now_iso  # noqa: WPS433
+        conn.execute(
+            "UPDATE task_hub_items SET metadata_json=?, updated_at=? WHERE task_id=?",
+            (_json_dumps(metadata), _now_iso(), tid),
+        )
+        conn.commit()
+        logger.warning(
+            "SDK timeout parking: task %s timeout %d/%d (mission %s)",
+            tid, new_count, limit, mission_id,
+        )
+        return False, new_count
+    except Exception as exc:
+        logger.debug(
+            "SDK timeout parking: bookkeeping error for task %s (mission %s): %s",
+            tid, mission_id, exc,
+        )
+        return False, 0
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+def reset_sdk_timeout_counter(*, task_id: str, mission_id: str = "") -> None:
+    """Clear the consecutive-timeout counter for a task.
+
+    Called by SDK clients on any non-timeout outcome (successful
+    completion OR a different failure mode) so that a transient timeout
+    doesn't permanently count against a task that later runs fine.
+
+    Best-effort. Silently returns on any error.
+    """
+    tid = str(task_id or "").strip()
+    if not tid:
+        return
+
+    try:
+        from universal_agent import task_hub as _th
+        from universal_agent.gateway_server import (
+            _task_hub_open_conn as _open_conn,
+        )
+    except Exception as exc:
+        logger.debug(
+            "SDK timeout reset: imports failed for mission %s: %s",
+            mission_id, exc,
+        )
+        return
+
+    try:
+        conn = _open_conn()
+    except Exception as exc:
+        logger.debug(
+            "SDK timeout reset: could not open task_hub conn (mission %s): %s",
+            mission_id, exc,
+        )
+        return
+
+    try:
+        item = _th.get_item(conn, tid)
+        if not item:
+            return
+        metadata = dict(item.get("metadata") or {})
+        if _COUNTER_KEY not in metadata and _LAST_REASON_KEY not in metadata:
+            return
+        metadata.pop(_COUNTER_KEY, None)
+        metadata.pop(_LAST_REASON_KEY, None)
+        from universal_agent.task_hub import _json_dumps, _now_iso  # noqa: WPS433
+        conn.execute(
+            "UPDATE task_hub_items SET metadata_json=?, updated_at=? WHERE task_id=?",
+            (_json_dumps(metadata), _now_iso(), tid),
+        )
+        conn.commit()
+    except Exception as exc:
+        logger.debug(
+            "SDK timeout reset: bookkeeping error for task %s (mission %s): %s",
+            tid, mission_id, exc,
+        )
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+
+__all__ = [
+    "is_sdk_timeout",
+    "record_sdk_timeout_and_maybe_park",
+    "reset_sdk_timeout_counter",
+]

--- a/src/universal_agent/vp/clients/claude_code_client.py
+++ b/src/universal_agent/vp/clients/claude_code_client.py
@@ -75,13 +75,55 @@ class ClaudeCodeClient(VpClient):
         finally:
             await adapter.close()
 
+        # SDK-path poison-pill parking: when a mission's task_id keeps
+        # hitting the wall-clock cap, the worker dies in cleanup and
+        # gets re-handed the same task — see services/sdk_timeout_park.
+        _task_id = str(payload.get("task_id") or "").strip() if isinstance(payload, dict) else ""
+        _mission_id = str(mission.get("mission_id") or "")
+        outcome_payload: dict[str, Any] = {"trace_id": trace_id, "final_text": final_text}
+
         if error_text:
+            try:
+                from universal_agent.services.sdk_timeout_park import (
+                    is_sdk_timeout,
+                    record_sdk_timeout_and_maybe_park,
+                    reset_sdk_timeout_counter,
+                )
+                if is_sdk_timeout(error_text):
+                    parked, count = record_sdk_timeout_and_maybe_park(
+                        task_id=_task_id,
+                        mission_id=_mission_id,
+                        error_text=error_text,
+                    )
+                    outcome_payload["sdk_consecutive_timeouts"] = count
+                    if parked:
+                        outcome_payload["sdk_parked_for_review"] = True
+                        error_text = (
+                            f"{error_text} "
+                            f"[parked after {count} consecutive SDK timeouts]"
+                        )
+                else:
+                    reset_sdk_timeout_counter(task_id=_task_id, mission_id=_mission_id)
+            except Exception:
+                # Best-effort — never let bookkeeping mask the original failure.
+                pass
+
             return MissionOutcome(
                 status="failed",
                 result_ref=f"workspace://{workspace_dir}",
                 message=error_text,
-                payload={"trace_id": trace_id, "final_text": final_text},
+                payload=outcome_payload,
             )
+
+        # Non-error path: reset any prior timeout counter so a flaky
+        # mission that finally succeeds doesn't carry stale state.
+        try:
+            from universal_agent.services.sdk_timeout_park import (
+                reset_sdk_timeout_counter,
+            )
+            reset_sdk_timeout_counter(task_id=_task_id, mission_id=_mission_id)
+        except Exception:
+            pass
 
         # Detect zero-output missions (startup crash / silent failure)
         if not final_text.strip():

--- a/src/universal_agent/vp/clients/claude_generalist_client.py
+++ b/src/universal_agent/vp/clients/claude_generalist_client.py
@@ -54,17 +54,54 @@ class ClaudeGeneralistClient(VpClient):
         finally:
             await adapter.close()
 
+        # SDK-path poison-pill parking — see services/sdk_timeout_park.
+        _task_id = str(payload.get("task_id") or "").strip() if isinstance(payload, dict) else ""
+        _mission_id = str(mission.get("mission_id") or "")
+        outcome_payload: dict[str, Any] = {"trace_id": trace_id, "final_text": final_text}
+
         if error_text:
+            try:
+                from universal_agent.services.sdk_timeout_park import (
+                    is_sdk_timeout,
+                    record_sdk_timeout_and_maybe_park,
+                    reset_sdk_timeout_counter,
+                )
+                if is_sdk_timeout(error_text):
+                    parked, count = record_sdk_timeout_and_maybe_park(
+                        task_id=_task_id,
+                        mission_id=_mission_id,
+                        error_text=error_text,
+                    )
+                    outcome_payload["sdk_consecutive_timeouts"] = count
+                    if parked:
+                        outcome_payload["sdk_parked_for_review"] = True
+                        error_text = (
+                            f"{error_text} "
+                            f"[parked after {count} consecutive SDK timeouts]"
+                        )
+                else:
+                    reset_sdk_timeout_counter(task_id=_task_id, mission_id=_mission_id)
+            except Exception:
+                pass
             return MissionOutcome(
                 status="failed",
                 result_ref=f"workspace://{workspace_dir}",
                 message=error_text,
-                payload={"trace_id": trace_id, "final_text": final_text},
+                payload=outcome_payload,
             )
+
+        try:
+            from universal_agent.services.sdk_timeout_park import (
+                reset_sdk_timeout_counter,
+            )
+            reset_sdk_timeout_counter(task_id=_task_id, mission_id=_mission_id)
+        except Exception:
+            pass
+
         return MissionOutcome(
             status="completed",
             result_ref=f"workspace://{workspace_dir}",
-            payload={"trace_id": trace_id, "final_text": final_text},
+            payload=outcome_payload,
         )
 
 

--- a/tests/unit/test_sdk_timeout_park.py
+++ b/tests/unit/test_sdk_timeout_park.py
@@ -1,0 +1,255 @@
+"""Unit tests for services.sdk_timeout_park.
+
+Covers the consecutive-timeout counter, parking on threshold, reset on
+non-timeout outcomes, and the best-effort behavior contract (no
+exceptions ever propagate to the caller).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+
+from universal_agent import task_hub as th
+from universal_agent.services.sdk_timeout_park import (
+    is_sdk_timeout,
+    record_sdk_timeout_and_maybe_park,
+    reset_sdk_timeout_counter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    """File-backed sqlite so the helper's open-per-call works on shared state."""
+    return tmp_path / "task_hub.db"
+
+
+def _open(db_path: Path) -> sqlite3.Connection:
+    c = sqlite3.connect(str(db_path))
+    c.row_factory = sqlite3.Row
+    return c
+
+
+@pytest.fixture
+def conn(db_path):
+    """Connection used by tests for inspection. Helper opens its own."""
+    c = _open(db_path)
+    th.ensure_schema(c)
+    c.commit()
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def task_id(conn) -> str:
+    """Create a fresh task_hub item and return its id."""
+    tid = "task-sdk-timeout-test-001"
+    th.upsert_item(
+        conn,
+        {
+            "task_id": tid,
+            "source_kind": "test",
+            "title": "test mission",
+            "description": "fixture",
+            "status": "in_progress",
+        },
+    )
+    conn.commit()
+    return tid
+
+
+@pytest.fixture
+def patch_conn(conn, db_path):
+    """Patch gateway_server._task_hub_open_conn so each helper call opens
+    its own connection to the same shared file DB. Mirrors production
+    behavior (each call opens + closes its own conn)."""
+    def _factory():
+        return _open(db_path)
+
+    with patch(
+        "universal_agent.gateway_server._task_hub_open_conn",
+        side_effect=_factory,
+    ):
+        yield conn
+
+
+# ---------------------------------------------------------------------------
+# 1. is_sdk_timeout pattern matching
+# ---------------------------------------------------------------------------
+def test_is_sdk_timeout_matches_execution_timeout():
+    assert is_sdk_timeout("Execution timed out after 300.0s") is True
+
+
+def test_is_sdk_timeout_matches_processturnadapter_phrase():
+    assert is_sdk_timeout("ProcessTurnAdapter timed out after 300.0s") is True
+
+
+def test_is_sdk_timeout_is_case_insensitive():
+    assert is_sdk_timeout("EXECUTION TIMED OUT AFTER 5s") is True
+
+
+def test_is_sdk_timeout_negative_unrelated_error():
+    assert is_sdk_timeout("permission denied") is False
+    assert is_sdk_timeout("model not found") is False
+    assert is_sdk_timeout("") is False
+    assert is_sdk_timeout(None) is False  # type: ignore[arg-type]
+
+
+def test_is_sdk_timeout_does_not_match_generic_timeout_word():
+    # We want substring "timed out after" — not just any "timeout" word,
+    # so we don't accidentally park on unrelated subprocess-level timeouts.
+    assert is_sdk_timeout("connection timeout") is False
+    assert is_sdk_timeout("request timeout while fetching") is False
+
+
+# ---------------------------------------------------------------------------
+# 2. record_sdk_timeout_and_maybe_park — happy paths
+# ---------------------------------------------------------------------------
+def test_first_timeout_increments_counter_does_not_park(patch_conn, task_id):
+    parked, count = record_sdk_timeout_and_maybe_park(
+        task_id=task_id,
+        mission_id="vp-mission-001",
+        error_text="Execution timed out after 300.0s",
+        threshold=3,
+    )
+    assert parked is False
+    assert count == 1
+    item = th.get_item(patch_conn, task_id)
+    assert item["metadata"]["sdk_consecutive_timeouts"] == 1
+    assert item["status"] == "in_progress"  # not parked yet
+
+
+def test_threshold_timeout_parks_task(patch_conn, task_id):
+    # First two timeouts: just increment.
+    for i in range(2):
+        parked, _ = record_sdk_timeout_and_maybe_park(
+            task_id=task_id,
+            mission_id=f"vp-mission-{i:03d}",
+            error_text="Execution timed out after 300.0s",
+            threshold=3,
+        )
+        assert parked is False
+    # Third timeout: should park.
+    parked, count = record_sdk_timeout_and_maybe_park(
+        task_id=task_id,
+        mission_id="vp-mission-002",
+        error_text="Execution timed out after 300.0s",
+        threshold=3,
+    )
+    assert parked is True
+    assert count == 3
+    item = th.get_item(patch_conn, task_id)
+    assert item["status"] == "needs_review"
+
+
+def test_threshold_one_parks_immediately(patch_conn, task_id):
+    """With threshold=1, even the first timeout parks."""
+    parked, count = record_sdk_timeout_and_maybe_park(
+        task_id=task_id,
+        mission_id="vp-mission-001",
+        error_text="Execution timed out after 300.0s",
+        threshold=1,
+    )
+    assert parked is True
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. reset_sdk_timeout_counter
+# ---------------------------------------------------------------------------
+def test_reset_clears_counter(patch_conn, task_id):
+    # Set up: two timeouts recorded.
+    for i in range(2):
+        record_sdk_timeout_and_maybe_park(
+            task_id=task_id,
+            mission_id=f"vp-mission-{i:03d}",
+            error_text="Execution timed out after 300.0s",
+            threshold=10,
+        )
+    item = th.get_item(patch_conn, task_id)
+    assert item["metadata"]["sdk_consecutive_timeouts"] == 2
+
+    # Reset.
+    reset_sdk_timeout_counter(task_id=task_id, mission_id="vp-mission-002")
+
+    item = th.get_item(patch_conn, task_id)
+    assert "sdk_consecutive_timeouts" not in item["metadata"]
+    assert "sdk_last_timeout_reason" not in item["metadata"]
+
+
+def test_reset_is_idempotent_with_no_prior_counter(patch_conn, task_id):
+    """Calling reset when no counter exists is a clean no-op (no crash)."""
+    reset_sdk_timeout_counter(task_id=task_id, mission_id="vp-mission-001")
+    item = th.get_item(patch_conn, task_id)
+    # Schema gives metadata={} default; we shouldn't have introduced anything.
+    assert item["metadata"] == {} or "sdk_consecutive_timeouts" not in item["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# 4. Non-timeout errors must NOT increment the counter
+# ---------------------------------------------------------------------------
+def test_non_timeout_error_is_a_no_op_on_record(patch_conn, task_id):
+    parked, count = record_sdk_timeout_and_maybe_park(
+        task_id=task_id,
+        mission_id="vp-mission-001",
+        error_text="permission denied",
+        threshold=3,
+    )
+    assert parked is False
+    assert count == 0
+    item = th.get_item(patch_conn, task_id)
+    assert "sdk_consecutive_timeouts" not in item["metadata"]
+
+
+# ---------------------------------------------------------------------------
+# 5. Empty task_id ⇒ silent no-op (the common case for unlinked missions)
+# ---------------------------------------------------------------------------
+def test_empty_task_id_is_silent_noop():
+    parked, count = record_sdk_timeout_and_maybe_park(
+        task_id="",
+        mission_id="vp-mission-001",
+        error_text="Execution timed out after 300.0s",
+    )
+    assert parked is False
+    assert count == 0
+    # Should not raise even though we didn't patch the DB conn.
+    reset_sdk_timeout_counter(task_id="", mission_id="vp-mission-001")
+
+
+# ---------------------------------------------------------------------------
+# 6. Best-effort: DB errors never raise
+# ---------------------------------------------------------------------------
+def test_db_open_failure_never_raises():
+    """When the task_hub conn can't be opened, helpers swallow the error."""
+    with patch(
+        "universal_agent.gateway_server._task_hub_open_conn",
+        side_effect=RuntimeError("db unavailable"),
+    ):
+        parked, count = record_sdk_timeout_and_maybe_park(
+            task_id="any-task",
+            mission_id="vp-mission-001",
+            error_text="Execution timed out after 300.0s",
+        )
+        assert parked is False
+        assert count == 0
+        # Reset must also swallow.
+        reset_sdk_timeout_counter(task_id="any-task", mission_id="vp-mission-001")
+
+
+# ---------------------------------------------------------------------------
+# 7. Unknown task ⇒ silent no-op
+# ---------------------------------------------------------------------------
+def test_unknown_task_is_silent_noop(patch_conn):
+    parked, count = record_sdk_timeout_and_maybe_park(
+        task_id="nonexistent-task-id",
+        mission_id="vp-mission-001",
+        error_text="Execution timed out after 300.0s",
+    )
+    assert parked is False
+    assert count == 0


### PR DESCRIPTION
## Summary
- Stops the **poison-pill crash-loop** observed today on `vp.coder.primary` where the same mission re-claimed every ~6m44s, hung to the 300s SDK wall-clock cap, and brought down the worker via cgroup `pids.max` exhaustion.
- After N consecutive `ProcessTurnAdapter timed out` outcomes for the same Task Hub task (default N=3, env-tunable), the task is parked into `needs_review` and dispatch stops re-handing it out.
- Non-timeout outcomes reset the counter so a flaky mission that later succeeds doesn't carry stale state.

## Background
Mission `vp-mission-fecbdc36d062e71d9be8c660` (CODIE, YouTube ingest of video `oekV5AQGRCY`) was caught in a re-claim loop today between 15:00 and 17:10 UTC. Pattern per cycle:

```
T+0:00  worker bootstraps (Infisical 272 secrets, soul=CODIE_SOUL)
T+0:80  mission claimed; ProcessTurnAdapter wall-clock cap=300s logged
T+5:80  ERROR universal_agent.execution_engine ProcessTurnAdapter timed out after 300.0s
T+5:90  Session reset
T+6:30  worker exits (no stack trace — cgroup kill on pids.max=256)
T+6:44  new worker bootstraps, GOTO 0
```

Cgroup state during active mission:
- `pids.max = 256`, peaked at 221
- `memory.max = 3 GiB`, peaked at 1.3 GiB

The SDK's bundled `claude` subprocess + MCP children aren't fully reaped by `engine_task.cancel()` in `execution_engine.py:884-888`, so the orphan PIDs accumulate over the timeout's cleanup window and trip the cgroup limit. That's a deeper fix in its own right; this PR addresses the **failure amplification** layer — stopping a single poison mission from infinitely re-killing the worker.

## Design
- New helper module: `src/universal_agent/services/sdk_timeout_park.py`
  - `is_sdk_timeout(error_text)` — substring match against "execution timed out after" and "processturnadapter timed out after". Tighter than matching the bare word "timeout" so we don't false-positive on subprocess-level timeouts.
  - `record_sdk_timeout_and_maybe_park(task_id, mission_id, error_text, threshold=N)` — reads `task_hub_items.metadata_json`, increments `sdk_consecutive_timeouts`, parks at threshold via `perform_task_action(action="review", reason="sdk_timeout_poison_pill: ...")`.
  - `reset_sdk_timeout_counter(task_id)` — clears the counter on any non-timeout outcome (success OR a different failure mode).
- Wired into both SDK clients: `claude_code_client.py` (vp.coder.primary) and `claude_generalist_client.py` (vp.general.primary). The CLI client already has its own F.1/F.3 flow.
- **Best-effort throughout.** All DB ops are wrapped in try/except; helpers log at debug/warning but never raise into the mission's own failure path. Empty `task_id` is a silent no-op (common for unlinked missions).
- Threshold: env var `UA_SDK_TIMEOUT_POISON_THRESHOLD`, default 3 (~15 minutes of repeated wedging before auto-park).

## Out of scope (separate follow-ups)
- The underlying SDK subprocess leak on `engine_task.cancel()` — fix needs process-group tracking + SIGTERM-then-SIGKILL.
- The 300s opus wall-clock cap is provably under-budget for the YouTube ingest mission — bump or make it per-mission overridable.
- `pids.max=256` is too tight for an Agent Teams worker — bump in the systemd unit drop-in.

## Test plan
- [x] 14 new unit tests in `tests/unit/test_sdk_timeout_park.py` — pattern matching positives/negatives, increment/threshold/reset, empty-task/unknown-task/DB-failure no-op contracts.
- [x] `uv run pytest tests/unit/test_sdk_timeout_park.py tests/unit/test_claude_cli_client.py -q` — 36 passed.
- [x] `uv run ruff check` clean on changed files.
- [ ] Production verification: unblock the current poison mission manually so this PR's behavior kicks in for the *next* such case.

## Operator action (independent of this PR)
The current poison mission needs manual unblocking — this PR only prevents *future* poison missions from infinite-looping. To unblock today, query `task_hub.db` for the row linked to `vp-mission-fecbdc36d062e71d9be8c660` (likely via `metadata_json` LIKE match or the YouTube video id `oekV5AQGRCY`) and `UPDATE ... SET status='needs_review'` so dispatch stops re-claiming it.

Generated with [Claude Code](https://claude.com/claude-code)
