### PR TITLE
chore(editor): stop git extension from scanning .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ tmp/vps_security_env_keys_*.env
 identity_registry.json
 
 # === IDEs ===
-.vscode/
+.vscode/*
+!.vscode/settings.json
 .idea/
 .windsurf/
 *.code-workspace

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "makefile.configureOnOpen": false,
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.terminal.activateEnvironment": true,
+    "python.useEnvironmentsExtension": false,
+    "git.autoRepositoryDetection": "openEditors",
+    "git.repositoryScanMaxDepth": 1,
+    "git.repositoryScanIgnoredFolders": [
+        "**/.claude/worktrees",
+        "**/.claude/skills",
+        "**/.claude/agents"
+    ]
+}


### PR DESCRIPTION
## Summary
- Root-cause fix for Antigravity/VS Code's "too many active changes" balloon: the git extension auto-discovers nested `.git` files regardless of parent `.gitignore`, then chokes on harness-leaked worktrees under `.claude/worktrees/` (each is a full ~70K-file checkout).
- Adds `git.repositoryScanIgnoredFolders` + `git.autoRepositoryDetection: "openEditors"` to a tracked `.vscode/settings.json` so the editor stops scanning `.claude/worktrees`, `.claude/skills`, and `.claude/agents`.
- Adjusts `.gitignore`: `.vscode/` → `.vscode/*` with `!.vscode/settings.json` so workspace settings travel with the repo while `mcp.json` and other per-machine files stay ignored.
- Also removed the orphan dir `.claude/worktrees/claude-csi-grounding-html-detect/` (no `.git` link, not in `.git/worktrees/` admin — residue from a partial creation).

The 4 remaining registered worktrees each hold real unmerged commits and were left alone; they should be PR'd through normal flow, then `git worktree remove` cleans them up properly.

## Test plan
- [x] `python3 -c "import json; json.load(open('.vscode/settings.json'))"` — valid JSON
- [x] `git check-ignore -v .vscode/settings.json` → matches `!.vscode/settings.json` (tracked)
- [x] `git check-ignore -v .vscode/mcp.json` → still matches `.vscode/*` (ignored)
- [x] `git add --dry-run .vscode/` → only stages `settings.json`
- [ ] After merge: reopen workspace in Antigravity — "too many active changes" balloon should not return

🤖 Generated with [Claude Code](https://claude.com/claude-code)