### PR TITLE
feat(csi): auto-dismiss policy for stale tier-3 triage candidates

### DIFF
--- a/src/universal_agent/scripts/csi_demo_triage_apply_policy.py
+++ b/src/universal_agent/scripts/csi_demo_triage_apply_policy.py
@@ -1,0 +1,102 @@
+"""Apply the CSI demo-triage auto-dismiss policy.
+
+Default behavior is dry-run: prints what would be dismissed but mutates
+nothing. Pass ``--apply`` to actually dismiss.
+
+Usage on the VPS::
+
+    cd /opt/universal_agent && PYTHONPATH=src uv run python \
+        -m universal_agent.scripts.csi_demo_triage_apply_policy
+
+    cd /opt/universal_agent && PYTHONPATH=src uv run python \
+        -m universal_agent.scripts.csi_demo_triage_apply_policy --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+from universal_agent.services.csi_demo_triage_policy import (
+    DEFAULT_POLICIES,
+    apply_policies,
+    policy_auto_apply_enabled,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually dismiss matching candidates (default is dry-run).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the full report as JSON instead of a human-readable summary.",
+    )
+    parser.add_argument(
+        "--require-env-opt-in",
+        action="store_true",
+        help=(
+            "Only apply when UA_CSI_TRIAGE_AUTO_POLICY_ENABLED is truthy. "
+            "Use this when scheduling via cron so the operator can stage the "
+            "policy via env flip without touching crontab."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    if args.apply and args.require_env_opt_in and not policy_auto_apply_enabled():
+        print(
+            "auto-apply requested but UA_CSI_TRIAGE_AUTO_POLICY_ENABLED is off; "
+            "running dry-run instead.",
+            file=sys.stderr,
+        )
+        dry_run = True
+    else:
+        dry_run = not args.apply
+
+    report = apply_policies(dry_run=dry_run)
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=True, sort_keys=True))
+        return 0
+
+    mode = "DRY-RUN" if report["dry_run"] else "APPLIED"
+    print(f"== CSI demo-triage auto-policy [{mode}] @ {report['as_of']} ==")
+    print(f"Policies considered: {', '.join(report['policies_applied'])}")
+    if report["actions_total"] == 0:
+        print("No matching candidates — queue already clean.")
+        return 0
+    print(f"Matched candidates : {report['actions_total']}")
+    print(f"Applied dismissals : {report['actions_applied']}")
+    for name, count in report["by_policy"].items():
+        print(f"  • {name}: {count}")
+
+    # Show the first 20 rows so the operator can sanity-check.
+    print()
+    print("First 20 affected candidates:")
+    for action in report["actions"][:20]:
+        score = action.get("ranking_score")
+        score_str = f"{score:.2f}" if isinstance(score, (int, float)) else "—"
+        print(
+            f"  - post={action['post_id']} tier={action['tier']} "
+            f"type={action['action_type']} score={score_str} "
+            f"age={action['age_days']:.1f}d state_after={action['state_after']} "
+            f"reason={action['reason']}"
+        )
+    if report["actions_total"] > 20:
+        print(f"  ... +{report['actions_total'] - 20} more")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/universal_agent/services/csi_demo_triage_policy.py
+++ b/src/universal_agent/services/csi_demo_triage_policy.py
@@ -1,0 +1,240 @@
+"""CSI demo-triage auto-dismiss policy engine.
+
+Background — 2026-05-17 trace: the demo-triage queue had accumulated 96
+pending candidates because the cron explicitly never auto-queues; every
+tier-3+ action waits for operator approval. Most stale tier-3 entries
+were never going to be acted on, but they hide the genuinely actionable
+items further down the list.
+
+This module applies a conservative auto-dismiss policy so the operator
+sees a short list of fresh, high-signal candidates instead of weeks of
+backlog. **Tier 4 candidates are never auto-dismissed** — they always
+require operator eyes.
+
+Auto-approve is intentionally NOT implemented here. Approving creates
+Task Hub work and burns ZAI quota; the upside of automating that does
+not justify the failure mode of approving the wrong thing. If the
+operator wants auto-approve, it should be a separate PR with explicit
+opt-in per action_type.
+
+The policy is fully audited: every auto-action stamps
+``decided_by = "auto-policy:<name>"`` so the dashboard, ledger, and
+``restore_candidate`` operator path can identify and reverse the
+auto-decisions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+import logging
+import os
+from pathlib import Path
+import sqlite3
+from typing import Any
+
+from universal_agent.services.csi_demo_triage import (
+    STATE_PENDING,
+    dismiss_candidate,
+    open_db,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ── Policy definitions ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class StaleTierPolicy:
+    """Auto-dismiss policy for stale low-signal candidates within a tier."""
+
+    name: str
+    tier: int
+    max_age_days: int
+    # When set, also require ``ranking_score <= max_ranking_score OR
+    # ranking_score IS NULL`` to dismiss. Leave None to ignore score.
+    max_ranking_score: float | None = None
+    decided_by: str = "auto-policy:stale"
+
+
+DEFAULT_POLICIES: tuple[StaleTierPolicy, ...] = (
+    # Tier-3 candidates older than 14 days with weak or missing ranking
+    # scores are almost never acted on. Default dismissal is reversible
+    # via the dashboard "Restore" button.
+    StaleTierPolicy(
+        name="stale-tier-3",
+        tier=3,
+        max_age_days=14,
+        max_ranking_score=5.0,
+        decided_by="auto-policy:stale-tier-3",
+    ),
+)
+
+
+# ── Application ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class CandidateAction:
+    """Record of one auto-policy decision for reporting/audit."""
+
+    post_id: str
+    tier: int
+    action_type: str
+    ranking_score: float | None
+    age_days: float
+    policy_name: str
+    state_before: str
+    state_after: str
+    applied: bool
+    reason: str = ""
+
+
+def _parse_iso(value: str) -> datetime | None:
+    if not value:
+        return None
+    value = value.strip()
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _candidates_matching_policy(
+    conn: sqlite3.Connection, policy: StaleTierPolicy, *, now: datetime
+) -> list[dict[str, Any]]:
+    """Return raw rows that this policy would dismiss right now."""
+    cutoff = now - timedelta(days=policy.max_age_days)
+    cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
+    if policy.max_ranking_score is None:
+        rows = conn.execute(
+            """
+            SELECT post_id, tier, action_type, ranking_score, first_seen_at
+              FROM demo_triage_candidates
+             WHERE state = ?
+               AND tier = ?
+               AND first_seen_at < ?
+             ORDER BY first_seen_at ASC
+            """,
+            (STATE_PENDING, policy.tier, cutoff_iso),
+        ).fetchall()
+    else:
+        # ranking_score must be NULL or ≤ threshold. NULL is treated as
+        # "low signal" because the ranker hasn't validated the item.
+        rows = conn.execute(
+            """
+            SELECT post_id, tier, action_type, ranking_score, first_seen_at
+              FROM demo_triage_candidates
+             WHERE state = ?
+               AND tier = ?
+               AND first_seen_at < ?
+               AND (ranking_score IS NULL OR ranking_score <= ?)
+             ORDER BY first_seen_at ASC
+            """,
+            (STATE_PENDING, policy.tier, cutoff_iso, policy.max_ranking_score),
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def apply_policies(
+    *,
+    conn: sqlite3.Connection | None = None,
+    artifacts_root: Path | None = None,
+    policies: tuple[StaleTierPolicy, ...] | None = None,
+    dry_run: bool = True,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Apply every configured auto-policy. Returns a structured report.
+
+    ``dry_run=True`` (the default) only reports what *would* change. Pass
+    ``dry_run=False`` to actually mutate state.
+    """
+    own_conn = conn is None
+    if conn is None:
+        conn = open_db(artifacts_root)
+    policies = policies or DEFAULT_POLICIES
+    when = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    actions: list[CandidateAction] = []
+    try:
+        for policy in policies:
+            matched = _candidates_matching_policy(conn, policy, now=when)
+            for row in matched:
+                first_seen = _parse_iso(str(row.get("first_seen_at") or ""))
+                age_days = (
+                    (when - first_seen).total_seconds() / 86_400.0
+                    if first_seen
+                    else 0.0
+                )
+                applied = False
+                reason = "dry_run"
+                state_after = STATE_PENDING
+                if not dry_run:
+                    result = dismiss_candidate(
+                        post_id=str(row["post_id"]),
+                        decided_by=policy.decided_by,
+                        conn=conn,
+                    )
+                    if result.get("ok"):
+                        applied = True
+                        reason = "auto_dismissed"
+                        state_after = "dismissed"
+                    else:
+                        reason = str(result.get("reason") or "dismiss_failed")
+                actions.append(
+                    CandidateAction(
+                        post_id=str(row["post_id"]),
+                        tier=int(row.get("tier") or 0),
+                        action_type=str(row.get("action_type") or ""),
+                        ranking_score=row.get("ranking_score"),
+                        age_days=round(age_days, 2),
+                        policy_name=policy.name,
+                        state_before=STATE_PENDING,
+                        state_after=state_after,
+                        applied=applied,
+                        reason=reason,
+                    )
+                )
+    finally:
+        if own_conn:
+            conn.close()
+
+    summary = {
+        "ok": True,
+        "dry_run": dry_run,
+        "as_of": when.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "policies_applied": [p.name for p in policies],
+        "actions_total": len(actions),
+        "actions_applied": sum(1 for a in actions if a.applied),
+        "by_policy": {
+            p.name: sum(1 for a in actions if a.policy_name == p.name)
+            for p in policies
+        },
+        "actions": [a.__dict__ for a in actions],
+    }
+    return summary
+
+
+# ── Operator entry-point ────────────────────────────────────────────────────
+
+
+def _env_truthy(name: str, default: bool = False) -> bool:
+    raw = str(os.getenv(name) or "").strip().lower()
+    if not raw:
+        return default
+    return raw not in {"0", "false", "no", "off"}
+
+
+def policy_auto_apply_enabled() -> bool:
+    """Operator switch — controls whether the daily cron actually mutates state.
+
+    The script-level ``--apply`` flag overrides this; the env var only
+    governs the would-be cron sweep so operators can stage the policy in
+    dry-run, validate the diff, then flip the switch.
+    """
+    return _env_truthy("UA_CSI_TRIAGE_AUTO_POLICY_ENABLED", default=False)

--- a/tests/unit/test_csi_demo_triage_policy.py
+++ b/tests/unit/test_csi_demo_triage_policy.py
@@ -1,0 +1,245 @@
+"""Tests for the CSI demo-triage auto-dismiss policy engine."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from universal_agent.services.csi_demo_triage import (
+    STATE_DISMISSED,
+    STATE_PENDING,
+    ensure_schema,
+)
+from universal_agent.services.csi_demo_triage_policy import (
+    DEFAULT_POLICIES,
+    StaleTierPolicy,
+    apply_policies,
+    policy_auto_apply_enabled,
+)
+
+
+def _make_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+def _insert(
+    conn: sqlite3.Connection,
+    *,
+    post_id: str,
+    tier: int,
+    age_days: float,
+    ranking_score: float | None = None,
+    state: str = STATE_PENDING,
+    action_type: str = "demo_task",
+    now: datetime,
+) -> None:
+    first_seen = (now - timedelta(days=age_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    conn.execute(
+        """
+        INSERT INTO demo_triage_candidates (
+          post_id, handle, tier, action_type, packet_dir,
+          first_seen_at, state, ranking_score
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (post_id, "bcherny", tier, action_type, "/tmp", first_seen, state, ranking_score),
+    )
+    conn.commit()
+
+
+# ── default policy semantics ──────────────────────────────────────────────
+
+
+def test_default_policies_only_target_tier_3():
+    """Tier 4 is never in the default auto-dismiss set."""
+    targeted = {p.tier for p in DEFAULT_POLICIES}
+    assert 4 not in targeted, "tier 4 must never be auto-dismissed by default"
+    assert targeted == {3}
+
+
+def test_default_policy_threshold_floor_is_14_days():
+    """If the operator wants to tune, the policy field is exposed; default is 14."""
+    policy = next(p for p in DEFAULT_POLICIES if p.name == "stale-tier-3")
+    assert policy.max_age_days == 14
+    assert policy.max_ranking_score == 5.0
+
+
+# ── dry-run preserves state ───────────────────────────────────────────────
+
+
+def test_dry_run_makes_no_mutations(tmp_path, monkeypatch):
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="stale1", tier=3, age_days=30, ranking_score=2.0, now=now)
+    _insert(conn, post_id="stale2", tier=3, age_days=20, ranking_score=None, now=now)
+
+    report = apply_policies(conn=conn, dry_run=True, now=now)
+    assert report["dry_run"] is True
+    assert report["actions_total"] == 2
+    assert report["actions_applied"] == 0
+
+    rows = conn.execute(
+        "SELECT state FROM demo_triage_candidates ORDER BY post_id"
+    ).fetchall()
+    assert [r["state"] for r in rows] == [STATE_PENDING, STATE_PENDING]
+
+
+# ── apply mutates state ───────────────────────────────────────────────────
+
+
+def test_apply_dismisses_stale_tier_3(tmp_path):
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="stale_a", tier=3, age_days=30, ranking_score=2.0, now=now)
+    _insert(conn, post_id="stale_b", tier=3, age_days=20, ranking_score=None, now=now)
+
+    report = apply_policies(conn=conn, dry_run=False, now=now)
+    assert report["actions_applied"] == 2
+    for action in report["actions"]:
+        assert action["state_after"] == STATE_DISMISSED
+        assert action["reason"] == "auto_dismissed"
+
+    states = {
+        row["post_id"]: row["state"]
+        for row in conn.execute("SELECT post_id, state FROM demo_triage_candidates")
+    }
+    assert states == {"stale_a": STATE_DISMISSED, "stale_b": STATE_DISMISSED}
+
+
+def test_decided_by_field_records_policy_name(tmp_path):
+    """Every auto-dismiss must stamp `decided_by` for audit/restore."""
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="stale_c", tier=3, age_days=30, ranking_score=2.0, now=now)
+
+    apply_policies(conn=conn, dry_run=False, now=now)
+    row = conn.execute(
+        "SELECT decided_by FROM demo_triage_candidates WHERE post_id = ?",
+        ("stale_c",),
+    ).fetchone()
+    assert row["decided_by"] == "auto-policy:stale-tier-3"
+
+
+# ── tier-4 never dismissed ────────────────────────────────────────────────
+
+
+def test_tier_4_candidates_are_never_auto_dismissed(tmp_path):
+    """The operator always reviews tier-4 even if it's old + unscored."""
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="t4_old", tier=4, age_days=90, ranking_score=None, now=now)
+
+    report = apply_policies(conn=conn, dry_run=False, now=now)
+    assert report["actions_total"] == 0
+    state = conn.execute(
+        "SELECT state FROM demo_triage_candidates WHERE post_id = ?", ("t4_old",)
+    ).fetchone()["state"]
+    assert state == STATE_PENDING
+
+
+# ── age + score gating ────────────────────────────────────────────────────
+
+
+def test_recent_tier_3_is_not_dismissed_regardless_of_score(tmp_path):
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="fresh", tier=3, age_days=2, ranking_score=2.0, now=now)
+    report = apply_policies(conn=conn, dry_run=False, now=now)
+    assert report["actions_total"] == 0
+
+
+def test_high_score_tier_3_is_not_dismissed_even_if_stale(tmp_path):
+    """A high score signals operator interest; do not auto-dismiss."""
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="hi_score", tier=3, age_days=30, ranking_score=8.5, now=now)
+    report = apply_policies(conn=conn, dry_run=False, now=now)
+    assert report["actions_total"] == 0
+
+
+def test_unscored_tier_3_is_dismissed_when_old(tmp_path):
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="unscored_old", tier=3, age_days=30, ranking_score=None, now=now)
+    report = apply_policies(conn=conn, dry_run=False, now=now)
+    assert report["actions_applied"] == 1
+
+
+# ── states other than pending are ignored ─────────────────────────────────
+
+
+def test_already_dismissed_candidates_are_not_revisited(tmp_path):
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(
+        conn,
+        post_id="already_dismissed",
+        tier=3,
+        age_days=30,
+        ranking_score=2.0,
+        state=STATE_DISMISSED,
+        now=now,
+    )
+    report = apply_policies(conn=conn, dry_run=False, now=now)
+    assert report["actions_total"] == 0
+
+
+def test_approved_candidates_are_not_revisited(tmp_path):
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(
+        conn,
+        post_id="already_approved",
+        tier=3,
+        age_days=30,
+        ranking_score=2.0,
+        state="approved",
+        now=now,
+    )
+    report = apply_policies(conn=conn, dry_run=False, now=now)
+    assert report["actions_total"] == 0
+
+
+# ── custom policies ───────────────────────────────────────────────────────
+
+
+def test_custom_policy_can_dismiss_tier_4(tmp_path):
+    """Operators with strong defaults can opt-in to broader auto-dismiss."""
+    now = datetime(2026, 5, 18, tzinfo=timezone.utc)
+    conn = _make_conn()
+    _insert(conn, post_id="t4_stale", tier=4, age_days=60, ranking_score=1.0, now=now)
+    aggressive = (
+        StaleTierPolicy(
+            name="aggressive-t4",
+            tier=4,
+            max_age_days=30,
+            max_ranking_score=2.0,
+            decided_by="auto-policy:aggressive-t4",
+        ),
+    )
+    report = apply_policies(conn=conn, dry_run=False, policies=aggressive, now=now)
+    assert report["actions_applied"] == 1
+
+
+# ── env switch ────────────────────────────────────────────────────────────
+
+
+def test_policy_auto_apply_enabled_default_off(monkeypatch):
+    monkeypatch.delenv("UA_CSI_TRIAGE_AUTO_POLICY_ENABLED", raising=False)
+    assert policy_auto_apply_enabled() is False
+
+
+def test_policy_auto_apply_enabled_truthy_values(monkeypatch):
+    for value in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv("UA_CSI_TRIAGE_AUTO_POLICY_ENABLED", value)
+        assert policy_auto_apply_enabled() is True, value
+
+
+def test_policy_auto_apply_enabled_falsy_values(monkeypatch):
+    for value in ("0", "false", "off", "no"):
+        monkeypatch.setenv("UA_CSI_TRIAGE_AUTO_POLICY_ENABLED", value)
+        assert policy_auto_apply_enabled() is False, value


### PR DESCRIPTION
## Summary

The 2026-05-17 trace surfaced **96 pending demo-triage candidates** — weeks of unreviewed backlog hiding the genuinely actionable items. This PR ships a conservative auto-dismiss policy so the operator's drawer shows fresh, high-signal candidates instead of accumulated noise.

## Policy defaults (safe)

- **Target**: tier-3 candidates older than 14 days with `ranking_score ≤ 5.0` OR `NULL`.
- **Never targets tier-4** — strategic follow-ups always require operator review.
- **Never targets high-score tier-3** — a strong ranking signals operator interest.
- Every auto-action stamps `decided_by="auto-policy:stale-tier-3"` so it's auditable and reversible via the dashboard "Restore" button.

## What's NOT in this PR

Auto-approve. Approving creates Task Hub work + ZAI quota burn; opt-in per action_type is the right shape and should ship separately when you decide which action types are safe to auto-promote.

## How to use

```bash
# Dry-run on the VPS (default — reports only):
cd /opt/universal_agent && PYTHONPATH=src uv run python \
    -m universal_agent.scripts.csi_demo_triage_apply_policy

# Actually dismiss:
cd /opt/universal_agent && PYTHONPATH=src uv run python \
    -m universal_agent.scripts.csi_demo_triage_apply_policy --apply
```

JSON output mode (`--json`) and an env-gated cron mode (`--require-env-opt-in` + `UA_CSI_TRIAGE_AUTO_POLICY_ENABLED=1`) are wired so we can schedule this later without code changes.

## Test plan

- [x] 15 unit tests in `tests/unit/test_csi_demo_triage_policy.py` covering:
    - Default tier-3 scope (tier-4 never targeted)
    - 14-day age floor
    - Dry-run preserves state
    - Apply mutates state
    - `decided_by` stamped correctly
    - Recent candidates preserved
    - High-score candidates preserved
    - NULL-score candidates dismissed when old
    - Already-dismissed / approved candidates skipped
    - Custom policy can target tier-4 (operator opt-in path)
    - Env switch truthy/falsy/default-off
- [x] `uv run ruff check …` clean
- [ ] After deploy: dry-run on VPS to see the impact across the 96 backlog candidates. Then `--apply` once the diff looks right.

## Follow-ups

1. Cron registration (after operator validates defaults via dry-run + apply).
2. Auto-approve scoped to specific action types (separate PR, opt-in only).