### PR TITLE
fix(cleanup): sweep true orphan worktree dirs

### DIFF
--- a/scripts/end_session_cleanup.sh
+++ b/scripts/end_session_cleanup.sh
@@ -110,6 +110,35 @@ fi
 git worktree prune
 
 # ---------------------------------------------------------------------------
+# Step 1b — sweep true orphan dirs (.git link severed, git has no record)
+#
+# A directory under .claude/worktrees/ that (a) is NOT in `git worktree list`
+# AND (b) has no .git file/link inside it cannot possibly hold trackable work
+# — git has no idea it exists. The IDE's Source Control panel may still
+# discover it via filesystem scan and inflate the "changed files" count to
+# the thousands. Safe to remove.
+# ---------------------------------------------------------------------------
+if [ -d "$REPO_ROOT/.claude/worktrees" ]; then
+  known_worktrees=$(git worktree list --porcelain | awk '/^worktree / {print $2}')
+  for wt in "$REPO_ROOT"/.claude/worktrees/*/; do
+    [ -d "$wt" ] || continue
+    wt_path="${wt%/}"
+    if [ "$wt_path" = "$SELF_WORKTREE" ]; then
+      continue
+    fi
+    if echo "$known_worktrees" | grep -qxF "$wt_path"; then
+      continue
+    fi
+    if [ -e "$wt_path/.git" ]; then
+      log "orphan candidate $wt_path has a .git link git doesn't recognise — keeping (manual review)"
+      continue
+    fi
+    log "orphan dir $wt_path has no .git link and is unknown to git — removing"
+    rm -rf "$wt_path" 2>&1 | sed 's/^/  /' || true
+  done
+fi
+
+# ---------------------------------------------------------------------------
 # Step 2 — get the parent checkout back on main if its branch is merged
 # ---------------------------------------------------------------------------
 current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary
- `just cleanup` / `scripts/end_session_cleanup.sh` only iterates worktrees that git still knows about. When a worktree dir is left on disk *after* its `.git` link is severed (a partial cleanup, a crashed session), nothing reaps it — and Antigravity's Source Control panel discovers it via filesystem scan, inflating the "changed files" count into the thousands.
- Add Step 1b: scan `.claude/worktrees/*/` directly, drop any dir that is (a) unknown to `git worktree list` AND (b) has no `.git` file/link. Preserves both safety rails (skip the active session's own worktree, skip dirs whose `.git` link git just doesn't recognise).

## Test plan
- [x] `bash -n scripts/end_session_cleanup.sh` (syntax)
- [x] Synthetic-orphan test: created `.claude/worktrees/fake-orphan-test/` with no `.git`, ran patched script — script logged "orphan dir ... — removing" and removed it; live worktree `claude+cleanup-orphan-sweep` was correctly skipped via the active-session guard.
- [ ] Operator: next Stop-hook firing (or `just cleanup` invocation) should pass through cleanly with no regression on real worktrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)