### PR TITLE
fix(ui): wrap long completed-card titles in todolist

### DIFF
--- a/web-ui/app/dashboard/todolist/page.tsx
+++ b/web-ui/app/dashboard/todolist/page.tsx
@@ -1551,7 +1551,7 @@ export default function ToDoListDashboardPage() {
         <div className="flex items-start justify-between gap-2 pr-6">
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-1.5 mb-1">{sourceKindPill(item.source_kind)}</div>
-            <h3 className="text-[13px] font-semibold text-kcd-text truncate m-0">
+            <h3 className="text-[13px] font-semibold text-kcd-text leading-snug m-0 break-words">
               {(() => {
                 const href = item.links?.session_href || taskSourceUrl(item.task_id, item.source_kind, undefined, item.source_ref);
                 if (href) {


### PR DESCRIPTION
## Summary
- The COMPLETED column in **Task Hub → Todolist** clipped long card titles to a single line with an ellipsis. Long tutorial titles (e.g. \"Build private tutorial repo: Microsoft's New Multi-Agent Orchestration Framework Magentic-One Released Today\") were unreadable.
- Replaced \`truncate\` with \`leading-snug … break-words\` on the completed-card \`<h3>\` at \`web-ui/app/dashboard/todolist/page.tsx:1554\` so titles wrap, matching the styling already used by cards in the other Task Hub columns (\`web-ui/app/dashboard/todolist/page.tsx:1221\`).

## Test plan
- [x] Visual regression via Playwright: started \`next dev\` on :3456 in the worktree, mocked \`/api/v1/dashboard/todolist/{overview,agent-queue,agent-activity,completed}\`, rendered the page with a long-title fixture, and confirmed:
  - The rendered \`<h3>\` has \`clientHeight=107px\` / \`scrollHeight=107px\` (equal → no overflow clipping)
  - Classes resolved to \`text-[13px] font-semibold text-kcd-text leading-snug m-0 break-words\`
  - Full title text rendered across 7 wrapped lines, no ellipsis
- [ ] Operator: confirm visually on production after deploy by checking the COMPLETED column at \`/dashboard/todolist\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)