### PR TITLE
fix(load-guard): raise proc threshold 100→250 + MCP-child containment

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -18,21 +18,6 @@
         "AGENTMAIL_API_KEY": "${AGENTMAIL_API_KEY}"
       }
     },
-    "arxiv-mcp-server": {
-      "command": "uvx",
-      "args": [
-        "arxiv-mcp-server"
-      ]
-    },
-    "hostinger-mcp": {
-      "command": "npx",
-      "args": [
-        "hostinger-api-mcp@latest"
-      ],
-      "env": {
-        "API_TOKEN": "${HOSTINGER_API_TOKEN}"
-      }
-    },
     "discord": {
       "command": "uvx",
       "args": [

--- a/src/universal_agent/services/system_load_guard.py
+++ b/src/universal_agent/services/system_load_guard.py
@@ -15,7 +15,7 @@ When thresholds are exceeded, the guard returns structured information
 investigate.  It does NOT kill processes — that's the reaper's job.
 
 Configuration via environment variables:
-  - UA_MAX_PROCESS_COUNT (default: 100) — per-user process count ceiling
+  - UA_MAX_PROCESS_COUNT (default: 250) — per-user process count ceiling
   - UA_MAX_SWAP_PCT (default: 85.0) — swap usage percentage ceiling
 """
 
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
 
-DEFAULT_MAX_PROCESS_COUNT = 100
+DEFAULT_MAX_PROCESS_COUNT = 250
 DEFAULT_MAX_SWAP_PCT = 85.0
 
 

--- a/src/universal_agent/vp/clients/claude_cli_client.py
+++ b/src/universal_agent/vp/clients/claude_cli_client.py
@@ -306,6 +306,7 @@ async def _execute_cli_session(
             stderr=asyncio.subprocess.PIPE,
             cwd=str(workspace_dir),
             env=env,
+            start_new_session=True,
         )
     except FileNotFoundError:
         return MissionOutcome(


### PR DESCRIPTION
## Summary

Three tactical fixes to stop `system_load_guard` from blocking dispatch on the production VPS:

- **`system_load_guard.py`**: bump `DEFAULT_MAX_PROCESS_COUNT` 100→250. The 100 default was set when the runtime was smaller. Current normal load sits at 120–150 procs (3 Simone session lanes × ~13 MCP children each + gateway/api/bot/discord/csi daemons + VP workers). Dispatch was being paused every minute, sustained. Operator can still override via `UA_MAX_PROCESS_COUNT`.
- **`claude_cli_client.py:302`**: add `start_new_session=True` when spawning the `claude` CLI subprocess so the child + its MCP fan-out form a new process group. A hard kill (`_kill_process` / SIGKILL) now tears MCP children down with the parent rather than orphaning them. No orphans today — defensive containment for failure modes.
- **`.mcp.json`**: remove `arxiv-mcp-server` and `hostinger-mcp` from the default config. Neither is invoked by Simone heartbeat/todo flows; dead weight spawned every session (~3 procs each).

## Context

Diagnosed during a production incident where wiki-creation tasks (`create_wiki` proactive_signal actions) sat in the dispatch queue for ~40 hours. Root cause: `system_load_guard` was tripping the 100-proc threshold every minute and blocking `idle_dispatch_loop`. Symptom log:

```
WARNING:universal_agent.services.system_load_guard:🚨 System overload detected: 135 processes (threshold: 100), swap at 1.0%. Dispatch paused.
WARNING:universal_agent.services.idle_dispatch_loop:🔄 Idle dispatch BLOCKED by system guard: process_count_exceeded:135>100
```

After bumping `UA_MAX_PROCESS_COUNT=250` in `/opt/universal_agent/.env` and restarting the gateway, dispatch resumed within seconds and the user's clicked task immediately moved `open` → `needs_review`.

## Followups (separate issues — not in this PR)

1. **`cron_simone_chat_auto_complete` bootstrap waste**. The cron is a 5-line Python SQL script that never invokes Claude, but still carries a full Simone-shaped workspace bootstrap (SOUL.md, HEARTBEAT.md, IDENTITY.md, capabilities.md @ 54KB, etc.) stamped into `work_products/` on every run. That's ~85KB persona files × 60 runs/hr = ~122 MB/day for nothing. Cleanup needs the three-panel session-dashboard view audited first to confirm no hard dependency.

2. **Code-injected MCP gating**. `notebooklm-mcp`, `link-cli`, `@stripe/link-cli`, `@z_ai/mcp-server` are injected programmatically in `agent_setup.py:555,570`, `main.py:8629,8644`, `tools/link_bridge.py:1052` for every Simone session — even when the session has no use for them. Per-principal gating (heartbeat skips all, todo loads conditionally based on claimed task kind) would meaningfully reduce the per-session footprint.

## Test plan

- [x] `uv run pytest tests/unit -k 'system_load_guard or claude_cli_client'` — 22 passed, 1 skipped
- [x] `python3 -c "import json; json.load(open('.mcp.json'))"` — valid JSON
- [x] `python3 -m py_compile` on touched modules — clean
- [x] `uv run ruff check` on touched modules — clean
- [x] Live verification on VPS: bumped `UA_MAX_PROCESS_COUNT=250` in `/opt/universal_agent/.env`, restarted gateway, observed dispatch resume and process count drop 102 → 75
- [ ] Post-merge: confirm `start_new_session=True` doesn't break VP mission spawning under real workload

🤖 Generated with [Claude Code](https://claude.com/claude-code)