### PR TITLE
feat(youtube-digest): demo-worthiness gate before tutorial pipeline dispatch

### DIFF
--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -361,15 +361,62 @@ def _rank_digest_decisions(decisions: dict[str, Any], processed_items: list[dict
     return {"ranked_videos": ranked}
 
 
+DEMO_GATE_MIN_SCORE_DEFAULT = 70
+_DEMO_GATE_REJECT_EVIDENCE = {"metadata_only"}
+_DEMO_GATE_REJECT_TIERS = {"low", "unknown"}
+
+
+def _is_demo_worthy(row: dict[str, Any], *, min_score: int) -> tuple[bool, str]:
+    """Deterministic guardrails around the LLM's `code_implementation_prospect=true`.
+
+    The LLM is allowed to nominate candidates, but we don't dispatch a tutorial
+    pipeline run unless three additional signals (all present in the digest
+    decisions JSON the LLM already emits) agree the video is build-tutorial
+    material. Each signal can be tuned via env var.
+    """
+    if not _coerce_bool(row.get("code_implementation_prospect")):
+        return False, "not_code_implementation_prospect"
+    evidence = str(row.get("evidence_quality") or "").strip().lower()
+    if evidence in _DEMO_GATE_REJECT_EVIDENCE:
+        return False, f"evidence_quality={evidence or 'unknown'}"
+    score = int(row.get("value_score") or 0)
+    if score < min_score:
+        return False, f"value_score={score}<min={min_score}"
+    tier = str(row.get("value_tier") or "").strip().lower()
+    if tier in _DEMO_GATE_REJECT_TIERS:
+        return False, f"value_tier={tier or 'unknown'}"
+    return True, "ok"
+
+
 def _select_tutorial_dispatch_candidates(
     decisions: dict[str, Any],
     *,
     top_n: int,
+    min_score: int | None = None,
 ) -> list[dict[str, Any]]:
-    if top_n <= 0:
-        return []
-    candidates = [row for row in decisions.get("ranked_videos", []) if row.get("code_implementation_prospect") is True]
-    return candidates[:top_n]
+    """Annotate every ranked row with a `dispatch_*` triplet and return only
+    the top-N rows that pass the deterministic demo-worthiness gate.
+
+    Side-effect: each ranked row in `decisions["ranked_videos"]` gains
+    `dispatch_eligible`, `dispatch_reject_reason`, and `dispatch_status`
+    fields so the saved candidates JSON and the human-facing email both
+    surface why a video was (or wasn't) sent to the tutorial pipeline.
+    """
+    threshold = DEMO_GATE_MIN_SCORE_DEFAULT if min_score is None else max(0, int(min_score))
+    selected: list[dict[str, Any]] = []
+    for row in decisions.get("ranked_videos", []):
+        ok, reason = _is_demo_worthy(row, min_score=threshold)
+        row["dispatch_eligible"] = ok
+        row["dispatch_reject_reason"] = "" if ok else reason
+        if top_n <= 0 or not ok:
+            row["dispatch_status"] = "rejected" if not ok else "disabled_top_n_zero"
+            continue
+        if len(selected) < top_n:
+            row["dispatch_status"] = "selected"
+            selected.append(row)
+        else:
+            row["dispatch_status"] = "eligible_overflow"
+    return selected
 
 
 def _save_tutorial_candidates(
@@ -507,18 +554,22 @@ def _dispatch_tutorial_candidates(
 
 def _format_tutorial_dispatch_summary(
     *,
+    decisions: dict[str, Any],
     selected: list[dict[str, Any]],
     dispatch_results: list[dict[str, Any]],
     candidates_path: Path,
     dispatch_path: Path | None,
     top_n: int,
+    min_score: int,
     dry_run: bool,
 ) -> str:
     """Build the human-facing tutorial pipeline section for the digest email/artifact."""
     lines = [
         "## YouTube Tutorial Pipeline Dispatch",
         "",
-        f"Automation target: top {max(0, top_n)} code implementation prospects.",
+        f"Automation target: top {max(0, top_n)} code implementation prospects "
+        f"(deterministic demo-worthiness gate: score >= {min_score}, "
+        f"value_tier not in {{low, unknown}}, evidence_quality != metadata_only).",
     ]
     if dry_run:
         lines.append("Mode: dry run; no tutorial pipeline dispatches were sent.")
@@ -526,7 +577,7 @@ def _format_tutorial_dispatch_summary(
         lines.extend(
             [
                 "",
-                "No videos were selected for the tutorial pipeline because no ranked video was classified as a code implementation prospect.",
+                "No videos were sent to the tutorial pipeline. Either no ranked video was a code-implementation prospect, or every prospect was rejected by the demo-worthiness gate (see below).",
             ]
         )
     else:
@@ -542,6 +593,30 @@ def _format_tutorial_dispatch_summary(
                 f"({video_id}) — score {row.get('value_score')}; {status}. "
                 f"Reason: {row.get('reason') or 'classified as a code implementation prospect.'}"
             )
+
+    rejected = [
+        row
+        for row in decisions.get("ranked_videos", [])
+        if _coerce_bool(row.get("code_implementation_prospect"))
+        and row.get("dispatch_status") == "rejected"
+    ]
+    if rejected:
+        lines.extend(
+            [
+                "",
+                "Rejected by demo-worthiness gate (LLM marked code-prospect, but deterministic checks disagreed):",
+            ]
+        )
+        for row in rejected[:10]:
+            video_id = str(row.get("video_id") or "")
+            lines.append(
+                "- "
+                f"#{row.get('rank')} {row.get('title') or video_id} "
+                f"({video_id}) — score {row.get('value_score')}, "
+                f"tier {row.get('value_tier')}, evidence {row.get('evidence_quality')}; "
+                f"reject_reason: {row.get('dispatch_reject_reason') or 'unknown'}."
+            )
+
     lines.extend(["", f"Decision artifact: `{candidates_path}`"])
     if dispatch_path:
         lines.append(f"Dispatch results: `{dispatch_path}`")
@@ -895,6 +970,16 @@ def process_daily_digest(
     except ValueError:
         logger.warning("Invalid UA_YOUTUBE_DIGEST_AUTO_TUTORIAL_TOP_N; defaulting to 4")
         configured_top_n = 4
+    try:
+        configured_min_score = int(
+            os.getenv("UA_YOUTUBE_DIGEST_DEMO_GATE_MIN_SCORE", str(DEMO_GATE_MIN_SCORE_DEFAULT))
+        )
+    except ValueError:
+        logger.warning(
+            "Invalid UA_YOUTUBE_DIGEST_DEMO_GATE_MIN_SCORE; defaulting to %d",
+            DEMO_GATE_MIN_SCORE_DEFAULT,
+        )
+        configured_min_score = DEMO_GATE_MIN_SCORE_DEFAULT
     decisions = _rank_digest_decisions(
         _extract_decision_json(digest_content),
         processed_items,
@@ -902,6 +987,7 @@ def process_daily_digest(
     selected_tutorial_candidates = _select_tutorial_dispatch_candidates(
         decisions,
         top_n=configured_top_n,
+        min_score=configured_min_score,
     )
     candidates_path = _save_tutorial_candidates(
         day_name=day_name,
@@ -927,11 +1013,13 @@ def process_daily_digest(
         logger.info("Saved tutorial dispatch results: %s", dispatch_path)
 
     tutorial_dispatch_summary = _format_tutorial_dispatch_summary(
+        decisions=decisions,
         selected=selected_tutorial_candidates,
         dispatch_results=dispatch_results,
         candidates_path=candidates_path,
         dispatch_path=dispatch_path,
         top_n=configured_top_n,
+        min_score=configured_min_score,
         dry_run=dry_run,
     )
     full_content = (

--- a/tests/unit/test_youtube_daily_digest_demo_gate.py
+++ b/tests/unit/test_youtube_daily_digest_demo_gate.py
@@ -1,0 +1,154 @@
+"""Tests for the deterministic demo-worthiness gate around
+`_select_tutorial_dispatch_candidates`.
+
+The gate sits between the LLM's `code_implementation_prospect` self-classification
+and the actual dispatch to the YouTube tutorial pipeline. It exists to prevent
+sales pitches, product overviews, and metadata-only judgments from being
+sent to a build-tutorial agent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from universal_agent.scripts import youtube_daily_digest as ydd
+
+
+def _make_row(
+    *,
+    video_id: str,
+    code_prospect: bool = True,
+    score: int = 90,
+    tier: str = "high",
+    evidence: str = "transcript",
+    rank: int = 1,
+    title: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "video_id": video_id,
+        "title": title or f"Video {video_id}",
+        "value_score": score,
+        "value_tier": tier,
+        "code_implementation_prospect": code_prospect,
+        "concept_only": not code_prospect,
+        "tutorial_candidate": code_prospect,
+        "recommended_tutorial_mode": "explainer_plus_code" if code_prospect else "concept_only",
+        "evidence_quality": evidence,
+        "reason": "test fixture",
+        "rank": rank,
+    }
+
+
+def test_passes_when_all_signals_agree():
+    row = _make_row(video_id="aaa", code_prospect=True, score=85, tier="high", evidence="transcript")
+    ok, reason = ydd._is_demo_worthy(row, min_score=70)
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_rejects_when_llm_says_not_code_prospect():
+    row = _make_row(video_id="aaa", code_prospect=False)
+    ok, reason = ydd._is_demo_worthy(row, min_score=70)
+    assert ok is False
+    assert reason == "not_code_implementation_prospect"
+
+
+def test_rejects_metadata_only_evidence():
+    row = _make_row(video_id="aaa", code_prospect=True, evidence="metadata_only", score=95)
+    ok, reason = ydd._is_demo_worthy(row, min_score=70)
+    assert ok is False
+    assert "evidence_quality" in reason
+
+
+def test_rejects_when_score_below_threshold():
+    row = _make_row(video_id="aaa", code_prospect=True, score=60, tier="medium")
+    ok, reason = ydd._is_demo_worthy(row, min_score=70)
+    assert ok is False
+    assert "value_score" in reason and "min=70" in reason
+
+
+def test_rejects_low_value_tier():
+    row = _make_row(video_id="aaa", code_prospect=True, score=95, tier="low")
+    ok, reason = ydd._is_demo_worthy(row, min_score=70)
+    assert ok is False
+    assert reason == "value_tier=low"
+
+
+def test_rejects_unknown_value_tier():
+    """`value_tier="unknown"` means the LLM didn't actually rank this video —
+    we refuse to dispatch without a real tier signal."""
+    row = _make_row(video_id="aaa", code_prospect=True, score=95, tier="unknown")
+    ok, reason = ydd._is_demo_worthy(row, min_score=70)
+    assert ok is False
+    assert reason == "value_tier=unknown"
+
+
+def test_select_returns_only_passing_candidates():
+    decisions = {
+        "ranked_videos": [
+            _make_row(video_id="good1", rank=1, score=92),
+            _make_row(video_id="metadata_only", rank=2, evidence="metadata_only", score=95),
+            _make_row(video_id="lowscore", rank=3, score=55),
+            _make_row(video_id="lowtier", rank=4, tier="low", score=80),
+            _make_row(video_id="good2", rank=5, score=80, tier="medium"),
+            _make_row(video_id="notcode", rank=6, code_prospect=False, score=88),
+        ]
+    }
+    selected = ydd._select_tutorial_dispatch_candidates(decisions, top_n=4, min_score=70)
+    assert [r["video_id"] for r in selected] == ["good1", "good2"]
+
+
+def test_select_respects_top_n_and_marks_overflow():
+    decisions = {
+        "ranked_videos": [
+            _make_row(video_id="a", rank=1, score=95),
+            _make_row(video_id="b", rank=2, score=90),
+            _make_row(video_id="c", rank=3, score=85),
+            _make_row(video_id="d", rank=4, score=80),
+        ]
+    }
+    selected = ydd._select_tutorial_dispatch_candidates(decisions, top_n=2, min_score=70)
+    assert [r["video_id"] for r in selected] == ["a", "b"]
+    statuses = {r["video_id"]: r["dispatch_status"] for r in decisions["ranked_videos"]}
+    assert statuses == {
+        "a": "selected",
+        "b": "selected",
+        "c": "eligible_overflow",
+        "d": "eligible_overflow",
+    }
+
+
+def test_select_top_n_zero_marks_disabled():
+    decisions = {"ranked_videos": [_make_row(video_id="a", rank=1, score=95)]}
+    selected = ydd._select_tutorial_dispatch_candidates(decisions, top_n=0, min_score=70)
+    assert selected == []
+    assert decisions["ranked_videos"][0]["dispatch_status"] == "disabled_top_n_zero"
+
+
+def test_select_annotates_reject_reason_on_failing_rows():
+    decisions = {
+        "ranked_videos": [
+            _make_row(video_id="lowscore", rank=1, score=40),
+            _make_row(video_id="good", rank=2, score=80),
+        ]
+    }
+    ydd._select_tutorial_dispatch_candidates(decisions, top_n=4, min_score=70)
+    lowscore = decisions["ranked_videos"][0]
+    good = decisions["ranked_videos"][1]
+    assert lowscore["dispatch_eligible"] is False
+    assert "value_score=40" in lowscore["dispatch_reject_reason"]
+    assert lowscore["dispatch_status"] == "rejected"
+    assert good["dispatch_eligible"] is True
+    assert good["dispatch_reject_reason"] == ""
+    assert good["dispatch_status"] == "selected"
+
+
+def test_min_score_override_via_kwarg():
+    """A caller passing min_score=60 should let an 80-tier video through that
+    would have failed the default-70 gate (regression guard for env-var path)."""
+    decisions = {"ranked_videos": [_make_row(video_id="a", rank=1, score=65, tier="medium")]}
+    selected_default = ydd._select_tutorial_dispatch_candidates(decisions.copy(), top_n=4)
+    assert selected_default == []
+    decisions2 = {"ranked_videos": [_make_row(video_id="a", rank=1, score=65, tier="medium")]}
+    selected_loose = ydd._select_tutorial_dispatch_candidates(decisions2, top_n=4, min_score=60)
+    assert [r["video_id"] for r in selected_loose] == ["a"]

--- a/tests/unit/test_youtube_daily_digest_pockets.py
+++ b/tests/unit/test_youtube_daily_digest_pockets.py
@@ -170,6 +170,10 @@ Digest text.
 
 
 def test_digest_decisions_dispatch_code_prospects_even_without_secondary_tutorial_flag():
+    """The demo-worthiness gate keys off `code_implementation_prospect` (and
+    score/tier/evidence), NOT `tutorial_candidate`. Even when the LLM marks
+    `tutorial_candidate=false`, a code-prospect row that clears the
+    score/tier/evidence checks should still be dispatched."""
     decisions = youtube_daily_digest._rank_digest_decisions(
         {
             "ranked_videos": [
@@ -177,6 +181,8 @@ def test_digest_decisions_dispatch_code_prospects_even_without_secondary_tutoria
                     "video_id": "code",
                     "title": "Code Prospect",
                     "value_score": 80,
+                    "value_tier": "high",
+                    "evidence_quality": "transcript",
                     "code_implementation_prospect": True,
                     "concept_only": False,
                     "tutorial_candidate": False,
@@ -234,6 +240,19 @@ def test_format_tutorial_dispatch_summary_lists_selected_videos(tmp_path):
     dispatch_path = tmp_path / "dispatch.json"
 
     summary = youtube_daily_digest._format_tutorial_dispatch_summary(
+        decisions={
+            "ranked_videos": [
+                {
+                    "rank": 2,
+                    "title": "Build Agent",
+                    "video_id": "abc123",
+                    "value_score": 91,
+                    "reason": "Runnable coding walkthrough.",
+                    "code_implementation_prospect": True,
+                    "dispatch_status": "selected",
+                }
+            ]
+        },
         selected=[
             {
                 "rank": 2,
@@ -247,6 +266,7 @@ def test_format_tutorial_dispatch_summary_lists_selected_videos(tmp_path):
         candidates_path=candidates_path,
         dispatch_path=dispatch_path,
         top_n=4,
+        min_score=70,
         dry_run=False,
     )
 


### PR DESCRIPTION
## Summary

Adds a deterministic guardrail layer between the LLM's `code_implementation_prospect=true` self-classification and actually dispatching a video to the YouTube tutorial pipeline. Closes the risk surfaced after the 2026-05-18 Sunday digest: today's 4 dispatches happened to be solid, but a noisier playlist day could green-light sales pitches, product overviews, or videos where the LLM only saw the title.

Per the LLM-Native Intelligence Design principle in CLAUDE.md ("LLMs synthesize meaning, code gates execution"), three deterministic checks now sit in `_select_tutorial_dispatch_candidates`:

1. **Reject `evidence_quality=metadata_only`** — the LLM only had the title (transcript blocked, private video, pre-ingest skipped). Judging "demo-worthy" without a transcript is unreliable.
2. **Reject `value_score < UA_YOUTUBE_DIGEST_DEMO_GATE_MIN_SCORE`** (default 70). Today's 4 dispatches scored 85-92; sales-pitch videos typically score below 70.
3. **Reject `value_tier in {low, unknown}`** — guards against the LLM rating a video both `code_prospect=true` AND `value_tier=low`.

All three signals are read from fields the LLM already emits in the digest-decisions JSON, so no prompt change is needed.

## Auditability

Every ranked row is annotated in-place with:

- `dispatch_eligible: bool`
- `dispatch_reject_reason: str` (empty when eligible, e.g. `"value_score=55<min=70"` otherwise)
- `dispatch_status: "selected" | "eligible_overflow" | "rejected" | "disabled_top_n_zero"`

These flow through to:
- The saved candidates JSON (`*_tutorial_candidates.json`) so you can audit decisions post-hoc
- The digest email's "Tutorial Pipeline Dispatch" section, which now also lists "Rejected by demo-worthiness gate" videos with their score / tier / evidence / reject reason

## Tunables

| Env var | Default | Notes |
|---|---|---|
| `UA_YOUTUBE_DIGEST_DEMO_GATE_MIN_SCORE` | `70` | Lower to loosen the gate; raise to be stricter |
| `UA_YOUTUBE_DIGEST_AUTO_TUTORIAL_TOP_N` | `4` | Unchanged; caps eligible-and-selected count |

## Tests

- 11 new unit tests in `tests/unit/test_youtube_daily_digest_demo_gate.py` covering each individual signal + combined selection + top-N overflow + reject-reason annotation + min_score override
- Two existing tests in `test_youtube_daily_digest_pockets.py` updated to the new function signatures
- Full suite: 22/22 pass

## Coordination with PR #356

This is a follow-up to the digest-restoration work in #356; both branch from `main` and touch the same file but in non-overlapping regions. They merge in either order without conflict.

## Test plan

- [ ] Next 6 AM Central cron run still dispatches at most 4 candidates
- [ ] Digest email lists rejected demo candidates in the new section (if any LLM-marked prospects fail the gate)
- [ ] `tutorial_candidates.json` artifact contains `dispatch_*` fields on every ranked row