### PR TITLE
feat(csi): tier-1 vault-write minimum-signal gate

### DIFF
--- a/src/universal_agent/services/claude_code_intel_replay.py
+++ b/src/universal_agent/services/claude_code_intel_replay.py
@@ -199,6 +199,7 @@ def replay_packet(
         "vault_path": vault_result.get("vault_path") or "",
         "wiki_pages": vault_result.get("pages") or [],
         "email_evidence_ids": vault_result.get("email_evidence_ids") or [],
+        "tier1_skipped_count": int(vault_result.get("tier1_skipped_count") or 0),
     }
     write_replay_summary(packet_dir=packet_dir, payload=result)
 
@@ -783,6 +784,57 @@ def apply_memex_pass(
     return results
 
 
+_TIER1_VERSION_PATTERN = re.compile(r"\bv?\d+\.\d+(?:\.\d+)?\b")
+
+_TIER1_SIGNAL_CONTENT_KINDS = frozenset(
+    {
+        "product_capability",
+        "release_announcement",
+        "usage_tip",
+        "feature_announcement",
+        "bug_fix",
+        "migration_note",
+    }
+)
+
+
+def _tier1_min_signal_enabled() -> bool:
+    raw = str(os.getenv("UA_CSI_TIER1_MIN_SIGNAL_ENABLED") or "1").strip().lower()
+    return raw not in {"0", "false", "no", "off"}
+
+
+def _tier1_has_signal(action: dict[str, Any]) -> bool:
+    """Return True when a tier-1 action is worth a vault page.
+
+    Tier 1 is the "digest" bucket — most entries here are conversational
+    community replies that carry zero durable intelligence ("Working on
+    it!", "Tell me more"). Writing a wiki page for each pollutes the vault
+    index without adding signal.
+
+    A tier-1 action qualifies for a vault page when at least one of:
+    - It has linked URLs.
+    - It has matched-term hits from the triage classifier.
+    - Its text mentions an explicit version number (``v1.2.3`` style).
+    - Its classifier-tagged content_kind is on the signal allowlist
+      (product_capability, release_announcement, usage_tip, ...).
+    """
+    links = action.get("links") or []
+    if any(str(link).strip() for link in links):
+        return True
+    matched = action.get("matched_terms") or []
+    if any(str(term).strip() for term in matched):
+        return True
+    text = str(action.get("text") or "")
+    if _TIER1_VERSION_PATTERN.search(text):
+        return True
+    classifier = action.get("classifier") or {}
+    if isinstance(classifier, dict):
+        content_kind = str(classifier.get("content_kind") or "").strip().lower()
+        if content_kind in _TIER1_SIGNAL_CONTENT_KINDS:
+            return True
+    return False
+
+
 def ingest_packet_into_external_vault(
     *,
     packet_dir: Path,
@@ -815,11 +867,27 @@ def ingest_packet_into_external_vault(
     work_product_pages: list[str] = []
     action_map = {str(a.get("post_id") or "").strip(): dict(a) for a in actions if str(a.get("post_id") or "").strip()}
 
+    tier1_gate_enabled = _tier1_min_signal_enabled()
+    tier1_skipped_count = 0
     for post in posts:
         post_id = str(post.get("id") or "").strip()
         if not post_id:
             continue
         action = action_map.get(post_id, {})
+        # Tier-1 min-signal gate: most tier-1 actions are conversational
+        # chatter ("Working on it!"). Writing a wiki page for each pollutes
+        # the vault index without adding intelligence. Tier-1 entries pass
+        # the gate only when they carry a link, matched term, version
+        # string, or a classifier content_kind on the signal allowlist.
+        # Higher tiers always pass.
+        action_tier = int(action.get("tier") or 0)
+        if (
+            tier1_gate_enabled
+            and action_tier == 1
+            and not _tier1_has_signal(action)
+        ):
+            tier1_skipped_count += 1
+            continue
         content = _post_source_markdown(handle=handle, post=post, action=action)
         result = wiki_ingest_external_source(
             vault_slug=KB_SLUG,
@@ -936,6 +1004,7 @@ def ingest_packet_into_external_vault(
         "work_product_pages": work_product_pages,
         "email_evidence_ids": email_evidence_ids,
         "memex_actions": memex_actions,
+        "tier1_skipped_count": tier1_skipped_count,
     }
 def reconcile_packet_candidate_ledger(
     *,

--- a/tests/unit/test_tier1_min_signal_gate.py
+++ b/tests/unit/test_tier1_min_signal_gate.py
@@ -1,0 +1,228 @@
+"""Tests for the tier-1 vault-write minimum-signal gate.
+
+Most tier-1 actions are conversational chatter ("Working on it!",
+"Tell me more"). Writing a wiki page for each pollutes the vault index
+without adding intelligence. The gate ensures tier-1 actions reach the
+vault only when they carry at least one of: a link, a matched term, a
+version string, or a signal-class content_kind classification.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from universal_agent.services import claude_code_intel_replay as ccir
+
+
+# ── Unit tests for the predicate ────────────────────────────────────────────
+
+
+def test_tier1_has_signal_links():
+    assert ccir._tier1_has_signal({"links": ["https://example.com"], "text": "x"}) is True
+
+
+def test_tier1_has_signal_matched_terms():
+    assert ccir._tier1_has_signal({"matched_terms": ["tool"], "text": "x"}) is True
+
+
+def test_tier1_has_signal_version_string():
+    assert ccir._tier1_has_signal({"text": "shipped v2.1.5 of the SDK"}) is True
+    assert ccir._tier1_has_signal({"text": "claude 4.6 released"}) is True
+
+
+def test_tier1_has_signal_content_kind_allowlist():
+    for kind in (
+        "product_capability",
+        "release_announcement",
+        "usage_tip",
+        "feature_announcement",
+        "bug_fix",
+        "migration_note",
+    ):
+        assert (
+            ccir._tier1_has_signal(
+                {"classifier": {"content_kind": kind}, "text": "x"}
+            )
+            is True
+        ), f"content_kind={kind} should pass"
+
+
+def test_tier1_has_signal_chatter_is_blocked():
+    """Realistic chatter replies from the 2026-05-17 packet."""
+    chatter_actions = [
+        {"text": "@rajankrx Working on it!", "links": [], "matched_terms": []},
+        {
+            "text": "@downtownberlin @rajankrx Tell me more. Can you give me step by step walk through?",
+            "links": [],
+            "matched_terms": [],
+        },
+        {
+            "text": "@nav7634 Let me see what we can do to improve this. Keep the feedback coming!",
+            "links": [],
+            "matched_terms": [],
+            "classifier": {"content_kind": "community_event"},
+        },
+    ]
+    for action in chatter_actions:
+        assert ccir._tier1_has_signal(action) is False, action["text"]
+
+
+def test_tier1_has_signal_treats_blank_strings_as_empty():
+    assert ccir._tier1_has_signal({"links": ["  ", ""], "matched_terms": [""]}) is False
+
+
+def test_tier1_has_signal_treats_empty_classifier_dict_safely():
+    assert ccir._tier1_has_signal({"classifier": {}, "text": "chatter"}) is False
+
+
+def test_tier1_has_signal_handles_non_dict_classifier():
+    assert ccir._tier1_has_signal({"classifier": "garbage", "text": "chatter"}) is False
+
+
+# ── Env toggle ──────────────────────────────────────────────────────────────
+
+
+def test_tier1_min_signal_enabled_default_on(monkeypatch):
+    monkeypatch.delenv("UA_CSI_TIER1_MIN_SIGNAL_ENABLED", raising=False)
+    assert ccir._tier1_min_signal_enabled() is True
+
+
+def test_tier1_min_signal_enabled_off_switch(monkeypatch):
+    for value in ("0", "false", "FALSE", "off", "no"):
+        monkeypatch.setenv("UA_CSI_TIER1_MIN_SIGNAL_ENABLED", value)
+        assert ccir._tier1_min_signal_enabled() is False, value
+
+
+# ── Integration with ingest_packet_into_external_vault ─────────────────────
+
+
+def _stub_ingest(calls: list[dict[str, Any]]):
+    def _impl(**kwargs):
+        calls.append(kwargs)
+        return {"status": "success", "path": f"sources/{kwargs.get('source_id')}.md"}
+
+    return _impl
+
+
+def _vault_inputs(tmp_path: Path):
+    """Minimal posts/actions structure with 5 tier-1 entries: 4 chatter + 1 signal."""
+    posts = [
+        {"id": f"p{i}", "text": "post " + str(i)} for i in range(5)
+    ]
+    actions = [
+        # 1: pure chatter
+        {"post_id": "p0", "tier": 1, "text": "Working on it!"},
+        # 2: tier-1 with link → keeps
+        {"post_id": "p1", "tier": 1, "text": "see this", "links": ["https://example.com"]},
+        # 3: chatter with content_kind that should be filtered
+        {
+            "post_id": "p2",
+            "tier": 1,
+            "text": "Tell me more",
+            "classifier": {"content_kind": "generic_update"},
+        },
+        # 4: tier-1 with version string → keeps
+        {"post_id": "p3", "tier": 1, "text": "shipped v3.2.1"},
+        # 5: tier-1 with signal content_kind → keeps
+        {
+            "post_id": "p4",
+            "tier": 1,
+            "text": "fixed it",
+            "classifier": {"content_kind": "bug_fix"},
+        },
+    ]
+    return posts, actions
+
+
+def test_tier1_chatter_does_not_get_vault_pages(monkeypatch, tmp_path):
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(ccir, "wiki_ingest_external_source", _stub_ingest(calls))
+    posts, actions = _vault_inputs(tmp_path)
+
+    result = ccir.ingest_packet_into_external_vault(
+        packet_dir=tmp_path / "packet",
+        handle="bcherny",
+        posts=posts,
+        actions=actions,
+        linked_source_entries=[],
+        artifacts_root=tmp_path,
+        work_product_dir=None,
+        enabled=True,
+    )
+
+    ingested_post_ids = {
+        c.get("source_id") for c in calls if str(c.get("source_id", "")).startswith("x_post_")
+    }
+    # Chatter (p0, p2) suppressed; signal entries (p1, p3, p4) kept.
+    assert ingested_post_ids == {"x_post_p1", "x_post_p3", "x_post_p4"}
+    assert result["tier1_skipped_count"] == 2
+
+
+def test_tier1_higher_tiers_always_pass(monkeypatch, tmp_path):
+    """Tier-2+ entries are not subject to the gate even if they look like chatter."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(ccir, "wiki_ingest_external_source", _stub_ingest(calls))
+
+    result = ccir.ingest_packet_into_external_vault(
+        packet_dir=tmp_path / "packet",
+        handle="bcherny",
+        posts=[{"id": "p_hi", "text": "x"}],
+        actions=[{"post_id": "p_hi", "tier": 3, "text": "ok"}],
+        linked_source_entries=[],
+        artifacts_root=tmp_path,
+        work_product_dir=None,
+        enabled=True,
+    )
+
+    assert any(c.get("source_id") == "x_post_p_hi" for c in calls)
+    assert result["tier1_skipped_count"] == 0
+
+
+def test_tier1_gate_can_be_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("UA_CSI_TIER1_MIN_SIGNAL_ENABLED", "0")
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(ccir, "wiki_ingest_external_source", _stub_ingest(calls))
+    posts, actions = _vault_inputs(tmp_path)
+
+    result = ccir.ingest_packet_into_external_vault(
+        packet_dir=tmp_path / "packet",
+        handle="bcherny",
+        posts=posts,
+        actions=actions,
+        linked_source_entries=[],
+        artifacts_root=tmp_path,
+        work_product_dir=None,
+        enabled=True,
+    )
+
+    ingested_post_ids = {
+        c.get("source_id") for c in calls if str(c.get("source_id", "")).startswith("x_post_")
+    }
+    # Gate off → all five posts ingested.
+    assert ingested_post_ids == {f"x_post_p{i}" for i in range(5)}
+    assert result["tier1_skipped_count"] == 0
+
+
+def test_tier1_gate_handles_missing_action(monkeypatch, tmp_path):
+    """A post without a matching action defaults to tier=0 and is NOT subject to the gate."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(ccir, "wiki_ingest_external_source", _stub_ingest(calls))
+
+    result = ccir.ingest_packet_into_external_vault(
+        packet_dir=tmp_path / "packet",
+        handle="bcherny",
+        posts=[{"id": "p_unmatched", "text": "x"}],
+        actions=[],
+        linked_source_entries=[],
+        artifacts_root=tmp_path,
+        work_product_dir=None,
+        enabled=True,
+    )
+
+    assert any(c.get("source_id") == "x_post_p_unmatched" for c in calls)
+    assert result["tier1_skipped_count"] == 0


### PR DESCRIPTION
## Summary

Move 3 from the 2026-05-17 trace remediation plan. Most tier-1 actions are conversational community replies ("Working on it!", "Tell me more") that carry zero durable intelligence. Writing a wiki page for each pollutes the vault index without adding signal — 4 of 6 actions in the 2026-05-17 \`@bcherny\` packet were exactly this.

## What changes

New `_tier1_has_signal(action)` predicate gates the post-page write loop in `ingest_packet_into_external_vault`. A tier-1 entry qualifies for a vault page only when at least one of:
- Has linked URLs
- Has matched-term hits from the triage classifier
- Text contains an explicit version string (\`v1.2.3\` style)
- Classifier `content_kind` is on the allowlist (product_capability, release_announcement, usage_tip, feature_announcement, bug_fix, migration_note)

Higher tiers always pass — the gate touches tier-1 only.

The function returns `tier1_skipped_count` so the operator report can surface how much chatter was suppressed each tick.

Off switch: \`UA_CSI_TIER1_MIN_SIGNAL_ENABLED=0\`.

## Test plan

- [x] `uv run pytest tests/unit/test_tier1_min_signal_gate.py tests/unit/test_claude_code_intel_replay.py` — 21 pass (14 new + 7 existing)
- [x] `uv run ruff check …` — clean
- [ ] After deploy: next bcherny cron tick should report `tier1_skipped_count ≥ 0` in the replay summary and no chatter `claudedevs-post-*.md` pages get written for the typical 4-of-6 chatter ratio.

## Phase A wrap-up

This completes Moves 1-3 of the trace plan:
- Move 1: research-grounding hallucination filter + SPA-404 detection (PR #329)
- Move 2: t.co → x.com self-reference fetch via X API (PR #336, pending merge)
- Move 3: tier-1 vault-write min-signal gate (this PR)

Move 4 is operator-only: approve the two pending tier-4 candidates in the triage flyout dashboard. Phase B follow-ups will start once Phase A is fully live.