### PR TITLE
fix(vp): post-mission PR hook targets main, not retired develop

### DIFF
--- a/src/universal_agent/vp/worker_loop.py
+++ b/src/universal_agent/vp/worker_loop.py
@@ -56,6 +56,12 @@ def _extract_first_target_path(constraints: dict[str, Any]) -> str:
 # ── GitHub repo for doc-maintenance PRs ──────────────────────────────────────
 _GH_REPO = os.getenv("UA_GH_REPO", "Kjdragan/universal_agent")
 
+# Default PR base for the post-mission doc-maintenance hook. ``develop`` was
+# retired 2026-05-10 in favor of a main-only branching model — see
+# docs/06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md.
+# Operator-overridable for staging environments via UA_GH_PR_BASE_BRANCH.
+_PR_BASE_BRANCH = os.getenv("UA_GH_PR_BASE_BRANCH", "main")
+
 
 def _post_mission_push_pr_merge(*, workspace_root: str, mission_id: str) -> None:
     """Push the agent's doc branch, create a PR, and squash-merge it.
@@ -80,14 +86,19 @@ def _post_mission_push_pr_merge(*, workspace_root: str, mission_id: str) -> None
         logger.info("Post-mission hook: not on a docs/ branch (%s), skipping push", branch)
         return
 
-    # 2. Check if there are commits on this branch that aren't on develop
+    # 2. Check if there are commits on this branch that aren't on the
+    # PR base. ``develop`` retired 2026-05-10; default base is ``main``
+    # (see module-level ``_PR_BASE_BRANCH``).
     result = subprocess.run(
-        ["git", "log", "develop..HEAD", "--oneline"],
+        ["git", "log", f"{_PR_BASE_BRANCH}..HEAD", "--oneline"],
         capture_output=True, text=True, cwd=cwd,
     )
     commits = result.stdout.strip()
     if not commits:
-        logger.info("Post-mission hook: no new commits on %s vs develop, skipping", branch)
+        logger.info(
+            "Post-mission hook: no new commits on %s vs %s, skipping",
+            branch, _PR_BASE_BRANCH,
+        )
         return
 
     logger.info("Post-mission hook [%s]: pushing branch %s (%d commits)",
@@ -124,7 +135,7 @@ def _post_mission_push_pr_merge(*, workspace_root: str, mission_id: str) -> None
     pr_body = json.dumps({
         "title": commit_title,
         "head": branch,
-        "base": "develop",
+        "base": _PR_BASE_BRANCH,
         "body": f"Automated doc maintenance (mission {mission_id}).",
     }).encode()
 
@@ -206,10 +217,13 @@ def _post_mission_push_pr_merge(*, workspace_root: str, mission_id: str) -> None
     except Exception as exc:
         logger.warning("Post-mission hook: merge failed: %s", exc)
 
-    # 7. Switch back to develop so the next mission starts clean
-    subprocess.run(["git", "checkout", "develop"], capture_output=True, cwd=cwd)
-    subprocess.run(["git", "pull", "origin", "develop"], capture_output=True, cwd=cwd)
-    logger.info("Post-mission hook: switched back to develop, ready for next mission")
+    # 7. Switch back to the PR base so the next mission starts clean
+    subprocess.run(["git", "checkout", _PR_BASE_BRANCH], capture_output=True, cwd=cwd)
+    subprocess.run(["git", "pull", "origin", _PR_BASE_BRANCH], capture_output=True, cwd=cwd)
+    logger.info(
+        "Post-mission hook: switched back to %s, ready for next mission",
+        _PR_BASE_BRANCH,
+    )
 
 
 class VpWorkerLoop:

--- a/tests/unit/test_worker_loop_post_mission_hook.py
+++ b/tests/unit/test_worker_loop_post_mission_hook.py
@@ -1,0 +1,145 @@
+"""Regression tests for the VP worker's post-mission PR hook.
+
+Specifically guards the bug observed 2026-05-17: ``_post_mission_push_pr_merge``
+was hard-coding ``"develop"`` for the PR base and the ``git log develop..HEAD``
+diff check, causing every doc-maintenance mission's PR to fail with
+HTTP 422 ``{"field":"base","code":"invalid"}`` because ``develop`` was
+retired on 2026-05-10.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def test_pr_base_branch_constant_defaults_to_main(monkeypatch):
+    """Bare module import (no env override) must resolve base to ``main``.
+
+    Guards against silent reintroduction of ``develop`` as a default.
+    """
+    monkeypatch.delenv("UA_GH_PR_BASE_BRANCH", raising=False)
+    from universal_agent.vp import worker_loop
+    importlib.reload(worker_loop)
+    assert worker_loop._PR_BASE_BRANCH == "main"
+
+
+def test_pr_base_branch_constant_respects_env_override(monkeypatch):
+    """Operator can override the default for staging via env var."""
+    monkeypatch.setenv("UA_GH_PR_BASE_BRANCH", "staging")
+    from universal_agent.vp import worker_loop
+    importlib.reload(worker_loop)
+    try:
+        assert worker_loop._PR_BASE_BRANCH == "staging"
+    finally:
+        # Restore default for other tests.
+        monkeypatch.delenv("UA_GH_PR_BASE_BRANCH", raising=False)
+        importlib.reload(worker_loop)
+
+
+def test_no_lingering_develop_literals_in_post_mission_hook():
+    """Source-level guard: the hook body must not reference ``develop`` as
+    an active branch literal anywhere (the only allowed mention is in a
+    historical-context comment about the 2026-05-10 retirement)."""
+    import inspect
+
+    from universal_agent.vp import worker_loop
+
+    src = inspect.getsource(worker_loop._post_mission_push_pr_merge)
+    # No git refs against develop, and no "base": "develop" PR payload.
+    assert "develop..HEAD" not in src
+    assert '"develop"' not in src
+    assert '"base": "develop"' not in src
+    # No checkout/pull of develop.
+    assert "checkout\", \"develop" not in src.replace("'", '"')
+    assert "pull\", \"origin\", \"develop" not in src.replace("'", '"')
+
+
+def test_post_mission_hook_pr_payload_uses_base_constant(monkeypatch):
+    """End-to-end: when the hook reaches the PR-creation step it must
+    send ``"base": _PR_BASE_BRANCH`` in the JSON body to the GitHub API.
+
+    We stub subprocess + urllib to capture the request body without
+    touching the network or a real git repo.
+    """
+    import json
+    from unittest.mock import MagicMock, patch
+
+    from universal_agent.vp import worker_loop
+
+    captured = {}
+
+    # Fake subprocess.run results in the sequence the hook calls them:
+    # 1. git rev-parse --abbrev-ref HEAD          → "docs/test"
+    # 2. git log {_PR_BASE_BRANCH}..HEAD --oneline → "abc1234 docs: x"
+    # 3. git remote get-url origin                → has x-access-token:TOKEN@
+    # 4. git push -u origin <branch>              → rc=0
+    # 5. (after merge) checkout
+    # 6. (after merge) pull
+    call_count = {"n": 0}
+
+    def fake_run(cmd, **_kwargs):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        if cmd[:2] == ["git", "rev-parse"]:
+            result.stdout = "docs/test-branch\n"
+        elif cmd[:2] == ["git", "log"]:
+            captured["log_cmd"] = list(cmd)
+            result.stdout = "abc1234 docs: test commit\n"
+        elif cmd[:3] == ["git", "remote", "get-url"]:
+            result.stdout = "https://x-access-token:FAKE_TOKEN@github.com/x/y.git\n"
+        elif cmd[:2] == ["git", "push"]:
+            result.stdout = ""
+        else:
+            # checkout / pull / anything else — record but no-op.
+            captured.setdefault("other_cmds", []).append(list(cmd))
+            result.stdout = ""
+        return result
+
+    class _FakeResp:
+        def __init__(self, payload):
+            self._payload = payload
+
+        def read(self):
+            return json.dumps(self._payload).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    def fake_urlopen(req, **_kwargs):
+        # Method=POST on /pulls is the PR creation call.
+        if req.method == "POST" and "/pulls" in req.full_url and "/merge" not in req.full_url:
+            captured["pr_body"] = json.loads(req.data.decode())
+            return _FakeResp({"number": 42, "html_url": "https://github.com/x/y/pull/42"})
+        if req.method == "PUT" and "/merge" in req.full_url:
+            return _FakeResp({"merged": True, "message": "ok"})
+        raise AssertionError(f"unexpected request: {req.method} {req.full_url}")
+
+    # Patch record_mission_pr so we don't reach into task_hub during the test.
+    with patch.object(worker_loop.subprocess, "run", side_effect=fake_run), \
+         patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+         patch(
+             "universal_agent.services.vp_mission_pr_reconciler.record_mission_pr",
+         ) as _rec, \
+         patch(
+             "universal_agent.durable.db.connect_runtime_db",
+             return_value=MagicMock(commit=MagicMock(), close=MagicMock()),
+         ), \
+         patch(
+             "universal_agent.durable.db.get_activity_db_path",
+             return_value="/tmp/fake.db",
+         ):
+        worker_loop._post_mission_push_pr_merge(
+            workspace_root="/tmp/fake-workspace",
+            mission_id="vp-mission-test-001",
+        )
+
+    assert captured.get("pr_body"), "PR creation request was not made"
+    assert captured["pr_body"]["base"] == worker_loop._PR_BASE_BRANCH
+    assert captured["pr_body"]["base"] == "main"  # belt-and-suspenders
+    # And the diff command must reference the same base, not "develop".
+    assert captured["log_cmd"][2] == f"{worker_loop._PR_BASE_BRANCH}..HEAD"


### PR DESCRIPTION
## Summary
- Fixes the VP worker's post-mission PR-creation hook, which has been silently failing for every doc-maintenance mission since `develop` was retired 2026-05-10.
- Replaces 4 hard-coded `develop` literals with a `_PR_BASE_BRANCH` constant (default `"main"`, overridable via `UA_GH_PR_BASE_BRANCH`).
- Adds 4 regression tests including a source-level guard against reintroducing a `develop` literal.

## Symptom (observed today)
A `docs/p2-fix-2026-05-17` doc-maintenance mission completed successfully at 2026-05-17 20:20:32 UTC: branch pushed clean, 133 commits. Then the post-mission hook tried to open the PR and the GitHub API rejected it:

```
2026-05-17 20:20:33,015 WARNING universal_agent.vp.worker_loop
Post-mission hook: PR creation failed (HTTP 422):
{"message":"Validation Failed","errors":[{"resource":"PullRequest","field":"base","code":"invalid"}], ...}
```

The branch is on origin with 133 commits; no PR opened; no auto-merge fired. The hook silently logged a warning and moved on.

## Root cause
`src/universal_agent/vp/worker_loop.py:_post_mission_push_pr_merge` had four hard-coded `develop` literals:
1. `git log develop..HEAD --oneline` — diff check.
2. `"base": "develop"` — PR creation body.
3. `git checkout develop` — post-merge cleanup.
4. `git pull origin develop` — post-merge cleanup.

`develop` was retired 2026-05-10 per `docs/06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md`. The diff check (item 1) actually worked because `develop` exists locally as a stale ref, so the `git log` returned commits and the hook proceeded. But the PR-creation API call (item 2) hit GitHub's server-side validation and got a clean 422.

## Test plan
- [x] `uv run pytest tests/unit/test_worker_loop_post_mission_hook.py -q` — 4 passed in 6.96s.
- [x] `uv run ruff check` clean on changed files.
- [x] Source-level grep: only remaining `develop` literal in the file is in a historical-context comment about the 2026-05-10 retirement.
- [ ] Production verification: next doc-maintenance mission's post-mission hook should successfully open and squash-merge a PR against `main`.

## Backfill (optional, not in this PR)
The orphaned `docs/p2-fix-2026-05-17` branch on origin has the 133 commits from today's mission but no PR. Once this PR ships, you can open that PR manually:
```
gh pr create --base main --head docs/p2-fix-2026-05-17 --title "docs: p2 fix 2026-05-17" --body "Backfill PR for orphaned post-mission hook output (pre-fix)."
```
Or just delete the branch if the changes have been superseded.

Generated with [Claude Code](https://claude.com/claude-code)
