### PR TITLE
fix(csi): reject raw-HTML grounding sources when defuddle is missing

### DIFF
--- a/src/universal_agent/services/csi_url_judge.py
+++ b/src/universal_agent/services/csi_url_judge.py
@@ -556,7 +556,14 @@ def _fetch_with_defuddle(url: str, output_path: Path, timeout: int) -> dict[str,
 
 
 def _fetch_with_httpx(url: str, output_path: Path, timeout: int) -> dict[str, Any]:
-    """Fallback: fetch with httpx and save raw content."""
+    """Fallback: fetch with httpx and save raw content.
+
+    Note: this writes the raw HTML response body to disk. Downstream consumers
+    that expect extracted markdown (e.g. research_grounding) must validate the
+    body — see research_grounding._looks_like_raw_html. When defuddle is
+    unavailable on the host (no ``npx``/``defuddle-cli``), every URL falls
+    through this path and the saved file is HTML markup, not prose.
+    """
     try:
         with httpx.Client(timeout=timeout, follow_redirects=True) as client:
             resp = client.get(url, headers={
@@ -570,6 +577,16 @@ def _fetch_with_httpx(url: str, output_path: Path, timeout: int) -> dict[str, An
                 if len(text) > cap:
                     text = text[:cap] + f"\n\n... [Content truncated at {cap} chars]"
                 output_path.write_text(f"# Source: {url}\n\n{text}", encoding="utf-8")
+                # Operator-visible signal: when this fires for every URL on a
+                # host, defuddle is missing or broken and downstream consumers
+                # are getting raw HTML they need to validate themselves.
+                if "<!doctype html>" in text[:2048].lower():
+                    logger.warning(
+                        "csi_url_judge._fetch_with_httpx: defuddle fallback saved raw HTML for %s "
+                        "(file=%s). Downstream consumers must validate this is not markup-only content.",
+                        url,
+                        output_path,
+                    )
                 return {"ok": True, "path": str(output_path), "method": "httpx", "chars": len(text)}
             return {"ok": False, "error": f"HTTP {resp.status_code}"}
     except httpx.TimeoutException:

--- a/src/universal_agent/services/research_grounding.py
+++ b/src/universal_agent/services/research_grounding.py
@@ -387,18 +387,25 @@ def candidate_urls_for_term(term: str, *, allowlist: list[str]) -> list[str]:
     return out
 
 
-# ── SPA-404 shell detection ─────────────────────────────────────────────────
+# ── Unusable-grounding-source detection ─────────────────────────────────────
 #
-# docs.anthropic.com is a Next.js SPA. Every path returns HTTP 200 with the
-# same shell HTML — the actual 404 message renders client-side after JS
-# executes. The fetcher cannot tell the page is a 404 from the HTTP status
-# alone, so we post-validate the saved markdown for two telltale signs:
+# Two failure modes the grounding fetcher can produce:
 #
-#   1. The extracted prose is tiny relative to the raw fetch (mostly CSS
-#      <link> tags and <script> bundles).
-#   2. The body contains the SPA marker attributes ``data-theme="claude"``
-#      or the literal "Page not found" string that the SPA renders inside
-#      <noscript> tags.
+#   1. SPA 404 shell. docs.anthropic.com is a Next.js SPA — every path
+#      returns HTTP 200 with the same shell HTML and renders the 404 only
+#      after JS executes. ``data-theme="claude"`` and ``_next/static``
+#      markers identify it.
+#   2. Raw HTML dump. ``csi_url_judge._fetch_with_httpx`` saves the response
+#      body straight into a ``.md`` file when ``defuddle`` is unavailable on
+#      the host. The saved file is 200KB of ``<!DOCTYPE html>``, ``<link>``
+#      tags, and JS bundles with little or no prose. This happens on the
+#      VPS where the defuddle CLI is not installed, so EVERY grounded
+#      source ends up as a raw HTML dump regardless of whether the URL was
+#      a real docs page or an SPA 404.
+#
+# Both cases are unusable as grounding context for the LLM (and worse,
+# poison the vault if ingested), so we reject them with the same predicate
+# and let the operator/cleanup script quarantine them.
 
 _SPA_SHELL_MARKERS = (
     'data-theme="claude"',
@@ -411,21 +418,65 @@ _SPA_SHELL_MARKERS = (
 # of body text; SPA shells extract to ~200 chars of mostly-empty markup.
 _SPA_SHELL_MIN_BODY_CHARS = 600
 
+# When fetched content is raw HTML masquerading as markdown, the file
+# typically opens with a ``# Source: <url>`` line written by the fetcher
+# followed almost immediately by a ``<!DOCTYPE html>`` declaration. Real
+# defuddle-extracted markdown never contains DOCTYPE in the header.
+_RAW_HTML_HEADER_MARKERS = (
+    "<!doctype html>",
+    "<html ",
+    "<html>",
+    "<html\n",
+)
+
+# When inspecting an arbitrary 1KB slice of body, this many HTML-tag
+# fragments strongly suggests we're looking at raw markup, not prose.
+_RAW_HTML_TAG_DENSITY_THRESHOLD = 8
+
+
+def _looks_like_raw_html(body: str) -> bool:
+    """Return True when the saved body is raw HTML rather than extracted prose.
+
+    Independent of size — a 200KB raw-HTML dump and a 2KB raw-HTML stub
+    both qualify. The fetcher pipeline expects extracted markdown; HTML
+    markup landing on disk means defuddle silently failed and httpx fell
+    through to writing the raw response body.
+    """
+    if not body:
+        return False
+    lowered = body.lower()
+    # Examine the first ~2KB so we ignore any spurious HTML appearing inside
+    # legitimate markdown code blocks deep in the document.
+    head = lowered[:2048]
+    if any(marker in head for marker in _RAW_HTML_HEADER_MARKERS):
+        return True
+    # Tag-density check on the same head slice. Real markdown rarely has
+    # more than a handful of HTML tags; raw documents have hundreds.
+    tag_hits = head.count("<link ") + head.count("<script") + head.count("<meta ")
+    if tag_hits >= _RAW_HTML_TAG_DENSITY_THRESHOLD:
+        return True
+    return False
+
 
 def _is_spa_404_shell(*, content_path: str, content_chars: int) -> bool:
-    """Return True when the fetched grounding source is a docs SPA 404 shell."""
+    """Return True when the fetched grounding source is unusable.
+
+    Despite the legacy name (kept stable for the cleanup script), this
+    predicate now also catches raw HTML dumps, since both failure modes
+    poison the vault identically.
+    """
     if content_chars <= 0:
         return False
-    if content_chars >= _SPA_SHELL_MIN_BODY_CHARS:
-        # Long bodies are almost always legitimate; cheap path out.
-        if not content_path:
-            return False
     if not content_path:
         return False
     try:
         body = Path(content_path).read_text(encoding="utf-8", errors="ignore")
     except Exception:
         return False
+    # Raw HTML masquerading as markdown — common when defuddle is
+    # unavailable. Independent of size.
+    if _looks_like_raw_html(body):
+        return True
     lowered = body.lower()
     if any(marker in lowered for marker in _SPA_SHELL_MARKERS):
         # When markers are present, also require the body to be short. The

--- a/tests/unit/test_research_grounding.py
+++ b/tests/unit/test_research_grounding.py
@@ -390,6 +390,65 @@ def test_is_spa_404_shell_handles_missing_file(tmp_path):
     assert not rg._is_spa_404_shell(content_path=str(tmp_path / "nope.md"), content_chars=1000)
 
 
+# ── Raw-HTML dump detection (regression for 200KB httpx fallback bug) ────────
+
+
+def test_is_spa_404_shell_detects_large_raw_html_dump(tmp_path):
+    """200KB raw HTML — what httpx writes when defuddle is unavailable."""
+    path = tmp_path / "dump.md"
+    body = (
+        "# Source: https://docs.anthropic.com/en/release-notes/claude-code\n\n"
+        "<!DOCTYPE html>\n"
+        "<html lang='en' data-color-mode='auto'>\n"
+        "<head>\n"
+        + "\n".join(
+            f"<link rel='stylesheet' href='https://example.com/static/{i}.css'/>"
+            for i in range(200)
+        )
+        + "\n</head>\n<body>"
+        + ("legitimate prose " * 5000)
+        + "</body></html>\n"
+    )
+    path.write_text(body, encoding="utf-8")
+    assert rg._is_spa_404_shell(content_path=str(path), content_chars=path.stat().st_size)
+
+
+def test_is_spa_404_shell_detects_html_via_tag_density(tmp_path):
+    """No DOCTYPE but a flood of <link>/<script>/<meta> tags up top."""
+    path = tmp_path / "dense.md"
+    header_tags = "\n".join(
+        f"<link rel='stylesheet' href='/a/{i}.css'/>" for i in range(20)
+    )
+    body = f"# Source: https://github.com/x/y\n\n{header_tags}\n\n" + ("a " * 2000)
+    path.write_text(body, encoding="utf-8")
+    assert rg._is_spa_404_shell(content_path=str(path), content_chars=path.stat().st_size)
+
+
+def test_is_spa_404_shell_accepts_legitimate_markdown(tmp_path):
+    """Real defuddle-extracted markdown must pass through unmolested."""
+    path = tmp_path / "real.md"
+    path.write_text(
+        "# Source: https://docs.anthropic.com/en/release-notes/claude-code\n\n"
+        "## v2.1.139 — 2026-05-11\n\n"
+        "- Added the `claude agents` subcommand for session-roster management.\n"
+        "- Fixed an issue where the agent panel would lose focus on resize.\n\n"
+        + ("Detailed release-note prose. " * 200),
+        encoding="utf-8",
+    )
+    assert not rg._is_spa_404_shell(content_path=str(path), content_chars=path.stat().st_size)
+
+
+def test_looks_like_raw_html_unit():
+    assert rg._looks_like_raw_html("# Source: x\n\n<!DOCTYPE html>\n<html>\n")
+    assert rg._looks_like_raw_html("<HTML lang='en'><head><title>x</title></head>")
+    # Markdown that mentions ``<html>`` only inline (backticked, not the literal
+    # opening tag form ``<html `` or ``<html>`` at line start) should not flag.
+    assert not rg._looks_like_raw_html(
+        "# Real Docs\n\nSome prose about the HTML5 spec; nothing to see here.\n"
+    )
+    assert not rg._looks_like_raw_html("")
+
+
 def test_execute_research_drops_spa_shell_sources(tmp_path, monkeypatch):
     """When fetch returns a SPA shell, the source must be marked skipped."""
     request = ResearchRequest(


### PR DESCRIPTION
## Summary

- Follow-up to #329. The earlier SPA-404 detector only flagged short bodies; on the VPS where defuddle is unavailable, `csi_url_judge._fetch_with_httpx` writes the raw HTML response body straight into a `.md` file. The 2026-05-17 `@bcherny` packet produced nine 200KB raw-HTML "grounded sources" that poisoned the vault.
- Hardened `_is_spa_404_shell` with a content-based check: any saved body whose first 2KB contains `<!DOCTYPE` / `<html` or has high `<link>/<script>/<meta>` tag density is rejected — independent of size.
- Added a `logger.warning` in `_fetch_with_httpx` when the saved body looks like raw HTML, so operators get per-URL visibility that defuddle is missing on the host.

## Why we don't fix defuddle right here

The fetcher saving raw HTML is the upstream root cause but it affects all linked-source consumers across all CSI lanes. That's a broader blast radius than this hotfix should carry. The warning log gives us the signal to plan a clean fix in a separate PR — either installing defuddle on the VPS, or having `_fetch_with_httpx` strip HTML to text before saving.

## Test plan

- [x] `uv run pytest tests/unit/test_research_grounding.py` — 38 pass (4 new)
- [x] `uv run ruff check --select E9,F --ignore E402,F401,F541,F811,F841 …` — clean
- [ ] After deploy: re-run `csi_vault_cleanup_grounding_hallucinations --dry-run` on the VPS — should now flag the nine 2026-05-17 grounded sources (and any others from older packets).
- [ ] Next bcherny cron tick: `research_grounding.json` should show `fetch_status: "skipped"` with `skip_reason: "spa_404_shell"` for every grounded source until defuddle is fixed upstream.

## Follow-ups

1. Move 2 (t.co → x.com self-reference fetcher) — separate PR
2. Move 3 (tier-1 vault-write min-signal gate) — separate PR
3. Operator triage: install defuddle on the VPS OR replace httpx fallback with text-extracted output