### PR TITLE
fix(justfile): preship matches CI env (sync + UA_RUNTIME_STAGE strip)

### DIFF
--- a/justfile
+++ b/justfile
@@ -131,12 +131,36 @@ lint-pr-scope:
 format:
     uv run --frozen ruff format .
 
-# Pre-ship: lint (changed-file scope) + unit tests + architecture canvas
-# pointer verify. These are the gates pr-validate.yml runs in CI; the
-# whole-repo `lint` recipe deliberately is NOT chained here because it
-# includes pre-existing rot the CI gate carves out.
-preship: lint-pr-scope test canvas-verify
-    @echo "✅ pr-scope lint + unit tests + canvas pointers green. Safe to /ship."
+# Resolve dependencies against `uv.lock` so the worktree's `.venv`
+# matches what CI provisions. Required as the first preship step
+# because a stale local `.venv` (e.g. carried over from another branch
+# or an older Python pin) makes pytest fail in ways CI doesn't
+# reproduce. Mirrors pr-validate.yml's "Install project dependencies".
+sync:
+    uv sync --frozen 2>&1 | tail -5
+
+# Run unit tests in a CI-equivalent environment. Specifically, this
+# strips `UA_RUNTIME_STAGE` (which is set to `development` in operator
+# shells via .env and flips production-default feature gates OFF for
+# local dev — `should_run_loop("dispatch_stale_sweep", prod_default=True)`
+# is the obvious case). CI never sets UA_RUNTIME_STAGE, so unit tests
+# that rely on the production-default behavior pass there but fail
+# locally in ways that look like "flaky tests" but are really a
+# `.env`-vs-CI mismatch. Use this recipe whenever you want pytest to
+# reproduce what pr-validate.yml will see.
+test-ci-env:
+    env -u UA_RUNTIME_STAGE -u UA_DEV_HEARTBEAT_FORCE_ON -u UA_DEV_DISPATCH_FORCE_ON -u UA_DEV_AGENTMAIL_FORCE_ON \
+        PYTHONPATH=src uv run --frozen pytest tests/unit -x -q
+
+# Pre-ship: venv sync + lint (changed-file scope) + unit tests in
+# CI-equivalent env + architecture canvas pointer verify. These are the
+# gates pr-validate.yml runs in CI; the whole-repo `lint` recipe and the
+# regular `test` recipe are deliberately NOT chained here — the first
+# includes pre-existing rot the CI gate carves out, the second inherits
+# the operator's UA_RUNTIME_STAGE=development which flips production-
+# default feature gates OFF and makes tests that pass in CI fail locally.
+preship: sync lint-pr-scope test-ci-env canvas-verify
+    @echo "✅ venv synced + pr-scope lint + ci-env unit tests + canvas pointers green. Safe to /ship."
 
 # ---------------------------------------------------------------------------
 # Architecture Canvas


### PR DESCRIPTION
## Summary

Followup to #350 — closes two more sources of local-vs-CI divergence in the `just preship` recipe so running it before push gives the same signal CI will give.

## Problem

While debugging PR #350's CI failure I ran `just preship` locally to confirm my fix. The recipe failed on `tests/unit/test_dispatch_sweep_stale_release.py::test_dispatch_sweep_releases_stale_assignment_with_default_config` — a test that **passed in CI on the same commit**. The fix for #350 was unrelated to dispatch_sweep, so this was a separate divergence: the recipe was advertised as "the same gates as pr-validate.yml" but in practice diverged from CI in three ways, two of which were not addressed by #350's `lint-pr-scope` work:

1. **(addressed in #350)** Whole-repo `lint` vs pr-validate's changed-file-scoped ruff.
2. **(this PR)** Stale `.venv` carry-over between worktrees/branches.
3. **(this PR)** Operator shell exports `UA_RUNTIME_STAGE=development` via `.env`; `should_run_loop("dispatch_stale_sweep", prod_default=True)` reads it and flips the default OFF for local dev. CI has no such env var → default-ON → test passes. Local shell has it → default-OFF → test fails. Looks flaky; really an env mismatch.

## Fixes

- **`sync` recipe** — runs `uv sync --frozen`. Mirrors pr-validate.yml's "Install project dependencies" step.
- **`test-ci-env` recipe** — runs pytest with operator UA_* env vars stripped (`env -u UA_RUNTIME_STAGE -u UA_DEV_HEARTBEAT_FORCE_ON -u UA_DEV_DISPATCH_FORCE_ON -u UA_DEV_AGENTMAIL_FORCE_ON`). Use this whenever you want pytest to see what pr-validate sees.
- **`preship` chain** — now `sync + lint-pr-scope + test-ci-env + canvas-verify`. The standalone `test` recipe is unchanged so direct invocation in dev mode still works.

## Verification

`tests/unit/test_dispatch_sweep_stale_release.py`:
- Before this PR with `UA_RUNTIME_STAGE=development` in shell: **1 failed, 4 passed** (timing-sensitive default flag flipped OFF)
- After this PR (`env -u UA_RUNTIME_STAGE pytest ...`): **10 passed**

## Test plan

- [ ] `just preship` from a worktree with `UA_RUNTIME_STAGE=development` in the operator shell now passes the dispatch-sweep test.
- [ ] `just test` (standalone) keeps dev-mode behavior — runs with shell env intact.
- [ ] `pr-validate.yml` continues to pass on this PR (only the justfile changed).

## Followups (out of scope)

- The dispatch-sweep test itself is arguably under-pinned — it asserts a `prod_default=True` behavior without pinning `UA_RUNTIME_STAGE` via monkeypatch. Tests in `tests/unit/` should be runtime-stage-agnostic. Worth a separate sweep to find similar cases.
- Consider auto-loading `.env` in `just dev` but auto-clearing UA_* in `just preship` via a shared variable list so the unset-list stays in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)