### PR TITLE
style: standardize import ordering in 3 service modules

### DIFF
--- a/src/universal_agent/services/atlas_direct_dispatch.py
+++ b/src/universal_agent/services/atlas_direct_dispatch.py
@@ -35,11 +35,11 @@ Safety:
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import json
 import logging
 import os
 import sqlite3
-from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from universal_agent import task_hub

--- a/src/universal_agent/services/cody_token_tracking.py
+++ b/src/universal_agent/services/cody_token_tracking.py
@@ -23,9 +23,9 @@ operator telemetry, not a correctness gate.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 import logging
 import sqlite3
-from datetime import datetime, timezone
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)

--- a/src/universal_agent/services/cron_task_hub_link.py
+++ b/src/universal_agent/services/cron_task_hub_link.py
@@ -62,8 +62,8 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-import uuid
 from typing import Any, Optional
+import uuid
 
 from universal_agent import task_hub
 


### PR DESCRIPTION
## Summary
- Alphabetize stdlib imports in `atlas_direct_dispatch.py`, `cody_token_tracking.py`, and `cron_task_hub_link.py` to satisfy ruff I001 (isort with `force-sort-within-sections = true`)
- Fixes the only 3 module-level import-ordering violations detected by `ruff check --select I` across the entire `src/` tree

## Theme
CODIE proactive cleanup: **standardize inconsistent import ordering and grouping** (daily theme rotation)

## Changes
| File | Fix |
|------|-----|
| `services/atlas_direct_dispatch.py` | `from datetime` moved before `import json` |
| `services/cody_token_tracking.py` | `from datetime` moved before `import logging` |
| `services/cron_task_hub_link.py` | `from typing` moved before `import uuid` |

## Tests run
- `ruff check --select I` passes on all 3 files (zero remaining violations)
- `ruff check` (full lint) passes on all 3 files
- `uv run pytest tests/unit/` — 393 passed, 1 skipped
- Import smoke test: all 3 modules import cleanly

## Risks
None. Import order does not affect runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)