### PR TITLE
feat(canvas): Phase 4 close-out — PR validate hook + preship + weekly drift cron

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -129,6 +129,26 @@ jobs:
             exit 1
           fi
 
+      - name: Architecture canvas pointer verify (only when canvas touched)
+        run: |
+          # Anti-rot gate for the Architecture Canvas. Only fires when this
+          # PR touches the canvas sources, drill-downs, or build script —
+          # untouched PRs don't pay the cost. Failures here mean a `source:`
+          # pointer in a YAML exhibit references a path that no longer
+          # exists on disk; fix the YAML or remove the dead reference.
+          # See: docs/02_Subsystems/Architecture_Canvas_View.md §6.
+          CANVAS_TOUCHED=$(git diff --name-only --diff-filter=AMR \
+              "origin/${{ github.base_ref }}...HEAD" \
+              | grep -E '^(docs/architecture-view/|scripts/build_architecture_view\.py$)' \
+              || true)
+          if [ -z "$CANVAS_TOUCHED" ]; then
+            echo "Canvas not touched in this PR; skipping pointer verify."
+            exit 0
+          fi
+          echo "Canvas-touching files in PR:"
+          echo "$CANVAS_TOUCHED" | sed 's/^/  /'
+          uv run scripts/build_architecture_view.py --verify-only
+
       - name: Ruff check (changed files only, errors-only gate)
         if: steps.changed.outputs.files != ''
         run: |

--- a/docs/02_Subsystems/Architecture_Canvas_View.md
+++ b/docs/02_Subsystems/Architecture_Canvas_View.md
@@ -101,13 +101,16 @@ The Architecture Canvas is that picture. It is **not** a dashboard (no live data
 
 **Renderer extensions:** new `mermaid_panel`, `html_grid`, `html_list` renderers in `scripts/build_architecture_view.py`. Layout migrated to 3-column grid for mid + lower rows.
 
-### Phase 4 — Wiring (operational integration)
+### Phase 4 — Wiring (operational integration) — **COMPLETE 2026-05-18**
 
 **Status:**
-- [x] **Dashboard sidebar link** — `web-ui/components/dashboard/GlobalSidebar.tsx` exposes "Architecture Map" in the Operations group (shipped in PR #342, 2026-05-18).
-- [x] **`just canvas` / `just canvas-verify` recipes** — added to `justfile`. Run `just canvas` to rebuild; `just canvas-verify` checks pointers without re-rendering.
-- [ ] **Pre-commit hook (deferred).** Repo currently has no `.pre-commit-config.yaml`. Adding one project-wide is out of scope for this PR. Workaround: run `just canvas-verify` manually before pushing, or chain it into `just preship` once you want it on the critical path.
-- [ ] **Weekly drift cron (deferred — requires operator sign-off).** Cron registration goes through `gateway_server._register_system_cron_job`. Suggested cadence: Mondays 06:30 America/Chicago (active hours, content-generation-adjacent). Suggested action: run `just canvas-verify` and post any newly red/missing pointer paths via `notification_dispatcher.py`. Not auto-registered here — the operator should choose the cadence + decide whether the notification should fire as an email or a Mission Control event.
+- [x] **Dashboard sidebar link** — `web-ui/components/dashboard/GlobalSidebar.tsx` exposes "Architecture Map" in the Operations group (shipped in PR #342).
+- [x] **`just canvas` / `just canvas-verify` recipes** — added to `justfile`. `just canvas` rebuilds; `just canvas-verify` checks pointers without re-rendering.
+- [x] **`just preship` chains `canvas-verify`** — the operator-side pre-ship gate now includes pointer verification alongside lint + unit tests.
+- [x] **PR Validate CI step** — `.github/workflows/pr-validate.yml` runs `--verify-only` automatically on every PR that touches `docs/architecture-view/` or `scripts/build_architecture_view.py`. PRs that don't touch the canvas pay zero cost; PRs that do are blocked on missing pointers.
+- [x] **Weekly drift cron** — registered via `_ensure_architecture_canvas_drift_cron_job` in `gateway_server.py`. Default schedule **Mondays 06:30 America/Chicago** (active hours; content-generation-adjacent under the dormancy default). Implementation: `src/universal_agent/scripts/architecture_canvas_drift_check.py` runs `--verify-only`, exits non-zero on **missing** pointers (surfaces as a failed cron tick on `/dashboard/cron-jobs`), writes `artifacts/architecture-canvas-drift/<date>.md` on **stale** pointers (exits 0; staleness is signal not failure), and is silent when everything is green. Env-controlled: `UA_ARCH_CANVAS_DRIFT_ENABLED`, `UA_ARCH_CANVAS_DRIFT_CRON`, `UA_ARCH_CANVAS_DRIFT_TIMEZONE`.
+
+**Why these notification choices.** Missing pointers route through cron-health because `/dashboard/cron-jobs` is already the canonical "did this scheduled job fail?" surface — no new UI needed. Stale pointers route to a dated markdown artifact because (a) email is quarantine-prone for this account, (b) Mission Control narrative cards are LLM-curated and overkill for a deterministic per-week drift report, and (c) the artifact format is self-explanatory and a natural place for the next operator pass to start fixing. The operator opens `artifacts/architecture-canvas-drift/YYYY-MM-DD.md` directly when they see a recent run on the cron-jobs page; no new UI required.
 
 ### Phase 5 — Optional polish
 

--- a/docs/02_Subsystems/Architecture_Canvas_View.md
+++ b/docs/02_Subsystems/Architecture_Canvas_View.md
@@ -186,6 +186,23 @@ Exits non-zero if any `source:` path no longer exists.
 
 Registered via `gateway_server._register_system_cron_job` per CLAUDE.md rule. Runs Mondays 06:30 America/Chicago (within active hours; respects dormancy default — this is content-generation-adjacent, so it fires during waking hours). Reports any newly red pointers via `notification_dispatcher.py`.
 
+## 6.5 Lessons learned (PR #350 close-out)
+
+The Phase 4 close-out PR caught a quality-gate failure in CI that's worth recording so the same class of mistake doesn't recur.
+
+**What happened.** The first revision of `src/universal_agent/scripts/architecture_canvas_drift_check.py` shelled out to the build script via `subprocess.run(["uv", "run", "scripts/build_architecture_view.py", "--verify-only"])`. That tripped `tests/unit/test_task_observability_coverage.py::test_subprocess_spawns_use_observability_protocol` — an AST-based ratchet that scans every file under `src/universal_agent/` for subprocess-spawn calls and requires either a compliant-helper import (from `services.worker_exit_classifier`, `services.cron_task_hub_link`, or `task_hub.record_worker_pid`) OR an entry in `tests/unit/task_observability_coverage_allowlist.txt`. The script had neither, so CI blocked merge of PR #350.
+
+**Root cause — two layers.**
+1. **Code:** the drift script reached for `subprocess.run` reflexively because the build script is "script-shaped." The build module is pure Python — there was no need to spawn anything. Importing the verification functions directly is the right pattern.
+2. **Process:** `just preship` was advertised as "the same gates as pr-validate.yml" but the recipe chained `just lint` (whole-repo ruff scan) which surfaces ~8000 lines of pre-existing rot the CI gate explicitly carves out. Running preship locally before pushing would therefore have failed for unrelated reasons, masking the protocol-test signal.
+
+**Durable fixes (this PR).**
+- Drift script now uses `importlib.util.spec_from_file_location` to load `scripts/build_architecture_view.py` as a module and calls its `load_exhibits()` + `verify_pointers()` directly. No subprocess; protocol test passes.
+- Important importlib gotcha captured in code comments: the loaded module **must** be registered in `sys.modules` BEFORE `exec_module` runs, otherwise `@dataclass` decoration fails on Python 3.13 with `AttributeError: 'NoneType' object has no attribute '__dict__'` inside `dataclasses._is_type`.
+- `justfile` adds a `lint-pr-scope` recipe that mirrors `pr-validate.yml` exactly (errors-only rules, changed-file scope vs `origin/main`). `preship` now chains `lint-pr-scope + test + canvas-verify` instead of the whole-repo `lint`. The whole-repo `lint` recipe stays available for operators who want to audit accumulated rot, but the comment now warns against chaining it into preship.
+
+**What to do for future cron-scripts.** Any new file under `src/universal_agent/scripts/` that wants to invoke another Python script should prefer `importlib.util` import over `subprocess.run` — the protocol test will fail every PR that spawns subprocesses without compliant-helper wiring, and 95% of the time the simpler answer is "don't spawn." Reach for `subprocess` only when you're actually invoking an external binary or running code in a different runtime.
+
 ## 7. Open follow-ups
 
 - **Dashboard wiring** — Phase 4. The HTML exists in `web-ui/public/`; the dashboard link is not yet added. When wired, the link should sit in the global sidenav near "Mission Control."

--- a/justfile
+++ b/justfile
@@ -99,18 +99,44 @@ test:
 test-one TEST:
     PYTHONPATH=src uv run --frozen pytest {{TEST}} -x -q
 
-# Lint.
+# Whole-repo ruff scan (all rules, all files). Surfaces pre-existing rot
+# the codebase has accumulated. Use this when you want a full picture;
+# do NOT chain it into preship — it includes ~8000 legacy findings the
+# CI gate explicitly carves out.
 lint:
     uv run --frozen ruff check .
+
+# Lint with the SAME scope CI uses: errors-only rules, changed Python
+# files only, evaluated against origin/main. This is what pr-validate.yml
+# runs; mirroring it here means `just preship` actually matches CI.
+# See: .github/workflows/pr-validate.yml § "Ruff check (changed files only)".
+lint-pr-scope:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    git fetch origin main --quiet 2>/dev/null || true
+    CHANGED=$(git diff --name-only --diff-filter=AMR origin/main...HEAD -- '*.py' || true)
+    if [ -z "$CHANGED" ]; then
+      echo "No Python files changed vs origin/main; nothing for pr-scope ruff to check."
+      exit 0
+    fi
+    echo "Linting (pr-scope, errors-only) on changed .py files:"
+    echo "$CHANGED" | sed 's/^/  /'
+    uv run --frozen ruff check \
+        --select E9,F \
+        --ignore E402,F401,F541,F811,F841 \
+        --no-cache \
+        $CHANGED
 
 # Auto-format.
 format:
     uv run --frozen ruff format .
 
-# Pre-ship: lint + unit tests + architecture canvas pointer verify, the
-# same gates as pr-validate.yml.
-preship: lint test canvas-verify
-    @echo "✅ Lint + unit tests + canvas pointers green. Safe to /ship."
+# Pre-ship: lint (changed-file scope) + unit tests + architecture canvas
+# pointer verify. These are the gates pr-validate.yml runs in CI; the
+# whole-repo `lint` recipe deliberately is NOT chained here because it
+# includes pre-existing rot the CI gate carves out.
+preship: lint-pr-scope test canvas-verify
+    @echo "✅ pr-scope lint + unit tests + canvas pointers green. Safe to /ship."
 
 # ---------------------------------------------------------------------------
 # Architecture Canvas

--- a/justfile
+++ b/justfile
@@ -107,9 +107,10 @@ lint:
 format:
     uv run --frozen ruff format .
 
-# Pre-ship: lint + unit tests, the same gates as pr-validate.yml.
-preship: lint test
-    @echo "✅ Lint + unit tests green. Safe to /ship."
+# Pre-ship: lint + unit tests + architecture canvas pointer verify, the
+# same gates as pr-validate.yml.
+preship: lint test canvas-verify
+    @echo "✅ Lint + unit tests + canvas pointers green. Safe to /ship."
 
 # ---------------------------------------------------------------------------
 # Architecture Canvas

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -14462,6 +14462,7 @@ async def lifespan(app: FastAPI):
                 _ensure_proactive_artifact_digest_cron_job()
                 _ensure_vp_coder_workspace_pruning_cron_job()
                 _ensure_vp_mission_pr_reconciler_cron_job()
+                _ensure_architecture_canvas_drift_cron_job()
                 _ensure_hackernews_snapshot_cron_job()
                 _ensure_atlas_direct_dispatch_cron_job()
                 _ensure_simone_chat_autocomplete_cron_job()
@@ -18235,6 +18236,41 @@ def _ensure_vp_coder_workspace_pruning_cron_job() -> Optional[dict[str, Any]]:
         timezone_env_var="UA_VP_CODER_WORKSPACE_PRUNING_TIMEZONE",
         # Ship 4 (Task Hub Observability Protocol): opted IN. Even GC
         # sweeps benefit from "did it run cleanly?" visibility.
+    )
+
+
+def _ensure_architecture_canvas_drift_cron_job() -> Optional[dict[str, Any]]:
+    """Weekly anti-rot sweep for the Architecture Canvas pointer pipeline.
+
+    Mondays 06:30 America/Chicago (active hours; content-generation-
+    adjacent so dormancy applies and we wake AFTER 06:00). Re-runs
+    `scripts/build_architecture_view.py --verify-only` and:
+
+      - exits non-zero if any `source:` path is missing (cron tick fails
+        → visible in /dashboard/cron-jobs)
+      - writes `artifacts/architecture-canvas-drift/<date>.md` when stale
+        pointers (>30d untouched) exist, exits 0 so the tick is "clean"
+      - silent when everything is green
+
+    See: docs/02_Subsystems/Architecture_Canvas_View.md §4 Phase 4.
+
+    `skip_task_hub_link=True` — this is a sweep, not a work-producing
+    job. We do NOT want every Monday tick creating a new task_hub row.
+    """
+    return _register_system_cron_job(
+        system_job="architecture_canvas_drift",
+        default_cron="30 6 * * 1",
+        default_timezone="America/Chicago",
+        command="!script universal_agent.scripts.architecture_canvas_drift_check",
+        description=(
+            "Weekly Architecture Canvas pointer drift check; fails the tick "
+            "on missing pointers, writes a markdown report on staleness."
+        ),
+        timeout_seconds=120,
+        enabled=_proactive_cron_enabled("UA_ARCH_CANVAS_DRIFT_ENABLED"),
+        cron_env_var="UA_ARCH_CANVAS_DRIFT_CRON",
+        timezone_env_var="UA_ARCH_CANVAS_DRIFT_TIMEZONE",
+        skip_task_hub_link=True,
     )
 
 

--- a/src/universal_agent/scripts/architecture_canvas_drift_check.py
+++ b/src/universal_agent/scripts/architecture_canvas_drift_check.py
@@ -16,7 +16,19 @@ pointer verification and surfaces drift in two ways:
 
 If both counts are zero, the script is silent (no artifact, exit 0).
 
-Wired in by: `_ensure_architecture_canvas_drift_cron_job` in
+Implementation note: this module loads ``scripts/build_architecture_view.py``
+via :func:`importlib.util.spec_from_file_location` and calls its
+``load_exhibits()`` + ``verify_pointers()`` functions directly. Earlier
+versions shelled out to ``uv run scripts/build_architecture_view.py
+--verify-only`` via :mod:`subprocess`, but that tripped the Task Hub
+Observability Protocol guard (``tests/unit/test_task_observability_coverage.py``)
+which requires every subprocess-spawning file in ``src/universal_agent/``
+to import a compliant helper OR be in the allowlist. Importing the
+verification functions directly is the right answer here — there is no
+worker to observe, and the in-process call is faster than spawning a
+fresh ``uv run`` per Monday tick (no venv warm-up, no shell layer).
+
+Wired in by: ``_ensure_architecture_canvas_drift_cron_job`` in
 ``gateway_server.py``. Disable via ``UA_ARCH_CANVAS_DRIFT_ENABLED=0``.
 Reschedule via ``UA_ARCH_CANVAS_DRIFT_CRON``.
 
@@ -25,10 +37,12 @@ See: docs/02_Subsystems/Architecture_Canvas_View.md §6.
 from __future__ import annotations
 
 import datetime as dt
+import importlib.util
 import logging
-import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -37,53 +51,62 @@ BUILD_SCRIPT = REPO_ROOT / "scripts" / "build_architecture_view.py"
 ARTIFACTS_DIR = REPO_ROOT / "artifacts" / "architecture-canvas-drift"
 
 
-def _run_verify() -> tuple[int, str]:
-    """Run the build script in --verify-only mode, capture output."""
-    proc = subprocess.run(
-        ["uv", "run", str(BUILD_SCRIPT), "--verify-only"],
-        cwd=str(REPO_ROOT),
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    combined = proc.stdout + proc.stderr
-    return proc.returncode, combined
+def _load_build_module() -> ModuleType:
+    """Load `scripts/build_architecture_view.py` as a module without spawning
+    a subprocess. The build script's ``if __name__ == "__main__":`` guard is
+    not triggered because we set the module name to ``_canvas_build``.
+
+    The module is registered in :data:`sys.modules` BEFORE
+    ``spec.loader.exec_module`` runs. Without this step, the build script's
+    use of ``@dataclass`` raises ``AttributeError: 'NoneType' object has no
+    attribute '__dict__'`` on Python 3.13 because
+    ``dataclasses._is_type`` calls ``sys.modules.get(cls.__module__).__dict__``
+    while processing each dataclass field. See
+    https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly.
+    """
+    spec = importlib.util.spec_from_file_location("_canvas_build", BUILD_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not build importlib spec for {BUILD_SCRIPT}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_canvas_build"] = mod
+    spec.loader.exec_module(mod)
+    return mod
 
 
-def _parse_counts(output: str) -> tuple[int, int]:
-    """Extract stale/missing counts from the build script's stdout."""
-    stale = missing = 0
-    for line in output.splitlines():
-        if "stale:" in line and "missing:" in line:
-            # Line shape: "[build] verified N pointers — stale: X, missing: Y"
-            try:
-                stale_str = line.split("stale:")[1].split(",")[0].strip()
-                missing_str = line.split("missing:")[1].strip().rstrip(".")
-                stale = int(stale_str)
-                missing = int(missing_str)
-            except (ValueError, IndexError):
-                pass
-    return stale, missing
-
-
-def _write_drift_report(stale: int, missing: int, output: str) -> Path:
+def _write_drift_report(stale: int, missing: int, statuses: dict[str, Any]) -> Path:
     ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
     date_str = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
     report_path = ARTIFACTS_DIR / f"{date_str}.md"
-    body = (
-        f"# Architecture Canvas drift report — {date_str}\n\n"
-        f"- Stale pointers (amber/red, >30 days untouched): **{stale}**\n"
-        f"- Missing pointers (path no longer exists): **{missing}**\n\n"
-        "## Build script output\n\n"
-        "```\n"
-        f"{output.strip()}\n"
-        "```\n\n"
-        "## Next step\n\n"
+
+    stale_lines: list[str] = []
+    missing_lines: list[str] = []
+    for path, status in sorted(statuses.items()):
+        if not status.exists:
+            missing_lines.append(f"- `{path}` — path no longer exists")
+        elif status.badge in ("red", "amber"):
+            age = f"{status.days_ago}d" if status.days_ago is not None else "unknown age"
+            stale_lines.append(f"- `{path}` — {status.badge}, last touched {age}")
+
+    body_parts = [
+        f"# Architecture Canvas drift report — {date_str}",
+        "",
+        f"- Stale pointers (amber/red, >30 days untouched): **{stale}**",
+        f"- Missing pointers (path no longer exists): **{missing}**",
+        "",
+    ]
+    if missing_lines:
+        body_parts.extend(["## Missing pointers", ""] + missing_lines + [""])
+    if stale_lines:
+        body_parts.extend(["## Stale pointers", ""] + stale_lines + [""])
+    body_parts.extend([
+        "## Next step",
+        "",
         "Open `docs/architecture-view/sources/*.yaml`, find pointers whose paths "
         "are missing or whose targets have been renamed, and update them. Rerun "
-        "`just canvas` after fixes to regenerate the rendered HTML.\n"
-    )
-    report_path.write_text(body, encoding="utf-8")
+        "`just canvas` after fixes to regenerate the rendered HTML.",
+        "",
+    ])
+    report_path.write_text("\n".join(body_parts), encoding="utf-8")
     return report_path
 
 
@@ -94,21 +117,33 @@ def main() -> int:
         logger.error("Build script not found at %s", BUILD_SCRIPT)
         return 2
 
-    rc, output = _run_verify()
-    stale, missing = _parse_counts(output)
+    try:
+        build = _load_build_module()
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to load build module: %s", exc)
+        return 2
+
+    try:
+        exhibits = build.load_exhibits()
+        statuses, stale, missing = build.verify_pointers(exhibits)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Pointer verification failed: %s", exc)
+        return 2
+
     logger.info(
-        "architecture canvas verify: rc=%d stale=%d missing=%d", rc, stale, missing
+        "architecture canvas verify: total=%d stale=%d missing=%d",
+        len(statuses), stale, missing,
     )
 
     if missing > 0:
         # Surface as a failed cron tick (visible in /dashboard/cron-jobs).
-        logger.error(
-            "MISSING POINTERS in architecture canvas — see build output above."
-        )
-        return 1 if rc == 0 else rc
+        for path, status in sorted(statuses.items()):
+            if not status.exists:
+                logger.error("  missing pointer: %s", path)
+        return 1
 
     if stale > 0:
-        report = _write_drift_report(stale, missing, output)
+        report = _write_drift_report(stale, missing, statuses)
         logger.info("Wrote drift report to %s", report)
     else:
         logger.info("No drift detected; staying silent.")

--- a/src/universal_agent/scripts/architecture_canvas_drift_check.py
+++ b/src/universal_agent/scripts/architecture_canvas_drift_check.py
@@ -1,0 +1,120 @@
+"""Architecture Canvas — weekly drift check.
+
+Runs Mondays 06:30 America/Chicago by default. Re-runs the build script's
+pointer verification and surfaces drift in two ways:
+
+- **Missing pointers** (a `source:` path no longer exists): the script exits
+  non-zero. The cron service records the tick as a failed run, which is
+  visible on the `/dashboard/cron-jobs` surface — operator notices in the
+  normal cron-health flow.
+
+- **Stale pointers** (a path exists but hasn't been touched within the
+  green/amber/red freshness thresholds): the script writes a structured
+  drift report to ``artifacts/architecture-canvas-drift/<date>.md`` for
+  later inspection. Exit code stays 0 so the cron tick is "successful" —
+  staleness is signal, not failure.
+
+If both counts are zero, the script is silent (no artifact, exit 0).
+
+Wired in by: `_ensure_architecture_canvas_drift_cron_job` in
+``gateway_server.py``. Disable via ``UA_ARCH_CANVAS_DRIFT_ENABLED=0``.
+Reschedule via ``UA_ARCH_CANVAS_DRIFT_CRON``.
+
+See: docs/02_Subsystems/Architecture_Canvas_View.md §6.
+"""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "build_architecture_view.py"
+ARTIFACTS_DIR = REPO_ROOT / "artifacts" / "architecture-canvas-drift"
+
+
+def _run_verify() -> tuple[int, str]:
+    """Run the build script in --verify-only mode, capture output."""
+    proc = subprocess.run(
+        ["uv", "run", str(BUILD_SCRIPT), "--verify-only"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    combined = proc.stdout + proc.stderr
+    return proc.returncode, combined
+
+
+def _parse_counts(output: str) -> tuple[int, int]:
+    """Extract stale/missing counts from the build script's stdout."""
+    stale = missing = 0
+    for line in output.splitlines():
+        if "stale:" in line and "missing:" in line:
+            # Line shape: "[build] verified N pointers — stale: X, missing: Y"
+            try:
+                stale_str = line.split("stale:")[1].split(",")[0].strip()
+                missing_str = line.split("missing:")[1].strip().rstrip(".")
+                stale = int(stale_str)
+                missing = int(missing_str)
+            except (ValueError, IndexError):
+                pass
+    return stale, missing
+
+
+def _write_drift_report(stale: int, missing: int, output: str) -> Path:
+    ARTIFACTS_DIR.mkdir(parents=True, exist_ok=True)
+    date_str = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+    report_path = ARTIFACTS_DIR / f"{date_str}.md"
+    body = (
+        f"# Architecture Canvas drift report — {date_str}\n\n"
+        f"- Stale pointers (amber/red, >30 days untouched): **{stale}**\n"
+        f"- Missing pointers (path no longer exists): **{missing}**\n\n"
+        "## Build script output\n\n"
+        "```\n"
+        f"{output.strip()}\n"
+        "```\n\n"
+        "## Next step\n\n"
+        "Open `docs/architecture-view/sources/*.yaml`, find pointers whose paths "
+        "are missing or whose targets have been renamed, and update them. Rerun "
+        "`just canvas` after fixes to regenerate the rendered HTML.\n"
+    )
+    report_path.write_text(body, encoding="utf-8")
+    return report_path
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+    if not BUILD_SCRIPT.exists():
+        logger.error("Build script not found at %s", BUILD_SCRIPT)
+        return 2
+
+    rc, output = _run_verify()
+    stale, missing = _parse_counts(output)
+    logger.info(
+        "architecture canvas verify: rc=%d stale=%d missing=%d", rc, stale, missing
+    )
+
+    if missing > 0:
+        # Surface as a failed cron tick (visible in /dashboard/cron-jobs).
+        logger.error(
+            "MISSING POINTERS in architecture canvas — see build output above."
+        )
+        return 1 if rc == 0 else rc
+
+    if stale > 0:
+        report = _write_drift_report(stale, missing, output)
+        logger.info("Wrote drift report to %s", report)
+    else:
+        logger.info("No drift detected; staying silent.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the two operator-discretion items deferred from PR #347 (the v1+Phase 2/3 ship):

1. **Pre-commit-style enforcement** — the v1 plan deferred a `.pre-commit-config.yaml` because the repo doesn't have one. Instead this PR wires the canvas pointer verify into the two gates that already exist: `just preship` (operator-side) and `.github/workflows/pr-validate.yml` (CI-side).
2. **Weekly drift cron** — Mondays 06:30 America/Chicago, with intentional notification routing.

## Changes

**CI / operator gates:**
- `justfile`: `preship` now chains `canvas-verify` alongside `lint` and `test`.
- `pr-validate.yml`: new conditional step. When the PR touches `docs/architecture-view/` or `scripts/build_architecture_view.py`, runs `--verify-only` and blocks merge on missing pointers. Untouched PRs pay zero cost (skips with a one-line message).

**Cron:**
- New `src/universal_agent/scripts/architecture_canvas_drift_check.py` — runs `--verify-only`, writes `artifacts/architecture-canvas-drift/<date>.md` on stale pointers, exits non-zero on missing pointers.
- `_ensure_architecture_canvas_drift_cron_job()` in `gateway_server.py` registers the schedule via the canonical `_register_system_cron_job` API. Env-tunable: `UA_ARCH_CANVAS_DRIFT_ENABLED`, `UA_ARCH_CANVAS_DRIFT_CRON`, `UA_ARCH_CANVAS_DRIFT_TIMEZONE`. `skip_task_hub_link=True` per Task Hub Observability Protocol — this is a sweep, not work-producing.

**Docs:**
- `Architecture_Canvas_View.md` §4: all five Phase 4 checkboxes flipped to `[x]` with the notification-routing rationale recorded.

## Notification routing — and why

| Signal | Route | Reason |
|---|---|---|
| Missing pointer | Non-zero exit → cron tick fails → visible in `/dashboard/cron-jobs` | Canonical "did this scheduled job fail" surface; no new UI needed |
| Stale pointer (amber/red, >30d) | `artifacts/architecture-canvas-drift/<date>.md` | Email is quarantine-prone; Mission Control narrative cards are LLM-curated overkill for a deterministic weekly drift signal; a dated markdown is a natural starting point for the next operator pass |
| Everything green | Silent | No notification churn |

## Verification

- `gateway_server.py` py_compiles cleanly with the new function inserted.
- Drift script ran end-to-end locally: rc=0, stale=2, missing=0 → wrote `artifacts/architecture-canvas-drift/2026-05-18.md` with the expected structure.
- `artifacts/` is gitignored — drift reports don't pollute git history.

## Test plan

- [ ] Once merged, after the next gateway restart the new cron `architecture_canvas_drift` shows up in `/dashboard/cron-jobs` with the Monday 06:30 schedule.
- [ ] Manually triggering it produces `artifacts/architecture-canvas-drift/<date>.md` on the VPS with stale=2 missing=0 (matches current state).
- [ ] A PR that intentionally breaks a pointer (e.g. renames a referenced file but not its YAML reference) gets blocked by the new pr-validate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)