### PR TITLE
feat(csi): fetch x.com tweet self-references via X API instead of skipping

### DIFF
--- a/src/universal_agent/services/claude_code_intel_replay.py
+++ b/src/universal_agent/services/claude_code_intel_replay.py
@@ -1317,6 +1317,77 @@ def _load_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def _try_x_api_tweet_self_ref(
+    *, final_url: str, entry: dict[str, Any], source_dir: Path, timeout: int = 15
+) -> tuple[str, dict[str, Any]] | None:
+    """Try to fetch a redirected-to x.com tweet via the X API.
+
+    When a t.co (or other) link resolves to ``x.com/<handle>/status/<id>``,
+    the standard browser-style fetch returns the JavaScript-gated SPA chrome
+    and the link gets marked ``browser_gated_x_page``. But this lane already
+    has X API credentials for polling the canonical handles — fetching one
+    referenced tweet via ``/2/tweets/{id}`` is the same API call that built
+    the rest of the packet. Surfacing the tweet body is the entire point of
+    a strategic-follow-up signal.
+
+    Returns ``(content, metadata)`` on success, or ``None`` if the URL is
+    not a tweet status URL OR the X API path fails. On ``None`` the caller
+    falls through to the legacy skip path so nothing regresses.
+
+    Off switch: ``UA_CSI_LINKED_X_SELF_REF_ENABLED=0``.
+    """
+    if str(os.getenv("UA_CSI_LINKED_X_SELF_REF_ENABLED") or "1").strip().lower() in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }:
+        return None
+    try:
+        from universal_agent.services.csi_url_judge import (
+            _fetch_tweet_via_x_api,
+            parse_tweet_id_from_url,
+        )
+    except Exception:
+        return None
+    tweet_id = parse_tweet_id_from_url(final_url)
+    if not tweet_id:
+        return None
+    try:
+        record = _fetch_tweet_via_x_api(
+            final_url, tweet_id, source_dir, timeout=timeout
+        )
+    except Exception:
+        return None
+    if str(record.fetch_status or "") != "fetched":
+        return None
+    content_path = str(record.content_path or "").strip()
+    if not content_path:
+        return None
+    try:
+        content = Path(content_path).read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return None
+    if not content.strip():
+        return None
+    metadata: dict[str, Any] = {
+        "url": entry.get("url") or final_url,
+        "final_url": final_url,
+        "post_id": entry.get("post_id") or "",
+        "tier": int(entry.get("tier") or 0),
+        "action_type": entry.get("action_type") or "",
+        "content_type": "text/markdown",
+        "http_status": 200,
+        "source_type": "x_tweet",
+        "domain": "x.com",
+        "tweet_id": tweet_id,
+        "title": f"x.com tweet {tweet_id}",
+        "fetch_method": "x_api_self_ref",
+        "summary_excerpt": _summary_excerpt(content),
+    }
+    return content, metadata
+
+
 def _fetch_linked_source(*, client: httpx.Client, url: str, entry: dict[str, Any], source_dir: Path) -> None:
     metadata: dict[str, Any] = {
         "url": url,
@@ -1340,6 +1411,29 @@ def _fetch_linked_source(*, client: httpx.Client, url: str, entry: dict[str, Any
             entry["fetch_status"] = "error"
             entry["error"] = f"HTTP {resp.status_code}"
         elif skip_reason := _detect_unusable_link_capture(url=str(resp.url), body=body, metadata=metadata):
+            # Before accepting the skip, try the X API self-reference path for
+            # tweet status URLs. The lane already has the auth that handles
+            # this; the legacy skip would lose strategic-follow-up signal.
+            x_self_ref = _try_x_api_tweet_self_ref(
+                final_url=str(resp.url), entry=entry, source_dir=source_dir
+            )
+            if x_self_ref is not None:
+                content, x_metadata = x_self_ref
+                metadata.update(x_metadata)
+                entry["title"] = metadata.get("title") or entry.get("title")
+                entry["fetch_status"] = "fetched"
+                entry["skip_reason"] = ""
+                analysis = _linked_source_analysis(
+                    entry=entry, content=content, metadata=metadata
+                )
+                _write_linked_source_files(
+                    source_dir=source_dir,
+                    entry=entry,
+                    content=content,
+                    analysis=analysis,
+                    metadata=metadata,
+                )
+                return
             entry["fetch_status"] = "skipped"
             entry["skip_reason"] = skip_reason
             analysis = _linked_source_analysis(entry=entry, content="", metadata=metadata)

--- a/tests/unit/test_replay_x_self_ref.py
+++ b/tests/unit/test_replay_x_self_ref.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 
 from universal_agent.services import claude_code_intel_replay as ccir
+from universal_agent.services import csi_url_judge as cuj  # noqa: F401 — imported so monkeypatch can resolve submodule attrs
 
 
 class _StubXApiRecord:

--- a/tests/unit/test_replay_x_self_ref.py
+++ b/tests/unit/test_replay_x_self_ref.py
@@ -1,0 +1,240 @@
+"""Tests for the t.co → x.com self-reference fetch path.
+
+When a tweet links to another tweet via a t.co shortlink (or directly to
+x.com), the browser-style fetch returns the JS-gated SPA chrome and the
+link is skipped as ``browser_gated_x_page``. This path dispatches to the
+X API ``/2/tweets/{id}`` endpoint so the referenced tweet's body becomes
+real grounded content instead of being silently dropped.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from universal_agent.services import claude_code_intel_replay as ccir
+
+
+class _StubXApiRecord:
+    """Mimics a successful csi_url_judge.EnrichmentRecord."""
+
+    def __init__(self, *, content_path: str, content_chars: int = 200) -> None:
+        self.fetch_status = "fetched"
+        self.content_path = content_path
+        self.content_chars = content_chars
+        self.skip_reason = ""
+
+
+def _write_tweet_md(tmp_path: Path, *, tweet_id: str, text: str) -> Path:
+    path = tmp_path / f"tweet_{tweet_id}.md"
+    path.write_text(
+        f"# Tweet: https://x.com/bcherny/status/{tweet_id}\n\n"
+        f"- **Author**: bcherny\n\n---\n\n{text}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_try_x_api_tweet_self_ref_disabled_by_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("UA_CSI_LINKED_X_SELF_REF_ENABLED", "0")
+    assert (
+        ccir._try_x_api_tweet_self_ref(
+            final_url="https://x.com/bcherny/status/123",
+            entry={"url": "https://t.co/abc", "tier": 4, "post_id": "p1"},
+            source_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_try_x_api_tweet_self_ref_returns_none_for_non_tweet_urls(monkeypatch, tmp_path):
+    """A x.com URL that isn't /status/<id> must not be misrouted."""
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
+        lambda url: None,
+    )
+    assert (
+        ccir._try_x_api_tweet_self_ref(
+            final_url="https://x.com/bcherny",
+            entry={"url": "https://t.co/abc", "tier": 4, "post_id": "p1"},
+            source_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_try_x_api_tweet_self_ref_success(monkeypatch, tmp_path):
+    """Happy path: tweet ID parsed, X API returns fetched, content returned."""
+    tweet_md = _write_tweet_md(tmp_path, tweet_id="999", text="Real tweet body prose.")
+
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
+        lambda url: "999",
+    )
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        lambda url, tweet_id, source_dir, *, timeout: _StubXApiRecord(
+            content_path=str(tweet_md), content_chars=tweet_md.stat().st_size
+        ),
+    )
+
+    result = ccir._try_x_api_tweet_self_ref(
+        final_url="https://x.com/bcherny/status/999",
+        entry={"url": "https://t.co/abc", "tier": 4, "post_id": "p1"},
+        source_dir=tmp_path,
+    )
+    assert result is not None
+    content, metadata = result
+    assert "Real tweet body prose." in content
+    assert metadata["fetch_method"] == "x_api_self_ref"
+    assert metadata["source_type"] == "x_tweet"
+    assert metadata["tweet_id"] == "999"
+    assert metadata["final_url"] == "https://x.com/bcherny/status/999"
+
+
+def test_try_x_api_tweet_self_ref_returns_none_on_x_api_failure(monkeypatch, tmp_path):
+    """When the X API path fails, return None so caller falls through."""
+
+    class FailedRecord:
+        fetch_status = "failed"
+        content_path = ""
+        content_chars = 0
+        skip_reason = "x_api_no_auth"
+
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
+        lambda url: "999",
+    )
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        lambda url, tweet_id, source_dir, *, timeout: FailedRecord(),
+    )
+
+    assert (
+        ccir._try_x_api_tweet_self_ref(
+            final_url="https://x.com/bcherny/status/999",
+            entry={"url": "https://t.co/abc", "tier": 4, "post_id": "p1"},
+            source_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_try_x_api_tweet_self_ref_handles_missing_content_file(monkeypatch, tmp_path):
+    """X API claims success but content file doesn't exist — return None."""
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
+        lambda url: "999",
+    )
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        lambda url, tweet_id, source_dir, *, timeout: _StubXApiRecord(
+            content_path=str(tmp_path / "nope.md")
+        ),
+    )
+    assert (
+        ccir._try_x_api_tweet_self_ref(
+            final_url="https://x.com/bcherny/status/999",
+            entry={"url": "https://t.co/abc", "tier": 4, "post_id": "p1"},
+            source_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_fetch_linked_source_uses_x_self_ref_for_browser_gated_tweets(monkeypatch, tmp_path):
+    """End-to-end: a t.co URL redirecting to x.com/.../status/N gets fetched
+    via X API instead of being marked skipped.
+    """
+    tweet_md = _write_tweet_md(tmp_path, tweet_id="888", text="Substantive tweet content.")
+
+    class FakeResponse:
+        status_code = 200
+        url = "https://x.com/bcherny/status/888"
+        headers = {"content-type": "text/html"}
+        text = (
+            "<html><body>"
+            "<p>JavaScript is not available.</p>"
+            "<p>We've detected that JavaScript is disabled in this browser.</p>"
+            "</body></html>"
+        )
+
+    class FakeClient:
+        def get(self, url):
+            return FakeResponse()
+
+    # Wire up X API success.
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
+        lambda url: "888" if "888" in url else None,
+    )
+    monkeypatch.setattr(
+        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        lambda url, tweet_id, source_dir, *, timeout: _StubXApiRecord(
+            content_path=str(tweet_md), content_chars=tweet_md.stat().st_size
+        ),
+    )
+
+    entry: dict[str, Any] = {
+        "url": "https://t.co/abc",
+        "post_id": "p1",
+        "tier": 4,
+        "action_type": "strategic_follow_up",
+    }
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+
+    ccir._fetch_linked_source(
+        client=FakeClient(), url="https://t.co/abc", entry=entry, source_dir=source_dir
+    )
+
+    assert entry["fetch_status"] == "fetched"
+    assert entry.get("skip_reason", "") == ""
+    # Source markdown must be written, not the analysis-only stub.
+    source_md = source_dir / "source.md"
+    assert source_md.exists()
+    assert "Substantive tweet content." in source_md.read_text(encoding="utf-8")
+    # Metadata records the X API method for auditability.
+    metadata = json.loads((source_dir / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["fetch_method"] == "x_api_self_ref"
+    assert metadata["final_url"] == "https://x.com/bcherny/status/888"
+    assert metadata["source_type"] == "x_tweet"
+
+
+def test_fetch_linked_source_falls_through_when_x_api_disabled(monkeypatch, tmp_path):
+    """When the env switch is off, browser-gated tweets remain skipped."""
+    monkeypatch.setenv("UA_CSI_LINKED_X_SELF_REF_ENABLED", "0")
+
+    class FakeResponse:
+        status_code = 200
+        url = "https://x.com/bcherny/status/888"
+        headers = {"content-type": "text/html"}
+        text = (
+            "<html><body>"
+            "<p>JavaScript is not available.</p>"
+            "<p>We've detected that JavaScript is disabled in this browser.</p>"
+            "</body></html>"
+        )
+
+    class FakeClient:
+        def get(self, url):
+            return FakeResponse()
+
+    entry: dict[str, Any] = {
+        "url": "https://t.co/abc",
+        "post_id": "p1",
+        "tier": 4,
+        "action_type": "strategic_follow_up",
+    }
+    source_dir = tmp_path / "src"
+    source_dir.mkdir()
+
+    ccir._fetch_linked_source(
+        client=FakeClient(), url="https://t.co/abc", entry=entry, source_dir=source_dir
+    )
+
+    assert entry["fetch_status"] == "skipped"
+    assert entry["skip_reason"] == "browser_gated_x_page"

--- a/tests/unit/test_replay_x_self_ref.py
+++ b/tests/unit/test_replay_x_self_ref.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 
 from universal_agent.services import claude_code_intel_replay as ccir
-from universal_agent.services import csi_url_judge as cuj  # noqa: F401 — imported so monkeypatch can resolve submodule attrs
+from universal_agent.services import csi_url_judge as cuj
 
 
 class _StubXApiRecord:
@@ -53,10 +53,7 @@ def test_try_x_api_tweet_self_ref_disabled_by_env(monkeypatch, tmp_path):
 
 def test_try_x_api_tweet_self_ref_returns_none_for_non_tweet_urls(monkeypatch, tmp_path):
     """A x.com URL that isn't /status/<id> must not be misrouted."""
-    monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
-        lambda url: None,
-    )
+    monkeypatch.setattr(cuj, "parse_tweet_id_from_url", lambda url: None)
     assert (
         ccir._try_x_api_tweet_self_ref(
             final_url="https://x.com/bcherny",
@@ -71,12 +68,10 @@ def test_try_x_api_tweet_self_ref_success(monkeypatch, tmp_path):
     """Happy path: tweet ID parsed, X API returns fetched, content returned."""
     tweet_md = _write_tweet_md(tmp_path, tweet_id="999", text="Real tweet body prose.")
 
+    monkeypatch.setattr(cuj, "parse_tweet_id_from_url", lambda url: "999")
     monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
-        lambda url: "999",
-    )
-    monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        cuj,
+        "_fetch_tweet_via_x_api",
         lambda url, tweet_id, source_dir, *, timeout: _StubXApiRecord(
             content_path=str(tweet_md), content_chars=tweet_md.stat().st_size
         ),
@@ -105,12 +100,10 @@ def test_try_x_api_tweet_self_ref_returns_none_on_x_api_failure(monkeypatch, tmp
         content_chars = 0
         skip_reason = "x_api_no_auth"
 
+    monkeypatch.setattr(cuj, "parse_tweet_id_from_url", lambda url: "999")
     monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
-        lambda url: "999",
-    )
-    monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        cuj,
+        "_fetch_tweet_via_x_api",
         lambda url, tweet_id, source_dir, *, timeout: FailedRecord(),
     )
 
@@ -126,12 +119,10 @@ def test_try_x_api_tweet_self_ref_returns_none_on_x_api_failure(monkeypatch, tmp
 
 def test_try_x_api_tweet_self_ref_handles_missing_content_file(monkeypatch, tmp_path):
     """X API claims success but content file doesn't exist — return None."""
+    monkeypatch.setattr(cuj, "parse_tweet_id_from_url", lambda url: "999")
     monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
-        lambda url: "999",
-    )
-    monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        cuj,
+        "_fetch_tweet_via_x_api",
         lambda url, tweet_id, source_dir, *, timeout: _StubXApiRecord(
             content_path=str(tmp_path / "nope.md")
         ),
@@ -169,11 +160,11 @@ def test_fetch_linked_source_uses_x_self_ref_for_browser_gated_tweets(monkeypatc
 
     # Wire up X API success.
     monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge.parse_tweet_id_from_url",
-        lambda url: "888" if "888" in url else None,
+        cuj, "parse_tweet_id_from_url", lambda url: "888" if "888" in url else None
     )
     monkeypatch.setattr(
-        "universal_agent.services.csi_url_judge._fetch_tweet_via_x_api",
+        cuj,
+        "_fetch_tweet_via_x_api",
         lambda url, tweet_id, source_dir, *, timeout: _StubXApiRecord(
             content_path=str(tweet_md), content_chars=tweet_md.stat().st_size
         ),


### PR DESCRIPTION
## Summary

Move 2 from the 2026-05-17 trace remediation plan. When a tweet links to another tweet via t.co (or directly to x.com), the browser-style fetch returns the JS-gated SPA chrome and the link gets marked `browser_gated_x_page`. The lane already has X API credentials — fetching one referenced tweet via `/2/tweets/{id}` is the same API call that built the rest of the packet. Surfacing the referenced tweet body is the whole point of a strategic-follow-up signal.

## What changes

- New `_try_x_api_tweet_self_ref` helper in `claude_code_intel_replay.py` parses the tweet ID from the final URL and dispatches to the existing `csi_url_judge._fetch_tweet_via_x_api`.
- Hooked into `_fetch_linked_source` right before the legacy skip path. On success the entry becomes `fetch_status=fetched` with `fetch_method=x_api_self_ref` in metadata; `source.md` contains the tweet body markdown.
- Falls through to legacy skip behavior on any failure (no auth, network error, parse failure) — never regresses.
- Off switch: `UA_CSI_LINKED_X_SELF_REF_ENABLED=0`.

## Concrete win

The 2026-05-17 `@bcherny` packet contained one such self-ref:

> @OniricSunset @ClaudeDevs Fix going out tomorrow. Details and workaround: `https://t.co/bpWPkfJgX7`

The t.co resolves to another bcherny tweet describing the workaround. Before this PR: silently skipped. After: fetched into the linked-source markdown so the operator/classifier sees the real workaround details.

## Test plan

- [x] `uv run pytest tests/unit/test_replay_x_self_ref.py tests/unit/test_claude_code_intel_replay.py` — 14 pass (7 new + 7 existing)
- [x] `uv run ruff check …` — clean
- [ ] After deploy: next `@bcherny` cron tick should fetch any new self-ref links. Re-run on the 2026-05-17 packet via replay to verify the existing self-ref gets surfaced.

## Follow-up queue (autonomous run)

- Move 3: tier-1 vault-write min-signal gate (next PR)
- Phase B: replay summary `wiki_pages` dedup audit, classifier typo-robustness pin, operator-report URL smoke