### PR TITLE
fix(csi): research grounding @-handle hallucinations + SPA-404 detection

### DIFF
--- a/docs/proactive_signals/claudedevs_intel_v2_remaining_work.md
+++ b/docs/proactive_signals/claudedevs_intel_v2_remaining_work.md
@@ -1,7 +1,7 @@
 # ClaudeDevs Intel v2 — Remaining Work Plan
 
 > **Status:** ✅ **Phases A + B complete in production as of 2026-05-16.** End-to-end loop verified (1 demo attached to `custom-subagents.md` entity page; 4 demo workspaces in `/opt/ua_demos/`). Only Phase C (operations/generalization) + Phase D (cross-pipeline lifecycle) remain — all small, optional, individually scopable. Living document.
-> **Last updated:** 2026-05-16 (post-gateway-incident audit: Phase A wiring + Phase B skill invocation + Phase 4 vault-attach all confirmed wired in `claude_code_intel_replay.py:116-148, 864-880` + `memory/HEARTBEAT.md:93-101`)
+> **Last updated:** 2026-05-17 — PR 16 fix-up: research grounding URL synthesizer was producing hallucinated `docs.anthropic.com` paths from `@`-handles in tweet text. Two-layer fix shipped: pre-strip mentions/hashtags/URLs in `extract_candidate_terms`, plus SPA-404 shell post-validation. New cleanup script `csi_vault_cleanup_grounding_hallucinations.py` quarantines the affected vault pages. See PR 16 section below.
 > **Owner:** AI Coder on `main`, with operator gates for `/ship` cycles
 > **Companion:** [`claudedevs_intel_v2_design.md`](claudedevs_intel_v2_design.md) (the original 13-PR design doc)
 > **🚨 Read first if returning after a session break:** [`csi_v2_next_session_priorities_2026-05-06.md`](csi_v2_next_session_priorities_2026-05-06.md) — the unambiguous "do this next" list.
@@ -134,6 +134,10 @@ Both wiring PRs shipped and live. Phase A latent integration gaps from PRs 2, 3,
 - **Wired at:** `src/universal_agent/services/claude_code_intel_replay.py:116-148` calls `apply_research_grounding_pass()` (lines 435-549) between linked-source expansion and vault ingest, so the Memex pass sees grounded sources alongside originally-linked ones. Grounded entries flow into `linked_source_entries` via list-merge (line 148) and are counted separately in `linked_source_count` semantics for stability.
 - **Toggle:** `UA_CSI_RESEARCH_GROUNDING_WIRING_ENABLED` (defaults to ON; emergency off switch).
 - **Cost guardrail:** Trigger logic enforced at `research_grounding.build_research_request` keeps the tier ≥ 2 gate strict.
+- **Fix-up (2026-05-17):** the original deterministic URL synthesizer treated Twitter `@`-handles from tweet text as feature names — for `@OniricSunset` it emitted `docs.anthropic.com/en/docs/oniricsunset`, which docs.anthropic.com (a Next.js SPA) served as a 200 shell. The fetcher persisted ~96 KiB of CSS/JS link markup as a "Grounded source" and the vault ingester linked it from the canonical index. Fixed in two layers:
+    1. `services/research_grounding.extract_candidate_terms` now pre-strips `@<handle>`, `#<tag>`, and bare URL tokens before regex matching, and accepts an `excluded_handles` set populated from `ClaudeCodeIntelConfig.all_handles_from_env()` + the packet's polled handle so previously-known handles are filtered even when they appear bare.
+    2. `services/research_grounding._is_spa_404_shell` post-validates fetched grounding bodies and drops anything that matches the docs.anthropic.com SPA shell signature (markers + content-char floor). On detection the artifact file is also unlinked so the vault writer can't pick it up.
+- **Vault cleanup script (2026-05-17):** `src/universal_agent/scripts/csi_vault_cleanup_grounding_hallucinations.py` walks both the vault sources tree and per-packet research_grounding directories and moves SPA-shell pages under sibling `quarantine/` dirs with a `*.reason.txt` describing why. Run once on the VPS after deploy: `uv run python -m universal_agent.scripts.csi_vault_cleanup_grounding_hallucinations --dry-run` to inspect, then drop `--dry-run` to apply.
 
 ### Phase B — Demo orchestration (the Simone↔Cody loop) ✅ COMPLETE
 

--- a/src/universal_agent/scripts/csi_vault_cleanup_grounding_hallucinations.py
+++ b/src/universal_agent/scripts/csi_vault_cleanup_grounding_hallucinations.py
@@ -1,0 +1,129 @@
+"""Quarantine SPA-404 hallucinations that the research-grounding pass wrote to the CSI vault.
+
+Background: prior to the 2026-05-17 fix in ``research_grounding`` the
+deterministic URL synthesizer slugified ``@`` mentions from tweet text into
+fake docs.anthropic.com paths (e.g. ``/en/docs/oniricsunset``). docs.anthropic.com
+is a Next.js SPA that returns HTTP 200 with the same shell HTML for any path,
+so the fetcher persisted ~96 KiB of CSS/JS link markup as a legitimate
+"Grounded source" and the vault ingester linked it from the canonical index.
+
+This script walks the CSI knowledge vault and the per-packet research_grounding
+directories, detects pages that look like SPA shells, and moves them under
+``<vault>/sources/quarantine/`` (and ``<packet>/research_grounding/quarantine/``)
+with a sibling ``*.reason.txt`` describing why they were flagged. It never
+deletes content — every move is reversible.
+
+Run with ``--dry-run`` first to inspect what would move.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+import shutil
+import sys
+from typing import Iterator
+
+from universal_agent.artifacts import resolve_artifacts_dir
+from universal_agent.services.research_grounding import _is_spa_404_shell
+
+logger = logging.getLogger(__name__)
+
+
+VAULT_SLUG = "claude-code-intelligence"
+QUARANTINE_DIRNAME = "quarantine"
+
+
+def _iter_vault_sources(vault_root: Path) -> Iterator[Path]:
+    sources_dir = vault_root / "sources"
+    if not sources_dir.exists():
+        return iter(())
+    return (
+        path
+        for path in sources_dir.iterdir()
+        if path.is_file()
+        and path.suffix == ".md"
+        and "grounded-source" in path.name
+    )
+
+
+def _iter_packet_grounding_files(packets_root: Path) -> Iterator[Path]:
+    if not packets_root.exists():
+        return iter(())
+    return packets_root.rglob("research_grounding/*/documentation_*.md")
+
+
+def _looks_like_spa_shell(path: Path) -> bool:
+    try:
+        chars = path.stat().st_size
+    except OSError:
+        return False
+    return _is_spa_404_shell(content_path=str(path), content_chars=chars)
+
+
+def _quarantine(path: Path, *, dry_run: bool, reason: str) -> bool:
+    """Move ``path`` under a sibling ``quarantine/`` dir. Returns True on action."""
+    target_dir = path.parent / QUARANTINE_DIRNAME
+    if not dry_run:
+        target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / path.name
+    if target.exists():
+        logger.info("already quarantined: %s", target)
+        return False
+    if dry_run:
+        logger.info("[dry-run] would quarantine %s -> %s (%s)", path, target, reason)
+        return True
+    shutil.move(str(path), str(target))
+    (target.with_suffix(target.suffix + ".reason.txt")).write_text(
+        f"Quarantined by csi_vault_cleanup_grounding_hallucinations.\nReason: {reason}\n",
+        encoding="utf-8",
+    )
+    logger.info("quarantined %s -> %s", path, target)
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts-root",
+        type=Path,
+        default=None,
+        help="Override artifacts dir (defaults to artifacts.resolve_artifacts_dir()).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would move without touching disk.",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    artifacts_root: Path = (args.artifacts_root or resolve_artifacts_dir()).expanduser().resolve()
+    vault_root = artifacts_root / "knowledge-vaults" / VAULT_SLUG
+    packets_root = artifacts_root / "proactive" / "claude_code_intel" / "packets"
+
+    moved_vault = 0
+    moved_grounding = 0
+
+    for path in _iter_vault_sources(vault_root):
+        if _looks_like_spa_shell(path):
+            if _quarantine(path, dry_run=args.dry_run, reason="spa_404_shell"):
+                moved_vault += 1
+
+    for path in _iter_packet_grounding_files(packets_root):
+        if _looks_like_spa_shell(path):
+            if _quarantine(path, dry_run=args.dry_run, reason="spa_404_shell"):
+                moved_grounding += 1
+
+    logger.info(
+        "Cleanup summary: %d vault page(s), %d grounding file(s) %s.",
+        moved_vault,
+        moved_grounding,
+        "would move" if args.dry_run else "moved",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/universal_agent/services/claude_code_intel_replay.py
+++ b/src/universal_agent/services/claude_code_intel_replay.py
@@ -461,12 +461,32 @@ def apply_research_grounding_pass(
     """
     # Lazy-import so the replay module doesn't pull research_grounding's
     # transitive deps (csi_url_judge, intel_lanes) when grounding is off.
+    from universal_agent.services.claude_code_intel import ClaudeCodeIntelConfig
     from universal_agent.services.research_grounding import (
         build_research_request,
         execute_research,
     )
 
     existing_entity_names = _existing_entity_names(vault_root)
+
+    # Build the "polled handles" exclusion set so X handles never get
+    # slugified into hallucinated docs URLs. Includes the configured handle
+    # list plus the handle attached to this packet (read from manifest).
+    excluded_handles: set[str] = set()
+    try:
+        for handle in ClaudeCodeIntelConfig.all_handles_from_env():
+            if handle:
+                excluded_handles.add(handle.lower())
+    except Exception:
+        pass
+    try:
+        manifest_path = packet_dir / "manifest.json"
+        if manifest_path.exists():
+            manifest_handle = str(_load_json(manifest_path).get("handle") or "").strip().lower()
+            if manifest_handle:
+                excluded_handles.add(manifest_handle)
+    except Exception:
+        pass
 
     # Pre-index linked sources per post so we can reason about per-post
     # link coverage when computing the THIN_LINKED_SOURCES signal.
@@ -502,6 +522,7 @@ def apply_research_grounding_pass(
                 },
                 classifier_result=classifier_result,
                 existing_entity_names=existing_entity_names,
+                excluded_handles=excluded_handles,
             )
         except Exception as exc:
             import logging

--- a/src/universal_agent/services/research_grounding.py
+++ b/src/universal_agent/services/research_grounding.py
@@ -180,15 +180,41 @@ def is_allowed(url: str, allowlist: list[str]) -> bool:
 _TERM_PATTERN = re.compile(r"\b([A-Z][a-zA-Z0-9_]{2,}|[a-z][a-zA-Z0-9_]+_[a-zA-Z0-9_]+)\b")
 
 
-def extract_candidate_terms(text: str) -> list[str]:
+_MENTION_HANDLE_RE = re.compile(r"@([A-Za-z0-9_]{1,30})")
+_HASH_TAG_RE = re.compile(r"#([A-Za-z0-9_]{1,80})")
+_URL_TOKEN_RE = re.compile(r"https?://\S+")
+
+
+def extract_candidate_terms(text: str, *, excluded_handles: set[str] | None = None) -> list[str]:
     """Extract probable feature / SDK terms from a post for grounding lookup.
 
     Conservative: prefers CamelCase identifiers and snake_case identifiers.
     Plain English words are filtered out via STOPWORDS.
+
+    Strips Twitter @-mentions, #-tags, and URL tokens before regex matching so
+    handles like ``@OniricSunset`` never get slugified into hallucinated docs
+    URLs. ``excluded_handles`` is an optional caller-supplied set of lowercased
+    @-handles to ignore even if they appear without the leading ``@`` (for
+    example the polled-handles list).
     """
     if not text:
         return []
-    candidates = _TERM_PATTERN.findall(text)
+    excluded = {h.lower().lstrip("@") for h in (excluded_handles or set())}
+
+    # Collect handles in the text so we exclude them even if a downstream
+    # regex would have caught the bare CamelCase form.
+    for match in _MENTION_HANDLE_RE.finditer(text):
+        excluded.add(match.group(1).lower())
+
+    # Strip handles, tags, and URLs entirely before tokenization. The
+    # original mentions could otherwise produce CamelCase tokens (e.g.
+    # ``@OniricSunset`` -> ``OniricSunset``) that downstream URL synthesis
+    # treats as feature names.
+    sanitized = _URL_TOKEN_RE.sub(" ", text)
+    sanitized = _MENTION_HANDLE_RE.sub(" ", sanitized)
+    sanitized = _HASH_TAG_RE.sub(" ", sanitized)
+
+    candidates = _TERM_PATTERN.findall(sanitized)
     # De-duplicate preserving order.
     seen: set[str] = set()
     out: list[str] = []
@@ -196,6 +222,8 @@ def extract_candidate_terms(text: str) -> list[str]:
         if len(term) < 3:
             continue
         if term.lower() in _TERM_STOPWORDS:
+            continue
+        if term.lower() in excluded:
             continue
         if term in seen:
             continue
@@ -240,6 +268,7 @@ def should_trigger_research(
     classifier_result: dict[str, Any] | None = None,
     existing_entity_names: set[str] | None = None,
     operator_force: bool = False,
+    excluded_handles: set[str] | None = None,
 ) -> tuple[bool, list[TriggerReason]]:
     """Apply the §6.3 trigger logic.
 
@@ -267,7 +296,10 @@ def should_trigger_research(
     # Unknown-term signal — any candidate term that isn't already an entity
     # in the vault.
     if existing_entity_names is not None:
-        terms = extract_candidate_terms(str(post.get("text") or ""))
+        terms = extract_candidate_terms(
+            str(post.get("text") or ""),
+            excluded_handles=excluded_handles,
+        )
         normalized_existing = {n.lower() for n in existing_entity_names}
         unknown = [t for t in terms if t.lower() not in normalized_existing]
         if unknown:
@@ -283,6 +315,7 @@ def build_research_request(
     existing_entity_names: set[str] | None,
     operator_force: bool = False,
     lane_slug: str = CLAUDE_CODE_LANE_KEY,
+    excluded_handles: set[str] | None = None,
 ) -> ResearchRequest | None:
     """Create a ResearchRequest if research should fire; else None."""
     triggered, reasons = should_trigger_research(
@@ -290,10 +323,16 @@ def build_research_request(
         classifier_result=classifier_result,
         existing_entity_names=existing_entity_names,
         operator_force=operator_force,
+        excluded_handles=excluded_handles,
     )
     if not triggered:
         return None
-    terms = tuple(extract_candidate_terms(str(post.get("text") or "")))
+    terms = tuple(
+        extract_candidate_terms(
+            str(post.get("text") or ""),
+            excluded_handles=excluded_handles,
+        )
+    )
     return ResearchRequest(
         post_id=str(post.get("id") or "").strip(),
         tier=int(post.get("tier") or (classifier_result or {}).get("tier") or 0),
@@ -346,6 +385,57 @@ def candidate_urls_for_term(term: str, *, allowlist: list[str]) -> list[str]:
         seen.add(url)
         out.append(url)
     return out
+
+
+# ── SPA-404 shell detection ─────────────────────────────────────────────────
+#
+# docs.anthropic.com is a Next.js SPA. Every path returns HTTP 200 with the
+# same shell HTML — the actual 404 message renders client-side after JS
+# executes. The fetcher cannot tell the page is a 404 from the HTTP status
+# alone, so we post-validate the saved markdown for two telltale signs:
+#
+#   1. The extracted prose is tiny relative to the raw fetch (mostly CSS
+#      <link> tags and <script> bundles).
+#   2. The body contains the SPA marker attributes ``data-theme="claude"``
+#      or the literal "Page not found" string that the SPA renders inside
+#      <noscript> tags.
+
+_SPA_SHELL_MARKERS = (
+    'data-theme="claude"',
+    "<noscript>page not found",
+    "anthropic.com/_next/static",
+)
+
+# Minimum prose length (in characters) for a fetched grounding source to be
+# considered legitimate. Real documentation pages are easily >1k characters
+# of body text; SPA shells extract to ~200 chars of mostly-empty markup.
+_SPA_SHELL_MIN_BODY_CHARS = 600
+
+
+def _is_spa_404_shell(*, content_path: str, content_chars: int) -> bool:
+    """Return True when the fetched grounding source is a docs SPA 404 shell."""
+    if content_chars <= 0:
+        return False
+    if content_chars >= _SPA_SHELL_MIN_BODY_CHARS:
+        # Long bodies are almost always legitimate; cheap path out.
+        if not content_path:
+            return False
+    if not content_path:
+        return False
+    try:
+        body = Path(content_path).read_text(encoding="utf-8", errors="ignore")
+    except Exception:
+        return False
+    lowered = body.lower()
+    if any(marker in lowered for marker in _SPA_SHELL_MARKERS):
+        # When markers are present, also require the body to be short. The
+        # legitimate release-notes page also has Next.js markup but renders
+        # plenty of prose around it.
+        if content_chars < _SPA_SHELL_MIN_BODY_CHARS * 4:
+            return True
+    if content_chars < _SPA_SHELL_MIN_BODY_CHARS:
+        return True
+    return False
 
 
 # ── Fetch ────────────────────────────────────────────────────────────────────
@@ -417,14 +507,35 @@ def execute_research(
             result = {"ok": False, "error": str(exc)}
 
         if result.get("ok"):
+            content_path = str(result.get("path", ""))
+            content_chars = int(result.get("chars", 0))
+            if _is_spa_404_shell(content_path=content_path, content_chars=content_chars):
+                # The "fetched" body is the docs.anthropic.com SPA shell —
+                # what the synthesized URL actually points to is a 404. Drop
+                # the artifact off disk so the vault ingest can never pick it
+                # up and record the skip reason for the operator.
+                try:
+                    Path(content_path).unlink(missing_ok=True)
+                except Exception:
+                    pass
+                sources.append(
+                    ResearchSource(
+                        url=url,
+                        domain=_domain_of(url),
+                        allowlist_rank=rank,
+                        fetched=False,
+                        skip_reason="spa_404_shell",
+                    )
+                )
+                continue
             sources.append(
                 ResearchSource(
                     url=url,
                     domain=_domain_of(url),
                     allowlist_rank=rank,
                     fetched=True,
-                    content_path=str(result.get("path", "")),
-                    content_chars=int(result.get("chars", 0)),
+                    content_path=content_path,
+                    content_chars=content_chars,
                 )
             )
         else:

--- a/tests/unit/test_research_grounding.py
+++ b/tests/unit/test_research_grounding.py
@@ -279,3 +279,142 @@ def test_skipped_research_source_round_trip():
     record = src.to_enrichment_record()
     assert record.fetch_status == "skipped"
     assert "HTTP 404" in record.skip_reason
+
+
+# ── @-mention / hashtag filtering (regression for 2026-05-17 hallucination) ──
+
+
+def test_extract_candidate_terms_strips_at_mentions():
+    """@OniricSunset in a tweet must never produce a candidate term.
+
+    Before the fix the CamelCase regex consumed handles like
+    ``OniricSunset`` because ``\\b`` doesn't include ``@``, and downstream
+    URL synthesis emitted ``docs.anthropic.com/en/docs/oniricsunset``.
+    """
+    text = "@OniricSunset @ClaudeDevs Fix going out tomorrow."
+    terms = extract_candidate_terms(text)
+    lowered = {t.lower() for t in terms}
+    assert "oniricsunset" not in lowered
+    assert "claudedevs" not in lowered
+
+
+def test_extract_candidate_terms_strips_hashtags():
+    text = "#ClaudeCode is shipping #AgentSDK with #ToolStreaming"
+    terms = extract_candidate_terms(text)
+    lowered = {t.lower() for t in terms}
+    assert "claudecode" not in lowered
+    assert "agentsdk" not in lowered
+    assert "toolstreaming" not in lowered
+
+
+def test_extract_candidate_terms_strips_urls():
+    text = "Read the docs at https://example.com/SomeBigPath for details"
+    terms = extract_candidate_terms(text)
+    # The path slug must never become a research term.
+    assert "SomeBigPath" not in terms
+
+
+def test_extract_candidate_terms_respects_excluded_handles():
+    """Bare CamelCase matching a polled handle must be excluded."""
+    text = "Bcherny shipped a new release with NewCoolFeature"
+    terms = extract_candidate_terms(text, excluded_handles={"bcherny"})
+    lowered = {t.lower() for t in terms}
+    assert "bcherny" not in lowered
+    # Legit features still pass through.
+    assert any(t == "NewCoolFeature" for t in terms)
+
+
+def test_extract_candidate_terms_keeps_legitimate_camelcase():
+    """Real product terms must still be extracted after handle stripping."""
+    text = "@bcherny We shipped MemoryTool and FileExplorer for the Sonnet release"
+    terms = extract_candidate_terms(text)
+    assert "MemoryTool" in terms
+    assert "FileExplorer" in terms
+    assert "bcherny" not in {t.lower() for t in terms}
+
+
+def test_build_research_request_excludes_handles_from_synthesis(monkeypatch):
+    """The handle-stripping must flow through build_research_request."""
+    request = build_research_request(
+        post={
+            "id": "p1",
+            "tier": 4,
+            "links": [],
+            "text": "@OniricSunset @ClaudeDevs Fix going out tomorrow.",
+        },
+        classifier_result=None,
+        existing_entity_names=set(),
+        excluded_handles={"bcherny", "claudedevs"},
+    )
+    assert request is not None
+    lowered = {t.lower() for t in request.terms}
+    assert "oniricsunset" not in lowered
+    assert "claudedevs" not in lowered
+
+
+# ── SPA-404 shell detection ──────────────────────────────────────────────────
+
+
+def _make_spa_shell_file(tmp_path: Path, name: str = "shell.md") -> Path:
+    body = (
+        "# Source: https://docs.anthropic.com/en/docs/missing\n"
+        "<!DOCTYPE html><html class='h-screen' data-theme=\"claude\" data-mode='auto'>"
+        "<head><link rel='stylesheet' href='/_next/static/css/foo.css'/>"
+        "</head><body></body></html>\n"
+    )
+    path = tmp_path / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_is_spa_404_shell_detects_docs_anthropic_shell(tmp_path):
+    path = _make_spa_shell_file(tmp_path)
+    assert rg._is_spa_404_shell(content_path=str(path), content_chars=path.stat().st_size)
+
+
+def test_is_spa_404_shell_accepts_long_real_docs(tmp_path):
+    real_doc = tmp_path / "real.md"
+    real_doc.write_text(
+        "# Claude Code Release Notes\n\n"
+        + "This is a substantial release note describing concrete changes. "
+        * 200,
+        encoding="utf-8",
+    )
+    assert not rg._is_spa_404_shell(
+        content_path=str(real_doc), content_chars=real_doc.stat().st_size
+    )
+
+
+def test_is_spa_404_shell_handles_missing_file(tmp_path):
+    assert not rg._is_spa_404_shell(content_path="", content_chars=1000)
+    assert not rg._is_spa_404_shell(content_path=str(tmp_path / "nope.md"), content_chars=1000)
+
+
+def test_execute_research_drops_spa_shell_sources(tmp_path, monkeypatch):
+    """When fetch returns a SPA shell, the source must be marked skipped."""
+    request = ResearchRequest(
+        post_id="p1",
+        tier=4,
+        terms=("CoolFeature",),
+        reasons=(TriggerReason.UNKNOWN_TERM,),
+    )
+
+    written_files: list[Path] = []
+
+    def fake_fetch_url_content(url, category, output_dir, *, timeout=15):  # noqa: ARG001
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path = _make_spa_shell_file(output_dir, name=f"shell_{len(written_files)}.md")
+        written_files.append(path)
+        return {"ok": True, "path": str(path), "chars": path.stat().st_size}
+
+    monkeypatch.setattr(rg, "fetch_url_content", fake_fetch_url_content)
+
+    out = execute_research(request, output_dir=tmp_path, max_sources=2)
+    for source in out.sources:
+        assert source.fetched is False
+        assert source.skip_reason == "spa_404_shell"
+    # The shell artifacts must be cleaned off disk so the vault writer can't
+    # pick them up later.
+    for path in written_files:
+        assert not path.exists()


### PR DESCRIPTION
## Summary

- The deterministic candidate-URL synthesizer in `research_grounding` was slugifying CamelCase tokens from tweet text (including `@`-mentions) into fake `docs.anthropic.com` paths. The Next.js SPA serves the same 200 shell HTML for any path, so the fetcher persisted ~96 KiB of CSS/JS markup as a "Grounded source" and the vault index linked it as legitimate Claude Code intelligence.
- Two-layer fix: `extract_candidate_terms` pre-strips `@mentions`/`#tags`/URLs and accepts an `excluded_handles` set populated by `apply_research_grounding_pass` (polled handles + manifest handle); `_is_spa_404_shell` post-validates fetched bodies and drops shell-only artifacts (also unlinking them on disk).
- New one-shot cleanup script `csi_vault_cleanup_grounding_hallucinations.py` quarantines pre-existing hallucinations in the vault + per-packet research_grounding dirs. Idempotent, `--dry-run` first.

## Trace

End-to-end trace of the 2026-05-17 21:00 UTC `@bcherny` run identified this hallucination as the highest-impact bug in an otherwise-correct lane. The triage flyout (`demo_triage_candidates`) caught the two legitimate tier-4 candidates; the corrupted "Grounded source" pages were the only material defect.

## Test plan

- [x] `uv run pytest tests/unit/test_research_grounding.py` — 34 pass (including 7 new regression cases)
- [x] `uv run pytest tests/unit/test_csi_research_grounding_wiring.py` — 9 pass
- [x] `uv run ruff check --select E9,F --ignore E402,F401,F541,F811,F841 <changed files>` — clean
- [x] `uv run python -m py_compile <changed files>` — clean
- [ ] Post-deploy on VPS: run `uv run python -m universal_agent.scripts.csi_vault_cleanup_grounding_hallucinations --dry-run` and report move count; then drop `--dry-run` to apply.
- [ ] Next bcherny cron tick: verify `research_grounding.json` no longer contains `oniricsunset`-style URLs.

## Follow-ups (separate PRs)

1. t.co → x.com self-reference fetcher (`csi_url_judge` already has `_fetch_tweet_via_x_api`; need to dispatch instead of skip)
2. Tier-1 vault-write minimum-signal gate (filter the chatter replies)
3. Replay summary `wiki_pages` duplicate count audit