### PR TITLE
feat(csi): one-off override flags for triage auto-policy CLI

### DIFF
--- a/src/universal_agent/scripts/csi_demo_triage_apply_policy.py
+++ b/src/universal_agent/scripts/csi_demo_triage_apply_policy.py
@@ -21,6 +21,7 @@ import sys
 
 from universal_agent.services.csi_demo_triage_policy import (
     DEFAULT_POLICIES,
+    StaleTierPolicy,
     apply_policies,
     policy_auto_apply_enabled,
 )
@@ -47,7 +48,67 @@ def _parse_args() -> argparse.Namespace:
             "policy via env flip without touching crontab."
         ),
     )
+    parser.add_argument(
+        "--age-days",
+        type=int,
+        default=None,
+        help=(
+            "Override max age in days. Default uses the configured policy "
+            "(14 days for tier-3). Lower for one-time aggressive sweeps; "
+            "raise to be more conservative."
+        ),
+    )
+    parser.add_argument(
+        "--max-score",
+        type=float,
+        default=None,
+        help=(
+            "Override max ranking_score for dismissal. Candidates with score "
+            "<= this OR NULL get dismissed. Default 5.0 for tier-3."
+        ),
+    )
+    parser.add_argument(
+        "--tier",
+        type=int,
+        default=None,
+        choices=[3, 4],
+        help=(
+            "Override which tier the policy targets. Default is the "
+            "configured policy (tier 3). Pass 4 ONLY for explicit one-time "
+            "purges of stale tier-4 candidates — operator-driven, not the "
+            "automatic default."
+        ),
+    )
+    parser.add_argument(
+        "--policy-name",
+        default=None,
+        help=(
+            "Override the policy name used in decided_by stamps. Useful for "
+            "one-off sweeps so the audit trail distinguishes them from the "
+            "default policy. Default: 'stale-tier-N-override' when other "
+            "overrides are provided, else the configured policy name."
+        ),
+    )
     return parser.parse_args()
+
+
+def _custom_policy_from_args(args: argparse.Namespace) -> StaleTierPolicy | None:
+    """Build a one-off StaleTierPolicy when the operator passed overrides."""
+    overrides = (args.age_days, args.max_score, args.tier)
+    if all(o is None for o in overrides):
+        return None
+    base = DEFAULT_POLICIES[0]
+    tier = args.tier if args.tier is not None else base.tier
+    max_age = args.age_days if args.age_days is not None else base.max_age_days
+    max_score = args.max_score if args.max_score is not None else base.max_ranking_score
+    name = args.policy_name or f"stale-tier-{tier}-override"
+    return StaleTierPolicy(
+        name=name,
+        tier=tier,
+        max_age_days=max_age,
+        max_ranking_score=max_score,
+        decided_by=f"auto-policy:{name}",
+    )
 
 
 def main() -> int:
@@ -64,7 +125,17 @@ def main() -> int:
     else:
         dry_run = not args.apply
 
-    report = apply_policies(dry_run=dry_run)
+    custom = _custom_policy_from_args(args)
+    policies = (custom,) if custom is not None else None
+    if custom is not None:
+        print(
+            f"using one-off policy: tier={custom.tier} "
+            f"max_age={custom.max_age_days}d max_score={custom.max_ranking_score} "
+            f"name={custom.name}",
+            file=sys.stderr,
+        )
+
+    report = apply_policies(dry_run=dry_run, policies=policies)
 
     if args.json:
         print(json.dumps(report, indent=2, ensure_ascii=True, sort_keys=True))

--- a/tests/unit/test_csi_demo_triage_apply_policy_cli.py
+++ b/tests/unit/test_csi_demo_triage_apply_policy_cli.py
@@ -1,0 +1,104 @@
+"""Tests for the override flags on csi_demo_triage_apply_policy CLI.
+
+The flags let an operator do one-time aggressive sweeps without editing
+code. The default policy stays conservative; overrides produce a new
+StaleTierPolicy with an audit-distinct decided_by stamp.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import pytest
+
+from universal_agent.scripts import csi_demo_triage_apply_policy as cli
+from universal_agent.services.csi_demo_triage_policy import (
+    DEFAULT_POLICIES,
+    StaleTierPolicy,
+)
+
+
+def _ns(**kwargs) -> argparse.Namespace:
+    defaults = {
+        "apply": False,
+        "json": False,
+        "require_env_opt_in": False,
+        "age_days": None,
+        "max_score": None,
+        "tier": None,
+        "policy_name": None,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+def test_no_overrides_returns_none():
+    """Without overrides the default policy stays in effect."""
+    assert cli._custom_policy_from_args(_ns()) is None
+
+
+def test_age_override_builds_custom_policy():
+    policy = cli._custom_policy_from_args(_ns(age_days=7))
+    assert policy is not None
+    assert policy.max_age_days == 7
+    assert policy.tier == DEFAULT_POLICIES[0].tier  # tier defaults to base
+    assert policy.max_ranking_score == DEFAULT_POLICIES[0].max_ranking_score
+    assert policy.decided_by.startswith("auto-policy:stale-tier-")
+
+
+def test_score_override_builds_custom_policy():
+    policy = cli._custom_policy_from_args(_ns(max_score=3.0))
+    assert policy is not None
+    assert policy.max_ranking_score == 3.0
+    assert policy.max_age_days == DEFAULT_POLICIES[0].max_age_days
+
+
+def test_tier_override_to_4_is_explicit_opt_in():
+    """tier=4 requires explicit operator override — the default never targets it."""
+    policy = cli._custom_policy_from_args(_ns(tier=4))
+    assert policy is not None
+    assert policy.tier == 4
+
+
+def test_custom_policy_name_propagates_to_decided_by():
+    policy = cli._custom_policy_from_args(_ns(age_days=5, policy_name="manual-cleanup"))
+    assert policy is not None
+    assert policy.name == "manual-cleanup"
+    assert policy.decided_by == "auto-policy:manual-cleanup"
+
+
+def test_default_policy_name_includes_tier_and_override_suffix():
+    """When no explicit name given, the name distinguishes overrides from default."""
+    policy = cli._custom_policy_from_args(_ns(age_days=5))
+    assert policy is not None
+    assert policy.name == "stale-tier-3-override"
+    assert policy.decided_by == "auto-policy:stale-tier-3-override"
+
+    policy_t4 = cli._custom_policy_from_args(_ns(tier=4, age_days=30))
+    assert policy_t4 is not None
+    assert policy_t4.name == "stale-tier-4-override"
+
+
+def test_all_three_overrides_build_correctly():
+    policy = cli._custom_policy_from_args(
+        _ns(age_days=7, max_score=3.0, tier=4, policy_name="emergency-purge")
+    )
+    assert policy is not None
+    assert policy.max_age_days == 7
+    assert policy.max_ranking_score == 3.0
+    assert policy.tier == 4
+    assert policy.name == "emergency-purge"
+
+
+def test_max_score_can_be_zero():
+    """max_score=0.0 must not collapse to falsy 'no override' check."""
+    policy = cli._custom_policy_from_args(_ns(max_score=0.0))
+    assert policy is not None
+    assert policy.max_ranking_score == 0.0
+
+
+def test_age_days_can_be_zero():
+    """age_days=0 means 'older than zero days' — a no-op upper bound. Still a valid override."""
+    policy = cli._custom_policy_from_args(_ns(age_days=0))
+    assert policy is not None
+    assert policy.max_age_days == 0


### PR DESCRIPTION
## Summary

Follow-up to #345. The default policy (tier-3, age>14d, score≤5) is calibrated for steady-state queue trimming. With 87 pending candidates and none yet older than 14 days, the dry-run returns 0 matches and the operator has no way to run a one-time aggressive sweep without editing code.

This PR adds CLI overrides so the operator can tune the policy for ad-hoc cleanups while leaving the default conservative.

## New flags

- \`--age-days N\` — override max age (days)
- \`--max-score F\` — override ranking_score threshold
- \`--tier T\` — opt in to targeting tier 4 (explicit per-invocation only)
- \`--policy-name S\` — custom audit name for \`decided_by\`

When any override is provided, the script builds a one-off \`StaleTierPolicy\` overlaying the defaults. The audit stamp becomes \`auto-policy:stale-tier-N-override\` (or operator-supplied name) so the dashboard distinguishes manual sweeps from the steady-state default.

## Example usage

```bash
# Aggressive one-time tier-3 cleanup (7 days, score ≤ 4):
PYTHONPATH=src uv run python -m universal_agent.scripts.csi_demo_triage_apply_policy \
  --age-days 7 --max-score 4.0 --policy-name pre-triage-cleanup

# Add --apply when the dry-run diff looks right
```

## Test plan

- [x] 9 new unit tests in \`tests/unit/test_csi_demo_triage_apply_policy_cli.py\` covering each override, full combination, audit name, and edge cases (max_score=0, age_days=0 — must register as overrides, not falsy)
- [x] Default behavior (no overrides) preserved — exercised in #345's tests
- [ ] After deploy: \`--age-days 5 --max-score 4 --policy-name dry-pass\` on VPS to preview the actual stale-tier-3 set, then \`--apply\`