### PR TITLE
fix(youtube-digest): restore daily digest, harden cron preflight, bump LLM timeout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,14 @@ Also note: bare `claude` on Kevin's desktop lazy-loads `HOSTINGER_API_TOKEN` (an
 - Run tests: `uv run pytest`
 - Lint/format (if configured): `uv run ruff check .` / `uv run ruff format .`
 
+## VPS Autonomy (MUST READ)
+
+You have direct SSH access to the VPS as `ua@uaonvps` and full SSHFS at `/home/kjdragan/...`. **Do not hand the operator commands you can run yourself.** Asking "should I run X?" or "please run X" when X is a non-destructive, fully-scriptable command burns operator time and is explicitly disallowed.
+
+Default to running it. Stop and ask first only for: destructive operations (deletes, force-pushes, dropping data), operations that incur real cost the operator hasn't already authorized, anything that mutates external accounts (Google, GitHub, Stripe), or operations that touch production secrets in a way that could leak credentials into the transcript.
+
+Diagnostic reads, log tails, manual cron triggers, status checks, restarting `universal-agent.service` after a change you just made, and similar operational steps: just do them, narrate the result.
+
 ## Git Workflow (MUST READ)
 - Read [`docs/deployment/ai_coder_instructions.md`](docs/deployment/ai_coder_instructions.md) before your first commit. It defines branch discipline, commit conventions, `/ship` handoff, and the **Agent-Type → Workflow Matrix**.
 - **Branch model:** any branch → PR → `main` → Deploy. `develop` retired 2026-05-10. See [`04_Branching_And_Release_Workflow`](docs/06_Deployment_And_Environments/04_Branching_And_Release_Workflow.md).

--- a/URW/README.md
+++ b/URW/README.md
@@ -48,7 +48,7 @@ PYTHONPATH=src uv run python URW/phase0_runner.py \
 ```bash
 PYTHONPATH=src uv run python URW/phase1_receipt_runner.py \
   --workspace ./urw_phase1_workspace_run2 \
-  --to kevin.dragan@outlook.com \
+  --to kevinjdragan@gmail.com \
   --connection "clearspring-cg / all-clearspring-cg"
 ```
 

--- a/discord_intelligence/event_digest.py
+++ b/discord_intelligence/event_digest.py
@@ -209,7 +209,7 @@ async def run_pipeline():
                             svc = AgentMailService()
                             await svc.startup()
                             if svc._started:
-                                target_email = os.getenv("UA_USER_EMAIL", "kevin.dragan@outlook.com")
+                                target_email = os.getenv("UA_USER_EMAIL", "kevinjdragan@gmail.com")
                                 await svc.send_email(
                                     to=target_email,
                                     subject=f"Discord Insight: Action Items from {event['name']}",

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -18447,6 +18447,9 @@ def _ensure_youtube_daily_digest_cron_job() -> Optional[dict[str, Any]]:
             "FRIDAY_YT_PLAYLIST",
             "SATURDAY_YT_PLAYLIST",
             "SUNDAY_YT_PLAYLIST",
+            "YOUTUBE_OAUTH_CLIENT_ID",
+            "YOUTUBE_OAUTH_CLIENT_SECRET",
+            "YOUTUBE_OAUTH_REFRESH_TOKEN",
         ],
     }
     updates = {

--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -133,7 +133,7 @@ async def _generate_digest_content(full_prompt: str) -> str:
     client_kwargs: dict[str, Any] = {
         "api_key": api_key,
         "max_retries": 0,
-        "timeout": float(os.getenv("UA_YOUTUBE_DIGEST_LLM_TIMEOUT_SECONDS", "180")),
+        "timeout": float(os.getenv("UA_YOUTUBE_DIGEST_LLM_TIMEOUT_SECONDS", "900")),
     }
     base_url = os.getenv("ANTHROPIC_BASE_URL")
     if base_url:


### PR DESCRIPTION
## Summary

- The Daily YouTube Digest had not run successfully since 2026-04-30. Root cause: production Infisical env had no `YOUTUBE_OAUTH_*` secrets while dev had a revoked refresh token. Both are now corrected in Infisical (out-of-band); these are the code-side hardening changes.
- Add `YOUTUBE_OAUTH_CLIENT_ID/CLIENT_SECRET/REFRESH_TOKEN` to the digest cron's `required_secrets` so the next missing-secret failure surfaces as a `cron_run_failed` dashboard alert at preflight instead of crashing silently at 6 AM.
- Bump default `UA_YOUTUBE_DIGEST_LLM_TIMEOUT_SECONDS` from 180s → 900s. A 29-video Sunday playlist took ~3.5 min to synthesize on glm-5.1; 180s was cutting LLM completion off entirely.
- Flip outlook → gmail in two outbound-email fallback defaults that don't honor `UA_USER_EMAIL`: `discord_intelligence/event_digest.py` and `URW/README.md` example. Inbound trusted-sender allowlists unchanged.
- Add a "VPS Autonomy" working rule to `CLAUDE.md` to stop handing the operator commands the agent can run directly via SSH.

## Verification

Manual production run on 2026-05-18 against the SUNDAY playlist:

- Artifact: `/opt/universal_agent/AGENT_RUN_WORKSPACES/daily_digests/2026-05-18_SUNDAY_Digest.md` (29 videos synthesized)
- CSI digest emitted: `74814a70-c1f7-42e9-8a65-51b85ec7f3ef`
- 4 tutorial candidates dispatched to `/api/v1/hooks/youtube/manual`, all 200 OK (`{"ok": true, "action": "agent"}`)
- Email sent: AgentMail msg_id `0100019e3bd3f07c-13db4bbc-0002-42e1-af85-5314f58bb3aa-000000@email.amazonses.com` to `kevinjdragan@gmail.com`
- Processed-videos DB recorded all 29 (no re-run risk for SUNDAY)

## Test plan

- [ ] Tomorrow's 6 AM Central cron fires automatically against MONDAY_YT_PLAYLIST and email arrives at `kevinjdragan@gmail.com`
- [ ] If MONDAY playlist is empty, run.log shows graceful "Playlist is empty" exit
- [ ] No `cron_run_failed` dashboard alert (preflight passes because all required_secrets are present)