### PR TITLE
feat(ci): auto-close ci-failure issues when workflow turns green on same branch

### DIFF
--- a/.github/workflows/ci-failure-issue.yml
+++ b/.github/workflows/ci-failure-issue.yml
@@ -2,7 +2,10 @@ name: CI Failure Issue Filer
 
 # Surfaces failed workflow runs as GitHub issues so the operator (and any
 # AI session reading the issue feed) discovers them immediately instead of
-# learning hours later that PR #N's Validate run failed silently.
+# learning hours later that PR #N's Validate run failed silently. Also
+# auto-closes those issues once a subsequent run of the SAME workflow on
+# the SAME branch turns green — closes the loop so the operator doesn't
+# accumulate stale issues for problems that were already fixed.
 #
 # Background (observed 2026-05-11): PR #221 had a failing `Validate PR`
 # run that sat unnoticed for hours. The operator's prompt — "Do we not
@@ -104,3 +107,64 @@ jobs:
             --title "${TITLE} — run_id=${RUN_ID}" \
             --body-file /tmp/issue-body.md \
             --label ci-failure
+
+  close-issue:
+    # Mirror of file-issue but for the "CI flipped green on this branch+workflow"
+    # signal. Closes any open ci-failure issues whose title matches the same
+    # workflow + branch as this successful run. Match is by branch, not SHA —
+    # PR #350's failure was filed for commit 75f54a48 but the green re-run
+    # was on 8f450812 (same branch, different SHA), and the underlying
+    # problem was resolved either way. Branch-level match handles that case.
+    #
+    # Without this job, ci-failure issues accumulate forever as historical
+    # debris even though their root cause merged; the operator has to close
+    # them by hand. Observed: PR #351 sat open after PR #350's success.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Close any ci-failure issues for this workflow + branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          set -euo pipefail
+          SHORT_SHA="${HEAD_SHA:0:7}"
+          # Title format from file-issue above:
+          #   "[ci-watchdog] {WORKFLOW_NAME} failed on {HEAD_BRANCH} ({sha}) — run_id={N}"
+          # We match on the unique substring "{WORKFLOW_NAME} failed on {HEAD_BRANCH}"
+          # which is stable across SHA changes for the same branch+workflow.
+          #
+          # List all open ci-failure issues, then filter in shell. This is
+          # more robust than gh's `--search` for branch names containing
+          # slashes or other special characters.
+          OPEN_JSON=$(gh issue list \
+            --repo "${REPO}" \
+            --label ci-failure \
+            --state open \
+            --limit 100 \
+            --json number,title)
+
+          # JQ extracts numbers whose title contains both the workflow name
+          # and "failed on $HEAD_BRANCH". Using `contains` not `==` so we
+          # match the full descriptive title.
+          MATCHES=$(echo "$OPEN_JSON" | jq -r \
+            --arg wf "${WORKFLOW_NAME} failed on ${HEAD_BRANCH}" \
+            '.[] | select(.title | contains($wf)) | .number')
+
+          if [ -z "$MATCHES" ]; then
+            echo "No open ci-failure issues to close for ${WORKFLOW_NAME} on ${HEAD_BRANCH}."
+            exit 0
+          fi
+
+          for NUM in $MATCHES; do
+            echo "Closing issue #${NUM} (workflow=${WORKFLOW_NAME} now green on ${HEAD_BRANCH} @ ${SHORT_SHA})"
+            gh issue comment "$NUM" --repo "${REPO}" --body \
+              "Auto-resolved: [${WORKFLOW_NAME}](${RUN_URL}) succeeded on branch \`${HEAD_BRANCH}\` at \`${SHORT_SHA}\` (run ${RUN_ID})."
+            gh issue close "$NUM" --repo "${REPO}" --reason completed
+          done


### PR DESCRIPTION
## Summary

Closes the loop on the CI-failure watchdog. Previously the workflow filed an issue on failure but never closed it when a subsequent run turned green — operator accumulated stale debris.

## Concrete trigger

PR #350's first push at \`75f54a48\` failed Validate. Watchdog filed issue #351. I pushed fix commit \`8f450812\`. Validate went green. PR auto-merged. Deploy ran. Everything autonomous. But issue #351 sat open until manually closed.

That's the gap. The pipeline absorbed my failure exactly the way the operator's prior investment intended; only the followup-issue paper trail leaked.

## Mechanism

New \`close-issue\` job in the same workflow file:

- Triggers on the same \`workflow_run\` event the filer watches
- Fires when \`conclusion == 'success'\` (filer fires on \`'failure'\`)
- Lists open \`ci-failure\` issues, filters in \`jq\` (not \`gh --search\`) to ones whose title contains \`"{WORKFLOW_NAME} failed on {HEAD_BRANCH}"\` — **branch-level match**, not SHA-level, so a green re-run on a different commit still closes the historic issue
- Comments with the resolving run URL, closes with \`reason=completed\`

Same workflow file because the logic is symmetric and the cross-reference between filer + closer is easier to read inline.

## What's NOT changed

- Filer behavior (still files on failure, dedups per run-id)
- Workflow list watched (Deploy / PR Validate / PR Auto-Merge / Auto-Promote / Nightly Docs / OpenClaw)
- 24/7 operation (infrastructure-event handler, dormancy-exempt per \`docs/operations/operating_hours_dormancy.md\`)

## Test plan

- [ ] After merge: manually close stale issue #351 (one-time cleanup)
- [ ] Next time a PR fails Validate and is fixed with a follow-up commit, observe: filer files new issue → closer auto-resolves with comment + closes when the green run completes
- [ ] If the operator force-pushes a fix that introduces a different failure on the same branch, the closer should close the old issue (resolved) and the filer should immediately file a new one (different run_id, distinct issue title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)