### PR TITLE
fix(csi): defuddle-cli 'parse --markdown' argv + regression test

### DIFF
--- a/src/universal_agent/services/csi_url_judge.py
+++ b/src/universal_agent/services/csi_url_judge.py
@@ -526,17 +526,32 @@ def _safe_filename(url: str, category: str) -> str:
     return f"{name}.md"
 
 
+_DEFUDDLE_CLI_ARGV = ("npx", "-y", "defuddle-cli@latest", "parse", "--markdown")
+"""Canonical defuddle-cli invocation.
+
+The CLI requires a ``parse`` subcommand (URL as positional source) and a
+``--markdown`` flag. Without the subcommand the CLI silently fails with
+``error: unknown command``, which the legacy invocation triggered for every
+URL — every fetch fell through to the raw-HTML httpx fallback. See PR #332
+and the regression test in ``tests/unit/test_research_grounding.py``.
+"""
+
+
 def _fetch_with_defuddle(url: str, output_path: Path, timeout: int) -> dict[str, Any]:
     """Try to fetch and convert to markdown using defuddle CLI."""
     try:
         result = sp.run(
-            ["npx", "-y", "defuddle-cli@latest", url],
+            [*_DEFUDDLE_CLI_ARGV, url],
             capture_output=True,
             text=True,
             timeout=timeout + 10,
             env={**os.environ, "NODE_NO_WARNINGS": "1"},
         )
         if result.returncode == 0 and result.stdout.strip():
+            # ``parse --markdown`` emits markdown directly, but defuddle has
+            # historically also exposed a ``--json`` mode whose payload wraps
+            # the content. Keep the JSON-decode try block as defensive
+            # parsing in case the CLI ever flips its default.
             try:
                 data = json.loads(result.stdout)
                 content = data.get("content") or data.get("markdown") or result.stdout

--- a/tests/unit/test_claude_code_intel_replay.py
+++ b/tests/unit/test_claude_code_intel_replay.py
@@ -217,6 +217,13 @@ def test_replay_fetches_linked_sources_and_writes_metadata(monkeypatch, tmp_path
 
 
 def test_replay_skips_tco_redirects_into_browser_gated_x_pages(monkeypatch, tmp_path: Path) -> None:
+    # Research grounding (PR 16) fires for tier-2 actions whose linked sources
+    # are thin — it would fetch additional grounded sources here and ingest
+    # them as `linked_source_*` pages, defeating the assertion below. The
+    # grounding behavior is exercised in `test_csi_research_grounding_wiring`;
+    # this test focuses on the t.co → x.com skip path, so isolate it.
+    monkeypatch.setenv("UA_CSI_RESEARCH_GROUNDING_WIRING_ENABLED", "0")
+
     calls: list[tuple[str, str]] = []
 
     def fake_ingest(*, vault_slug: str, source_title: str, source_content: str, source_id: str | None = None, root_override: str | None = None):

--- a/tests/unit/test_csi_url_judge_defuddle_argv.py
+++ b/tests/unit/test_csi_url_judge_defuddle_argv.py
@@ -1,0 +1,150 @@
+"""Regression tests for the defuddle-cli subprocess invocation.
+
+The CLI silently fails with ``error: unknown command`` when the ``parse``
+subcommand is omitted. That regression went unnoticed for months because
+the function returns ``{"ok": False}`` on any subprocess failure and the
+fetcher falls through to the raw-HTML httpx fallback — every URL still
+"worked" from the caller's perspective.
+
+These tests pin the canonical argv so future refactors can't silently
+break it again, and exercise both the JSON-output and markdown-output
+code paths.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from universal_agent.services import csi_url_judge as cuj
+
+
+class _FakeCompletedProcess:
+    def __init__(self, *, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _patch_sp_run(monkeypatch: pytest.MonkeyPatch, *, stdout: str, returncode: int = 0):
+    """Patch subprocess.run inside csi_url_judge and capture the argv."""
+    captured: dict[str, Any] = {}
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        captured["argv"] = list(argv)
+        captured["kwargs"] = kwargs
+        return _FakeCompletedProcess(stdout=stdout, returncode=returncode)
+
+    monkeypatch.setattr(cuj.sp, "run", fake_run)
+    return captured
+
+
+def test_defuddle_argv_includes_parse_subcommand(monkeypatch, tmp_path):
+    """Regression: defuddle-cli requires the ``parse`` subcommand.
+
+    Without it, the CLI fails with ``error: unknown command``. The legacy
+    invocation passed the URL straight as the first positional and silently
+    failed for every URL.
+    """
+    captured = _patch_sp_run(monkeypatch, stdout="# Real Markdown\n\nsome prose\n")
+    out_path = tmp_path / "out.md"
+
+    result = cuj._fetch_with_defuddle(
+        "https://example.com/article", out_path, timeout=15
+    )
+    assert result["ok"] is True
+
+    argv = captured["argv"]
+    assert argv[:3] == ["npx", "-y", "defuddle-cli@latest"], (
+        f"npx invocation drifted: argv={argv!r}"
+    )
+    # The CRITICAL assertion: 'parse' must be present before the URL.
+    assert "parse" in argv, f"missing 'parse' subcommand: argv={argv!r}"
+    parse_index = argv.index("parse")
+    url_index = argv.index("https://example.com/article")
+    assert parse_index < url_index, (
+        f"'parse' must precede the URL positional: argv={argv!r}"
+    )
+
+
+def test_defuddle_argv_requests_markdown_output(monkeypatch, tmp_path):
+    """The CLI defaults to HTML output; we need explicit --markdown."""
+    captured = _patch_sp_run(monkeypatch, stdout="# Markdown\n\nbody\n")
+    cuj._fetch_with_defuddle(
+        "https://example.com/x", tmp_path / "x.md", timeout=15
+    )
+    argv = captured["argv"]
+    assert "--markdown" in argv or "--md" in argv, (
+        f"defuddle invocation must request markdown output: argv={argv!r}"
+    )
+
+
+def test_defuddle_argv_constant_matches_invocation(monkeypatch, tmp_path):
+    """The module-level _DEFUDDLE_CLI_ARGV constant must be what we ship."""
+    captured = _patch_sp_run(monkeypatch, stdout="# x\n")
+    cuj._fetch_with_defuddle(
+        "https://example.com/y", tmp_path / "y.md", timeout=15
+    )
+    expected_prefix = list(cuj._DEFUDDLE_CLI_ARGV)
+    assert captured["argv"][: len(expected_prefix)] == expected_prefix
+
+
+def test_defuddle_markdown_stdout_is_saved_verbatim(monkeypatch, tmp_path):
+    """When the CLI returns markdown, the saved file should contain it."""
+    md = "# Title\n\nReal prose paragraph with sentences.\n"
+    _patch_sp_run(monkeypatch, stdout=md)
+    out_path = tmp_path / "article.md"
+
+    result = cuj._fetch_with_defuddle(
+        "https://example.com/article", out_path, timeout=15
+    )
+    assert result["ok"] is True
+    body = out_path.read_text(encoding="utf-8")
+    assert body.startswith("# Source: https://example.com/article")
+    assert "Real prose paragraph with sentences." in body
+
+
+def test_defuddle_json_stdout_unwraps_content(monkeypatch, tmp_path):
+    """Defensive: if the CLI ever flips back to JSON-by-default, unwrap it."""
+    payload = json.dumps(
+        {"content": "# Wrapped\n\nprose", "title": "Article", "domain": "example.com"}
+    )
+    _patch_sp_run(monkeypatch, stdout=payload)
+    out_path = tmp_path / "json.md"
+
+    result = cuj._fetch_with_defuddle(
+        "https://example.com/wrapped", out_path, timeout=15
+    )
+    assert result["ok"] is True
+    body = out_path.read_text(encoding="utf-8")
+    assert "# Wrapped" in body
+    assert "prose" in body
+    # The raw JSON envelope must not leak into the saved file.
+    assert '"title"' not in body
+
+
+def test_defuddle_nonzero_returncode_returns_not_ok(monkeypatch, tmp_path):
+    """A failing CLI invocation must surface as ok=False, not save garbage."""
+    _patch_sp_run(monkeypatch, stdout="", returncode=1)
+    out_path = tmp_path / "fail.md"
+    result = cuj._fetch_with_defuddle(
+        "https://example.com/", out_path, timeout=15
+    )
+    assert result == {"ok": False}
+    assert not out_path.exists()
+
+
+def test_defuddle_missing_npx_returns_not_ok(monkeypatch, tmp_path):
+    """If npx is missing on the host, function returns ok=False cleanly."""
+
+    def raise_filenotfound(argv, **kwargs):  # type: ignore[no-untyped-def]
+        raise FileNotFoundError("npx not on PATH")
+
+    monkeypatch.setattr(cuj.sp, "run", raise_filenotfound)
+    result = cuj._fetch_with_defuddle(
+        "https://example.com/", tmp_path / "x.md", timeout=15
+    )
+    assert result == {"ok": False}


### PR DESCRIPTION
## Summary

Root-cause fix that #332 missed because auto-merge fired before this commit pushed.

The defuddle CLI requires a `parse` subcommand (URL is the positional source) and `--markdown` for markdown output. The legacy invocation called `npx -y defuddle-cli@latest <url>` which the CLI rejects with `error: unknown command`. `_fetch_with_defuddle` returned `{ok: False}` and the fetcher silently fell through to the raw-HTML httpx fallback — every URL on the VPS has been writing 200KB of HTML markup to disk for months.

Fix: pass `parse --markdown` as the canonical argv, hoisted into a module-level `_DEFUDDLE_CLI_ARGV` constant.

## Regression test

`tests/unit/test_csi_url_judge_defuddle_argv.py` (7 cases) pins the argv shape so a future "let me clean up that subprocess call" can't silently drop `parse` again. This is the test you correctly asked for — it catches exactly the silent-CLI-breakage class of failure that lay undetected.

## Test plan

- [x] `uv run pytest tests/unit/test_csi_url_judge_defuddle_argv.py tests/unit/test_research_grounding.py` — 45 pass
- [x] `uv run ruff check …` — clean
- [x] Manual VPS verification: `npx -y defuddle-cli@latest parse --markdown https://github.com/anthropics/claude-agent-sdk-python` returns real extracted markdown
- [ ] After deploy: re-run `csi_vault_cleanup_grounding_hallucinations --dry-run` on VPS to confirm historical hallucinations get flagged; then drop `--dry-run` to apply
- [ ] Next bcherny cron tick: `research_grounding.json` shows `fetch_status: "fetched"` with REAL markdown content, not 200KB HTML dumps