### PR TITLE
feat(youtube-digest): map-reduce pipeline + comparison harness for A/B-testing model+concurrency

### DIFF
--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -22,6 +22,7 @@ Playlist IDs are stored in Infisical as <DAY>_YT_PLAYLIST:
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 import json
 import logging
@@ -60,6 +61,59 @@ logger = logging.getLogger(__name__)
 
 DAYS = ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY", "SATURDAY", "SUNDAY"]
 POCKET_SCHEMA_VERSION = 1
+
+# ---------------------------------------------------------------------------
+# Map-reduce pipeline defaults (all overridable via env var)
+# ---------------------------------------------------------------------------
+# Pipeline selector: "map_reduce" (default, per-video retell + meta-synthesis)
+#                    "single_call" (legacy one-LLM-call shape; kept for fallback + A/B)
+DIGEST_PIPELINE_DEFAULT = "map_reduce"
+# Map-step model defaults. We hardcode glm-4.5-air (haiku-equivalent on Z.AI) for
+# the map step rather than calling resolve_model("haiku"), because resolve_model
+# globally points haiku at glm-5-turbo to dodge a historical preflight wedge
+# (see model_resolution.py:11-30). Probe 2026-05-18 showed glm-4.5-air is stable
+# at concurrency 1-3 for digest-shape prompts and ~30% faster per call than
+# glm-5-turbo. Both models share the same account-level Fair-Usage-Policy
+# throttle (Z.AI error 1313) when concurrency >= 5, so concurrency caps below
+# are conservative.
+DIGEST_MAP_MODEL_DEFAULT = "glm-4.5-air"
+DIGEST_MAP_CONCURRENCY_DEFAULT = 3
+DIGEST_MAP_TIMEOUT_SECONDS_DEFAULT = 180
+DIGEST_MAP_MAX_TOKENS_DEFAULT = 4000
+DIGEST_MAP_TRANSCRIPT_CHAR_LIMIT_DEFAULT = 50_000
+# Reduce-step model defaults. Reduce sees only titles + per-video classifications
+# + thesis lines (no full retellings), so context stays small.
+DIGEST_REDUCE_MODEL_TIER_DEFAULT = "opus"  # → glm-5.1 today
+DIGEST_REDUCE_TIMEOUT_SECONDS_DEFAULT = 600
+DIGEST_REDUCE_MAX_TOKENS_DEFAULT = 8000
+
+
+@dataclass
+class VideoTranscriptPayload:
+    """Per-video data passed into both pipelines.
+
+    `transcript_text` is empty when only metadata was available — the map step
+    will handle that case by emitting a metadata-only classification."""
+    video_id: str
+    title: str
+    transcript_text: str
+    is_metadata_only: bool = False
+    original_item: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MapResult:
+    """Output of a single map-step call (one video → one retell + classification)."""
+    video_id: str
+    title: str
+    retell_markdown: str
+    thesis_line: str
+    classification: dict[str, Any]
+    error: str | None = None
+    elapsed_seconds: float = 0.0
+    map_model: str = ""
+
+
 
 SYNTHESIS_PROMPT = """You are an expert technical researcher and knowledge synthesizer.
 You are given the transcripts and metadata of several YouTube videos that the user queued up to watch today.
@@ -116,11 +170,123 @@ Here are the videos:
 
 
 # ---------------------------------------------------------------------------
+# Map-step prompt: produces a per-video retelling + classification.
+#
+# Output contract (strict):
+#   1. Markdown "## <title>" heading
+#   2. ### Retelling section (30-40% length retelling, NOT a summary)
+#   3. ### Actionable Insights section (bullets)
+#   4. ### Thesis (single short sentence — fed to the reducer for cross-video themes)
+#   5. ```per_video_classification JSON fenced block (parsed by code, stripped from email)
+#
+# The map LLM does NOT see other videos and is told NOT to draw cross-video themes —
+# that's the reducer's job.
+# ---------------------------------------------------------------------------
+RETELL_PROMPT = """You are a technical knowledge synthesizer. You will be given the transcript and metadata for ONE YouTube video. Produce a "Compressed Retelling" that lets the reader skip watching the video while preserving its substance.
+
+REQUIREMENTS:
+- Length target: roughly 30-40% of the original transcript length. Be substantial, NOT a short summary. If the transcript is ~3000 words, your retelling should be ~900-1200 words.
+- Reproduce the speaker's argument in your own words, preserving the order and structure of their reasoning.
+- Preserve all specific examples, numbers, quoted phrases, library/tool names, file paths, code snippets, product names, and "this works because..." explanations. These details are what distinguish a retelling from a summary.
+- Do NOT add commentary, opinion, cross-references to other videos, or business context.
+- If the transcript text is "[Metadata-only — transcript unavailable]", produce only a one-paragraph note based on the title and stop. Mark the classification's `evidence_quality` as `metadata_only` and `reason` explaining that no transcript was available.
+
+REQUIRED OUTPUT FORMAT (markdown — do not deviate):
+
+## <video title>
+
+**Video ID:** <video_id>
+
+### Retelling
+<the 30-40% length retelling>
+
+### Actionable Insights
+- <concrete thing a reader could do>
+- <another bullet>
+
+### Thesis
+<one short sentence — the core claim or core takeaway of the video, 15-30 words>
+
+```per_video_classification
+{
+  "video_id": "<video_id>",
+  "value_score": <integer 0-100>,
+  "value_tier": "<high|medium|low>",
+  "code_implementation_prospect": <true|false>,
+  "concept_only": <true|false>,
+  "evidence_quality": "<transcript|metadata_only|mixed>",
+  "reason": "<short reason grounded in the transcript>"
+}
+```
+
+INPUT FOLLOWS:
+"""
+
+
+# ---------------------------------------------------------------------------
+# Reduce-step prompt: sees only titles + classifications + thesis lines (NOT
+# full retellings), produces the meta-synthesis (cross-video themes, learning
+# insights, neglected opportunities) and the final ranked `youtube_digest_decisions`
+# JSON block. Python code assembles the final markdown by sandwiching the
+# retellings between the meta-synthesis and the JSON block.
+# ---------------------------------------------------------------------------
+REDUCE_PROMPT = """You are a senior technical analyst preparing a "Daily YouTube Digest" for a busy operator. You have ALREADY received per-video retellings from a map step; do NOT re-summarize the videos. Your job is meta-synthesis across them.
+
+Below is the structured roll-up of every video in today's digest (titles, one-sentence theses, value scores, tiers, evidence quality, and the map-step's reasoning). Use this as your input.
+
+Produce exactly the following markdown, in order:
+
+1. A single H1 title line: `# Daily YouTube Digest: <day_name>, <date_str>`
+2. `## Meta-Synthesis: Daily Digest`
+3. `### Cross-Video Themes` — 3-7 themes that appear across multiple videos. Each theme is one short paragraph naming the relevant videos.
+4. `### Learning Insights` — 2-5 non-obvious technical insights that wouldn't be apparent from any single video.
+5. `### Neglected Opportunities` — 1-3 gaps (topics that should have been discussed but weren't).
+6. Then a single fenced JSON block labeled exactly `youtube_digest_decisions` with this shape (one entry per video, sorted by value_score descending):
+
+```youtube_digest_decisions
+{{
+  "ranked_videos": [
+    {{
+      "rank": 1,
+      "video_id": "string",
+      "title": "string",
+      "value_score": <int 0-100>,
+      "value_tier": "high|medium|low",
+      "code_implementation_prospect": <bool>,
+      "concept_only": <bool>,
+      "tutorial_candidate": <bool>,
+      "recommended_tutorial_mode": "explainer_plus_code|concept_only|none",
+      "evidence_quality": "transcript|metadata_only|mixed",
+      "reason": "short reason from the map step's classification"
+    }}
+  ]
+}}
+```
+
+JSON rules:
+- `tutorial_candidate` may be true only when `code_implementation_prospect` is true.
+- `recommended_tutorial_mode` must be `explainer_plus_code` for tutorial_candidates, `concept_only` otherwise.
+- Include every video from the input exactly once.
+- Use the value_score and value_tier from the map-step input; do NOT re-score from scratch.
+
+DAY_NAME: {day_name}
+DATE: {date_str}
+VIDEO COUNT: {video_count}
+
+PER-VIDEO ROLL-UP:
+{rollup_json}
+"""
+
+
+# ---------------------------------------------------------------------------
 # LLM synthesis
 # ---------------------------------------------------------------------------
 
-async def _generate_digest_content(full_prompt: str) -> str:
-    """Generate digest synthesis through the Anthropic-compatible ZAI path."""
+def _build_anthropic_client_for_zai(timeout_seconds: float) -> AsyncAnthropic:
+    """Build a configured AsyncAnthropic client. Routes to Z.AI proxy if the
+    configured key looks like a ZAI key; otherwise falls through to the SDK
+    default (api.anthropic.com).
+    """
     api_key = (
         os.getenv("ANTHROPIC_API_KEY")
         or os.getenv("ANTHROPIC_AUTH_TOKEN")
@@ -128,60 +294,493 @@ async def _generate_digest_content(full_prompt: str) -> str:
     )
     if not api_key:
         raise RuntimeError("No ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, or ZAI_API_KEY configured")
-
-    model = os.getenv("UA_YOUTUBE_DIGEST_MODEL") or resolve_model("opus")
-    client_kwargs: dict[str, Any] = {
+    kwargs: dict[str, Any] = {
         "api_key": api_key,
         "max_retries": 0,
-        "timeout": float(os.getenv("UA_YOUTUBE_DIGEST_LLM_TIMEOUT_SECONDS", "900")),
+        "timeout": float(timeout_seconds),
     }
     base_url = os.getenv("ANTHROPIC_BASE_URL")
     if base_url:
-        client_kwargs["base_url"] = base_url
+        kwargs["base_url"] = base_url
     elif os.getenv("ZAI_API_KEY") and api_key == os.getenv("ZAI_API_KEY"):
-        client_kwargs["base_url"] = "https://api.z.ai/api/anthropic"
+        kwargs["base_url"] = "https://api.z.ai/api/anthropic"
+    return AsyncAnthropic(**kwargs)
 
-    client = AsyncAnthropic(**client_kwargs)
+
+def _is_rate_limit_error(exc: Exception) -> bool:
+    """Detect Z.AI rate-limit / Fair-Usage-Policy responses worth retrying.
+
+    Z.AI returns:
+      - HTTP 429 with various messages ("Too many requests", "high concurrency")
+      - HTTP 429 with FUP code 1313 ("Fair Usage Policy", "request frequency has been limited")
+    All of the above are retry-eligible.
+    """
+    err_str = str(exc).lower()
+    return (
+        "429" in err_str
+        or "too many requests" in err_str
+        or "high concurrency" in err_str
+        or "fair usage policy" in err_str
+        or "1313" in err_str
+    )
+
+
+async def _zai_call_with_retry(
+    *,
+    client: AsyncAnthropic,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    context: str,
+    max_retries: int = 5,
+    temperature: float = 0.4,
+) -> str:
+    """Send one messages.create() call to Z.AI with the global rate limiter
+    and a 429/FUP-aware retry loop. Returns the concatenated text response.
+
+    All non-rate-limit errors are re-raised immediately.
+    """
     limiter = ZAIRateLimiter.get_instance()
-    max_retries = int(os.getenv("UA_YOUTUBE_DIGEST_LLM_MAX_RETRIES", "5"))
-    max_tokens = int(os.getenv("UA_YOUTUBE_DIGEST_MAX_TOKENS", "12000"))
-    context = "youtube_daily_digest"
     last_error: Exception | None = None
-
-    logger.info("Generating Meta-Synthesis with Anthropic-compatible model=%s...", model)
     for attempt in range(max_retries):
         async with limiter.acquire(context):
             try:
                 response = await client.messages.create(
                     model=model,
                     max_tokens=max_tokens,
-                    temperature=0.4,
-                    messages=[{"role": "user", "content": full_prompt}],
+                    temperature=temperature,
+                    messages=[{"role": "user", "content": prompt}],
                 )
                 await limiter.record_success()
                 text = "".join(getattr(block, "text", "") for block in response.content).strip()
                 if not text:
-                    raise RuntimeError("LLM returned an empty digest response")
+                    raise RuntimeError(f"LLM returned an empty response (context={context})")
                 return text
             except Exception as exc:
                 last_error = exc
-                error_str = str(exc).lower()
-                if "429" not in error_str and "too many requests" not in error_str and "high concurrency" not in error_str:
+                if not _is_rate_limit_error(exc):
                     raise
                 await limiter.record_429(context)
                 if attempt >= max_retries - 1:
                     break
                 delay = limiter.get_backoff(attempt)
                 logger.warning(
-                    "Digest LLM rate limited; retrying in %.1fs (attempt %d/%d): %s",
+                    "ZAI rate-limited at context=%s; retrying in %.1fs (attempt %d/%d): %s",
+                    context,
                     delay,
                     attempt + 1,
                     max_retries,
-                    exc,
+                    str(exc)[:200],
                 )
                 await asyncio.sleep(delay)
+    raise RuntimeError(
+        f"ZAI call failed after {max_retries} attempts at context={context}: {last_error}"
+    )
 
-    raise RuntimeError(f"Digest LLM synthesis failed after {max_retries} attempts: {last_error}")
+
+# ---------------------------------------------------------------------------
+# Map / Reduce pipeline primitives
+# ---------------------------------------------------------------------------
+
+_PER_VIDEO_CLASSIFICATION_PATTERN = re.compile(
+    r"```per_video_classification\s*(.*?)\s*```",
+    flags=re.DOTALL | re.IGNORECASE,
+)
+_THESIS_LINE_PATTERN = re.compile(
+    r"### Thesis\s*\n+(.+?)(?:\n{2,}|\Z)",
+    flags=re.DOTALL,
+)
+
+
+def _parse_map_output(raw_text: str, *, video_id: str, fallback_title: str) -> dict[str, Any]:
+    """Parse a single map-step LLM response into (clean_markdown, thesis, classification).
+
+    On any parse failure, returns a best-effort classification so the digest
+    can still proceed (the reducer ranks low-confidence entries near the
+    bottom and the dispatch gate further filters them out).
+    """
+    # Extract classification block
+    classification: dict[str, Any] = {}
+    match = _PER_VIDEO_CLASSIFICATION_PATTERN.search(raw_text)
+    if match:
+        try:
+            classification = json.loads(match.group(1))
+        except json.JSONDecodeError as exc:
+            logger.warning(
+                "Map step %s: failed to parse per_video_classification JSON: %s",
+                video_id,
+                exc,
+            )
+            classification = {}
+    if not isinstance(classification, dict):
+        classification = {}
+    classification.setdefault("video_id", video_id)
+    classification.setdefault("value_score", 0)
+    classification.setdefault("value_tier", "unknown")
+    classification.setdefault("code_implementation_prospect", False)
+    classification.setdefault("concept_only", True)
+    classification.setdefault("evidence_quality", "unknown")
+    classification.setdefault("reason", "")
+
+    # Extract thesis
+    thesis = ""
+    thesis_match = _THESIS_LINE_PATTERN.search(raw_text)
+    if thesis_match:
+        thesis = thesis_match.group(1).strip()
+    if not thesis:
+        thesis = classification.get("reason") or fallback_title
+
+    # Strip the classification block from the markdown (we'll re-emit it from
+    # the reducer's structured output, not from per-video raw blocks).
+    clean_markdown = _PER_VIDEO_CLASSIFICATION_PATTERN.sub("", raw_text).strip()
+
+    return {
+        "retell_markdown": clean_markdown,
+        "thesis_line": thesis,
+        "classification": classification,
+    }
+
+
+async def _retell_one_video(
+    *,
+    client: AsyncAnthropic,
+    model: str,
+    video: VideoTranscriptPayload,
+    max_tokens: int,
+    transcript_char_limit: int,
+) -> MapResult:
+    """One map call: turn one video's transcript into a Compressed Retelling +
+    structured classification. Errors are caught and converted into a
+    metadata-only MapResult so the digest run can finish even if one or two
+    videos fail."""
+    started = datetime.now(timezone.utc)
+    transcript_text = video.transcript_text or ""
+    if transcript_text and len(transcript_text) > transcript_char_limit:
+        transcript_text = transcript_text[: transcript_char_limit] + "... [TRUNCATED]"
+    if video.is_metadata_only or not transcript_text:
+        transcript_text = "[Metadata-only — transcript unavailable]"
+
+    prompt_body = (
+        f"TITLE: {video.title}\n"
+        f"VIDEO ID: {video.video_id}\n"
+        f"TRANSCRIPT:\n{transcript_text}\n"
+    )
+    prompt = RETELL_PROMPT + prompt_body
+    context = f"youtube_digest_map:{video.video_id}"
+
+    try:
+        raw_text = await _zai_call_with_retry(
+            client=client,
+            model=model,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            context=context,
+        )
+        elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+        parsed = _parse_map_output(raw_text, video_id=video.video_id, fallback_title=video.title)
+        return MapResult(
+            video_id=video.video_id,
+            title=video.title,
+            retell_markdown=parsed["retell_markdown"],
+            thesis_line=parsed["thesis_line"],
+            classification=parsed["classification"],
+            elapsed_seconds=elapsed,
+            map_model=model,
+        )
+    except Exception as exc:
+        elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+        logger.error("Map step failed for %s after %.1fs: %s", video.video_id, elapsed, exc)
+        fallback_md = (
+            f"## {video.title}\n\n"
+            f"**Video ID:** {video.video_id}\n\n"
+            f"### Retelling\n\n"
+            f"_Map-step retelling failed: {exc}. Tutorial pipeline dispatch will skip this video._\n"
+        )
+        return MapResult(
+            video_id=video.video_id,
+            title=video.title,
+            retell_markdown=fallback_md,
+            thesis_line="(map step failed — see digest log)",
+            classification={
+                "video_id": video.video_id,
+                "value_score": 0,
+                "value_tier": "unknown",
+                "code_implementation_prospect": False,
+                "concept_only": True,
+                "evidence_quality": "unknown",
+                "reason": f"Map step error: {type(exc).__name__}",
+            },
+            error=str(exc),
+            elapsed_seconds=elapsed,
+            map_model=model,
+        )
+
+
+async def _map_retell_videos(
+    videos: list[VideoTranscriptPayload],
+    *,
+    model: str | None = None,
+    concurrency: int | None = None,
+    timeout_seconds: int | None = None,
+    max_tokens: int | None = None,
+    transcript_char_limit: int | None = None,
+) -> list[MapResult]:
+    """Run the map step over all videos with bounded concurrency.
+
+    The internal semaphore bounds how many tasks we *try* to run in parallel.
+    The global ZAIRateLimiter (`ZAI_MAX_CONCURRENT`, default 2) bounds how
+    many of those actually hit the Z.AI proxy at once. So the effective
+    parallelism is min(internal_semaphore, ZAI_MAX_CONCURRENT).
+    """
+    resolved_model = (
+        model
+        or os.getenv("UA_YOUTUBE_DIGEST_MAP_MODEL")
+        or DIGEST_MAP_MODEL_DEFAULT
+    )
+    resolved_concurrency = max(
+        1,
+        int(
+            concurrency
+            if concurrency is not None
+            else os.getenv("UA_YOUTUBE_DIGEST_MAP_CONCURRENCY", str(DIGEST_MAP_CONCURRENCY_DEFAULT))
+        ),
+    )
+    resolved_timeout = int(
+        timeout_seconds
+        if timeout_seconds is not None
+        else os.getenv("UA_YOUTUBE_DIGEST_MAP_TIMEOUT_SECONDS", str(DIGEST_MAP_TIMEOUT_SECONDS_DEFAULT))
+    )
+    resolved_max_tokens = int(
+        max_tokens
+        if max_tokens is not None
+        else os.getenv("UA_YOUTUBE_DIGEST_MAP_MAX_TOKENS", str(DIGEST_MAP_MAX_TOKENS_DEFAULT))
+    )
+    resolved_char_limit = int(
+        transcript_char_limit
+        if transcript_char_limit is not None
+        else os.getenv(
+            "UA_YOUTUBE_DIGEST_MAP_TRANSCRIPT_CHAR_LIMIT",
+            str(DIGEST_MAP_TRANSCRIPT_CHAR_LIMIT_DEFAULT),
+        )
+    )
+
+    logger.info(
+        "Map step: model=%s videos=%d concurrency=%d timeout=%ds max_tokens=%d",
+        resolved_model,
+        len(videos),
+        resolved_concurrency,
+        resolved_timeout,
+        resolved_max_tokens,
+    )
+
+    client = _build_anthropic_client_for_zai(timeout_seconds=resolved_timeout)
+    semaphore = asyncio.Semaphore(resolved_concurrency)
+
+    async def _bounded(v: VideoTranscriptPayload) -> MapResult:
+        async with semaphore:
+            return await _retell_one_video(
+                client=client,
+                model=resolved_model,
+                video=v,
+                max_tokens=resolved_max_tokens,
+                transcript_char_limit=resolved_char_limit,
+            )
+
+    results = await asyncio.gather(*[_bounded(v) for v in videos])
+    # Surface aggregate stats in the log so operators can spot regressions.
+    successes = [r for r in results if r.error is None]
+    failures = [r for r in results if r.error is not None]
+    if successes:
+        elapsed_list = sorted(r.elapsed_seconds for r in successes)
+        median = elapsed_list[len(elapsed_list) // 2]
+        logger.info(
+            "Map step complete: %d ok / %d failed; latency min=%.1fs p50=%.1fs max=%.1fs",
+            len(successes),
+            len(failures),
+            min(elapsed_list),
+            median,
+            max(elapsed_list),
+        )
+    else:
+        logger.error("Map step complete: 0 ok / %d failed (all videos failed)", len(failures))
+    return results
+
+
+async def _reduce_meta_synthesize(
+    map_results: list[MapResult],
+    *,
+    day_name: str,
+    date_str: str,
+    model_tier: str | None = None,
+    timeout_seconds: int | None = None,
+    max_tokens: int | None = None,
+) -> str:
+    """One reduce call: meta-synthesis across all per-video classifications.
+
+    The reducer sees only titles + thesis lines + classifications (NOT full
+    retellings), so context stays small even on 30+ video days.
+    """
+    resolved_model = (
+        os.getenv("UA_YOUTUBE_DIGEST_REDUCE_MODEL")
+        or resolve_model(model_tier or DIGEST_REDUCE_MODEL_TIER_DEFAULT)
+    )
+    resolved_timeout = int(
+        timeout_seconds
+        if timeout_seconds is not None
+        else os.getenv(
+            "UA_YOUTUBE_DIGEST_REDUCE_TIMEOUT_SECONDS",
+            str(DIGEST_REDUCE_TIMEOUT_SECONDS_DEFAULT),
+        )
+    )
+    resolved_max_tokens = int(
+        max_tokens
+        if max_tokens is not None
+        else os.getenv("UA_YOUTUBE_DIGEST_REDUCE_MAX_TOKENS", str(DIGEST_REDUCE_MAX_TOKENS_DEFAULT))
+    )
+
+    rollup = [
+        {
+            "video_id": r.video_id,
+            "title": r.title,
+            "thesis": r.thesis_line,
+            "value_score": r.classification.get("value_score", 0),
+            "value_tier": r.classification.get("value_tier", "unknown"),
+            "code_implementation_prospect": bool(
+                r.classification.get("code_implementation_prospect", False)
+            ),
+            "concept_only": bool(r.classification.get("concept_only", True)),
+            "evidence_quality": r.classification.get("evidence_quality", "unknown"),
+            "reason": r.classification.get("reason", ""),
+        }
+        for r in map_results
+    ]
+    rollup_json = json.dumps(rollup, indent=2, ensure_ascii=False)
+    prompt = REDUCE_PROMPT.format(
+        day_name=day_name.title(),
+        date_str=date_str,
+        video_count=len(map_results),
+        rollup_json=rollup_json,
+    )
+
+    logger.info(
+        "Reduce step: model=%s timeout=%ds max_tokens=%d rollup_chars=%d",
+        resolved_model,
+        resolved_timeout,
+        resolved_max_tokens,
+        len(rollup_json),
+    )
+
+    client = _build_anthropic_client_for_zai(timeout_seconds=resolved_timeout)
+    return await _zai_call_with_retry(
+        client=client,
+        model=resolved_model,
+        prompt=prompt,
+        max_tokens=resolved_max_tokens,
+        context="youtube_digest_reduce",
+    )
+
+
+def _assemble_map_reduce_digest(
+    *,
+    reduce_output: str,
+    map_results: list[MapResult],
+) -> str:
+    """Combine the reducer's meta-synthesis (markdown + JSON block) with the
+    map-step retellings into the final digest content. The retellings get
+    inserted BEFORE the youtube_digest_decisions JSON block so the email
+    body (`_strip_digest_decision_blocks`) carries them and the dispatch
+    parser (`_extract_decision_json`) still finds the JSON at the end.
+    """
+    retellings_md = "\n\n---\n\n".join(r.retell_markdown for r in map_results)
+    section = f"\n\n---\n\n## Per-Video Retellings\n\n{retellings_md}\n\n---\n\n"
+    json_block_match = re.search(
+        r"```(?:youtube_digest_decisions|json)\s*",
+        reduce_output,
+        flags=re.IGNORECASE,
+    )
+    if json_block_match:
+        head = reduce_output[: json_block_match.start()].rstrip()
+        tail = reduce_output[json_block_match.start():]
+        return f"{head}{section}{tail}"
+    # No JSON block in reducer output (shouldn't happen but fall back gracefully).
+    return f"{reduce_output.rstrip()}{section}"
+
+
+async def _generate_digest_content_map_reduce(
+    *,
+    videos: list[VideoTranscriptPayload],
+    day_name: str,
+    date_str: str,
+) -> str:
+    """Map-reduce pipeline entry point. Parallel per-video retellings, then
+    one reduce call for meta-synthesis + ranked JSON decision block."""
+    map_results = await _map_retell_videos(videos)
+    reduce_output = await _reduce_meta_synthesize(
+        map_results,
+        day_name=day_name,
+        date_str=date_str,
+    )
+    return _assemble_map_reduce_digest(reduce_output=reduce_output, map_results=map_results)
+
+
+async def _generate_digest_content_single_call(full_prompt: str) -> str:
+    """Legacy single-LLM-call digest synthesis. Kept for fallback and for
+    A/B comparison against the new map-reduce path. Hits one big-context
+    glm-5.1 call with all transcripts concatenated.
+    """
+    model = os.getenv("UA_YOUTUBE_DIGEST_MODEL") or resolve_model("opus")
+    timeout_seconds = float(os.getenv("UA_YOUTUBE_DIGEST_LLM_TIMEOUT_SECONDS", "900"))
+    max_retries = int(os.getenv("UA_YOUTUBE_DIGEST_LLM_MAX_RETRIES", "5"))
+    max_tokens = int(os.getenv("UA_YOUTUBE_DIGEST_MAX_TOKENS", "12000"))
+
+    client = _build_anthropic_client_for_zai(timeout_seconds=timeout_seconds)
+    logger.info("Single-call digest synthesis with model=%s...", model)
+    return await _zai_call_with_retry(
+        client=client,
+        model=model,
+        prompt=full_prompt,
+        max_tokens=max_tokens,
+        context="youtube_daily_digest",
+        max_retries=max_retries,
+    )
+
+
+async def _generate_digest_content(
+    *,
+    full_prompt: str | None = None,
+    videos: list[VideoTranscriptPayload] | None = None,
+    day_name: str | None = None,
+    date_str: str | None = None,
+    pipeline_override: str | None = None,
+) -> str:
+    """Dispatcher for digest synthesis. Picks pipeline based on
+    `UA_YOUTUBE_DIGEST_PIPELINE` env var (or explicit override).
+
+    - `map_reduce` (default): requires `videos`, `day_name`, `date_str`.
+    - `single_call`: requires `full_prompt`.
+    """
+    pipeline = (
+        pipeline_override
+        or os.getenv("UA_YOUTUBE_DIGEST_PIPELINE", DIGEST_PIPELINE_DEFAULT)
+    ).strip().lower()
+    if pipeline == "single_call":
+        if full_prompt is None:
+            raise ValueError("single_call pipeline requires full_prompt")
+        return await _generate_digest_content_single_call(full_prompt)
+    if pipeline != "map_reduce":
+        logger.warning(
+            "Unknown UA_YOUTUBE_DIGEST_PIPELINE=%r; falling back to map_reduce",
+            pipeline,
+        )
+    if videos is None or day_name is None or date_str is None:
+        raise ValueError(
+            "map_reduce pipeline requires videos, day_name, and date_str"
+        )
+    return await _generate_digest_content_map_reduce(
+        videos=videos,
+        day_name=day_name,
+        date_str=date_str,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -882,6 +1481,7 @@ def process_daily_digest(
     items = new_items
 
     transcripts: list[str] = []
+    transcript_payloads: list[VideoTranscriptPayload] = []
     processed_items: list[dict] = []
     video_titles: list[str] = []
 
@@ -920,6 +1520,15 @@ def process_daily_digest(
                 text = text[:50000] + "... [TRUNCATED]"
 
             transcripts.append(f"Title: {title}\nVideo ID: {video_id}\nTranscript:\n{text}\n")
+            transcript_payloads.append(
+                VideoTranscriptPayload(
+                    video_id=video_id,
+                    title=title,
+                    transcript_text=text,
+                    is_metadata_only=False,
+                    original_item=item,
+                )
+            )
             processed_items.append(item)
         else:
             if result:
@@ -938,6 +1547,15 @@ def process_daily_digest(
             # Metadata-only fallback: use title for synthesis (playlist API doesn't return description)
             fallback_text = f"[Metadata-only — transcript unavailable]\n\nTitle: {title}"
             transcripts.append(f"Title: {title}\nVideo ID: {video_id}\n{fallback_text}\n")
+            transcript_payloads.append(
+                VideoTranscriptPayload(
+                    video_id=video_id,
+                    title=title,
+                    transcript_text="",
+                    is_metadata_only=True,
+                    original_item=item,
+                )
+            )
             processed_items.append(item)
             logger.info("Using metadata-only fallback for %s", video_id)
 
@@ -945,16 +1563,30 @@ def process_daily_digest(
         logger.info("No transcripts could be extracted. Exiting.")
         return
 
+    # date_str is needed by both the map_reduce pipeline (passed to the reducer
+    # for the H1 title line) and by artifact path construction below.
+    date_str = datetime.now().strftime("%Y-%m-%d")
+    pipeline = os.getenv("UA_YOUTUBE_DIGEST_PIPELINE", DIGEST_PIPELINE_DEFAULT).strip().lower()
     full_prompt = SYNTHESIS_PROMPT + "\n\n---\n\n".join(transcripts)
 
     try:
-        digest_content = asyncio.run(_generate_digest_content(full_prompt))
+        if pipeline == "single_call":
+            digest_content = asyncio.run(
+                _generate_digest_content(full_prompt=full_prompt, pipeline_override="single_call")
+            )
+        else:
+            digest_content = asyncio.run(
+                _generate_digest_content(
+                    videos=transcript_payloads,
+                    day_name=day_name,
+                    date_str=date_str,
+                )
+            )
     except Exception as e:
-        logger.error("Failed to generate digest content with LLM: %s", e)
+        logger.error("Failed to generate digest content with LLM (pipeline=%s): %s", pipeline, e)
         return
 
     # Save Artifact to the persistent daily_digests workspace
-    date_str = datetime.now().strftime("%Y-%m-%d")
     artifacts_dir = _digest_artifacts_dir()
     artifacts_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/universal_agent/scripts/youtube_digest_compare.py
+++ b/src/universal_agent/scripts/youtube_digest_compare.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""YouTube Digest pipeline comparison harness.
+
+Runs the daily-digest synthesis pipelines against the SAME input transcripts so
+you can A/B-evaluate output quality across:
+
+  - single_call: legacy one-LLM-call shape (today's production default)
+  - map_reduce:  per-video retell + meta-synthesis (default for new path)
+
+It also lets you sweep model + concurrency knobs on the map step without
+touching the live cron, so you can answer questions like:
+  - "Is glm-4.5-air retell quality on par with glm-5-turbo?"
+  - "At what concurrency do FUP 429s start dominating wall time?"
+  - "How does single_call output compare to map_reduce on the same playlist?"
+
+Usage:
+  # Compare both pipelines on the latest SUNDAY pocket:
+  uv run python -m universal_agent.scripts.youtube_digest_compare \
+      --day SUNDAY \
+      --runs single_call:default \
+      --runs map_reduce:glm-4.5-air@conc=3 \
+      --runs map_reduce:glm-5-turbo@conc=3
+
+  # Sweep concurrency on glm-4.5-air alone:
+  uv run python -m universal_agent.scripts.youtube_digest_compare \
+      --day SUNDAY \
+      --runs map_reduce:glm-4.5-air@conc=2 \
+      --runs map_reduce:glm-4.5-air@conc=3 \
+      --runs map_reduce:glm-4.5-air@conc=5
+
+Each --runs entry has the shape <pipeline>[:<model>][@conc=<int>]. Outputs:
+  AGENT_RUN_WORKSPACES/daily_digests/comparison_<date>/<label>/{digest.md, run_metadata.json}
+  AGENT_RUN_WORKSPACES/daily_digests/comparison_<date>/index.json  (sweep manifest)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import json
+import logging
+import os
+from pathlib import Path
+import sys
+import time
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from universal_agent.infisical_loader import initialize_runtime_secrets
+from universal_agent.scripts import youtube_daily_digest as ydd
+from universal_agent.youtube_ingest import ingest_youtube_transcript
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("youtube_digest_compare")
+
+
+@dataclass
+class RunSpec:
+    label: str
+    pipeline: str  # "single_call" | "map_reduce"
+    map_model: str | None  # only meaningful for map_reduce
+    map_concurrency: int | None  # only meaningful for map_reduce
+
+
+def _parse_run_spec(spec: str) -> RunSpec:
+    """Parse one --runs argument into a RunSpec.
+
+    Accepted shapes:
+      single_call:default
+      single_call
+      map_reduce
+      map_reduce:glm-4.5-air
+      map_reduce:glm-4.5-air@conc=3
+    """
+    raw = spec.strip()
+    if "@" in raw:
+        head, conc_part = raw.split("@", 1)
+    else:
+        head, conc_part = raw, ""
+    if ":" in head:
+        pipeline, model_part = head.split(":", 1)
+    else:
+        pipeline, model_part = head, ""
+    pipeline = pipeline.strip().lower()
+    if pipeline not in {"single_call", "map_reduce"}:
+        raise ValueError(f"Unknown pipeline in --runs entry: {spec!r} (expected single_call|map_reduce)")
+    model = (model_part or "").strip() or None
+    if model and model.lower() == "default":
+        model = None
+    conc = None
+    if conc_part:
+        if not conc_part.startswith("conc="):
+            raise ValueError(f"Unknown qualifier in --runs entry: {spec!r}; expected @conc=<int>")
+        try:
+            conc = int(conc_part.removeprefix("conc=").strip())
+        except ValueError as exc:
+            raise ValueError(f"Invalid concurrency in {spec!r}: {exc}") from exc
+    parts = [pipeline]
+    if model:
+        parts.append(model)
+    if conc is not None:
+        parts.append(f"conc{conc}")
+    label = "_".join(parts)
+    return RunSpec(label=label, pipeline=pipeline, map_model=model, map_concurrency=conc)
+
+
+def _load_pocket(day_name: str, date_override: str | None) -> dict[str, Any]:
+    """Load the most recent (or specified) repopulate pocket for the given day."""
+    day = day_name.upper()
+    pockets_dir = ydd._pockets_dir() / day
+    if not pockets_dir.exists():
+        raise FileNotFoundError(f"No pocket directory for {day} at {pockets_dir}")
+    if date_override:
+        path = ydd._pocket_path(day_name=day, date_str=date_override)
+    else:
+        candidates = sorted(pockets_dir.glob(f"*_{day}_playlist_pocket.json"))
+        if not candidates:
+            raise FileNotFoundError(f"No pocket files in {pockets_dir}")
+        path = candidates[-1]
+    pocket = json.loads(path.read_text(encoding="utf-8"))
+    logger.info("Loaded pocket: %s (%d videos)", path, pocket.get("video_count", 0))
+    return pocket
+
+
+def _ingest_payloads(pocket: dict[str, Any]) -> list[ydd.VideoTranscriptPayload]:
+    """Re-ingest transcripts for the pocket's videos so both pipelines see the
+    SAME source data. This mirrors the production ingestion loop including
+    proxy → no-proxy → metadata-only fallback."""
+    payloads: list[ydd.VideoTranscriptPayload] = []
+    for video in pocket.get("videos", []):
+        video_id = str(video.get("video_id") or "").strip()
+        title = str(video.get("title") or "").strip() or video_id
+        if not video_id:
+            continue
+        result = None
+        for attempt_proxy in [True, False]:
+            try:
+                result = ingest_youtube_transcript(
+                    video_url=None,
+                    video_id=video_id,
+                    require_proxy=attempt_proxy,
+                )
+                if result.get("ok"):
+                    break
+                detail = str(result.get("detail", ""))
+                if attempt_proxy and ("407" in detail or "NO_USER" in detail or "proxy" in detail.lower()):
+                    continue
+                break
+            except Exception as exc:
+                logger.warning("Ingest %s proxy=%s: %s", video_id, attempt_proxy, exc)
+                if attempt_proxy:
+                    continue
+                result = {"ok": False, "error": str(exc)}
+        if result and result.get("ok"):
+            text = result.get("transcript_text", "") or ""
+            if len(text) > 50_000:
+                text = text[:50_000] + "... [TRUNCATED]"
+            payloads.append(
+                ydd.VideoTranscriptPayload(
+                    video_id=video_id,
+                    title=title,
+                    transcript_text=text,
+                    is_metadata_only=False,
+                    original_item={"video_id": video_id, "title": title},
+                )
+            )
+        else:
+            payloads.append(
+                ydd.VideoTranscriptPayload(
+                    video_id=video_id,
+                    title=title,
+                    transcript_text="",
+                    is_metadata_only=True,
+                    original_item={"video_id": video_id, "title": title},
+                )
+            )
+    logger.info(
+        "Re-ingest complete: %d total, %d with transcript, %d metadata-only",
+        len(payloads),
+        sum(1 for p in payloads if not p.is_metadata_only),
+        sum(1 for p in payloads if p.is_metadata_only),
+    )
+    return payloads
+
+
+async def _run_one(spec: RunSpec, payloads: list[ydd.VideoTranscriptPayload], *, day_name: str, date_str: str) -> dict[str, Any]:
+    """Execute a single labeled run. Returns metrics + artifact path."""
+    started = time.perf_counter()
+    env_snapshot: dict[str, str | None] = {}
+    # Apply env overrides ONLY for this run; restore at the end.
+    overrides: dict[str, str] = {}
+    if spec.pipeline == "map_reduce":
+        if spec.map_model:
+            overrides["UA_YOUTUBE_DIGEST_MAP_MODEL"] = spec.map_model
+        if spec.map_concurrency is not None:
+            overrides["UA_YOUTUBE_DIGEST_MAP_CONCURRENCY"] = str(spec.map_concurrency)
+    for k, v in overrides.items():
+        env_snapshot[k] = os.environ.get(k)
+        os.environ[k] = v
+    try:
+        if spec.pipeline == "single_call":
+            full_prompt = ydd.SYNTHESIS_PROMPT + "\n\n---\n\n".join(
+                f"Title: {p.title}\nVideo ID: {p.video_id}\nTranscript:\n"
+                + (p.transcript_text if p.transcript_text else f"[Metadata-only — transcript unavailable]\n\nTitle: {p.title}")
+                + "\n"
+                for p in payloads
+            )
+            digest_content = await ydd._generate_digest_content(
+                full_prompt=full_prompt,
+                pipeline_override="single_call",
+            )
+            map_metrics = None
+        else:
+            map_results = await ydd._map_retell_videos(payloads)
+            reduce_output = await ydd._reduce_meta_synthesize(
+                map_results,
+                day_name=day_name,
+                date_str=date_str,
+            )
+            digest_content = ydd._assemble_map_reduce_digest(
+                reduce_output=reduce_output,
+                map_results=map_results,
+            )
+            map_metrics = {
+                "videos": len(map_results),
+                "ok": sum(1 for r in map_results if r.error is None),
+                "failed": sum(1 for r in map_results if r.error is not None),
+                "latency_seconds": [r.elapsed_seconds for r in map_results],
+                "map_model": map_results[0].map_model if map_results else None,
+            }
+        elapsed = time.perf_counter() - started
+        return {
+            "label": spec.label,
+            "pipeline": spec.pipeline,
+            "map_model": spec.map_model,
+            "map_concurrency": spec.map_concurrency,
+            "ok": True,
+            "elapsed_seconds": elapsed,
+            "digest_content": digest_content,
+            "map_metrics": map_metrics,
+        }
+    except Exception as exc:
+        elapsed = time.perf_counter() - started
+        logger.error("Run %s failed after %.1fs: %s", spec.label, elapsed, exc)
+        return {
+            "label": spec.label,
+            "pipeline": spec.pipeline,
+            "map_model": spec.map_model,
+            "map_concurrency": spec.map_concurrency,
+            "ok": False,
+            "elapsed_seconds": elapsed,
+            "error": str(exc),
+            "digest_content": None,
+            "map_metrics": None,
+        }
+    finally:
+        # Restore env so back-to-back runs don't bleed.
+        for k, prev in env_snapshot.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def _diff_classifications(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a video-id-keyed table of how each run classified each video."""
+    table: dict[str, dict[str, Any]] = {}
+    for run in runs:
+        if not run.get("ok") or not run.get("digest_content"):
+            continue
+        decisions = ydd._extract_decision_json(run["digest_content"])
+        for row in decisions.get("ranked_videos", []):
+            vid = str(row.get("video_id") or "")
+            if not vid:
+                continue
+            entry = table.setdefault(vid, {"title": row.get("title", ""), "runs": {}})
+            entry["runs"][run["label"]] = {
+                "value_score": row.get("value_score"),
+                "value_tier": row.get("value_tier"),
+                "code_implementation_prospect": row.get("code_implementation_prospect"),
+                "evidence_quality": row.get("evidence_quality"),
+                "reason": row.get("reason"),
+            }
+    return table
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="A/B comparison harness for YouTube Digest pipelines.")
+    parser.add_argument("--day", required=True, help="Day of week (MONDAY..SUNDAY) — picks the matching pocket.")
+    parser.add_argument("--pocket-date", default=None, help="Pocket date YYYY-MM-DD (optional; defaults to latest).")
+    parser.add_argument(
+        "--runs",
+        action="append",
+        required=True,
+        help="Run specs of the form <pipeline>[:<model>][@conc=<int>]. Pass multiple times.",
+    )
+    parser.add_argument(
+        "--output-label",
+        default=None,
+        help="Optional label appended to the comparison output directory name.",
+    )
+    args = parser.parse_args()
+
+    initialize_runtime_secrets()
+    specs = [_parse_run_spec(s) for s in args.runs]
+    logger.info("Will execute %d runs: %s", len(specs), [s.label for s in specs])
+
+    pocket = _load_pocket(args.day, args.pocket_date)
+    payloads = _ingest_payloads(pocket)
+    if not payloads:
+        logger.error("No payloads; aborting.")
+        return 2
+
+    now = datetime.now(timezone.utc)
+    date_str = now.strftime("%Y-%m-%d")
+    label_suffix = f"_{args.output_label}" if args.output_label else ""
+    base_dir = ydd._digest_artifacts_dir() / f"comparison_{date_str}_{args.day.upper()}{label_suffix}"
+    base_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("Writing comparison outputs to %s", base_dir)
+
+    runs: list[dict[str, Any]] = []
+    for spec in specs:
+        logger.info(">>> Running %s ...", spec.label)
+        run = await _run_one(spec, payloads, day_name=args.day, date_str=date_str)
+        runs.append(run)
+        run_dir = base_dir / spec.label
+        run_dir.mkdir(parents=True, exist_ok=True)
+        if run.get("digest_content"):
+            (run_dir / "digest.md").write_text(run["digest_content"], encoding="utf-8")
+        metadata = {k: v for k, v in run.items() if k != "digest_content"}
+        metadata["started_at_utc"] = now.isoformat()
+        (run_dir / "run_metadata.json").write_text(
+            json.dumps(metadata, indent=2, ensure_ascii=False, default=str),
+            encoding="utf-8",
+        )
+        logger.info("  done: ok=%s elapsed=%.1fs", run["ok"], run["elapsed_seconds"])
+
+    classifications = _diff_classifications(runs)
+    (base_dir / "classifications_diff.json").write_text(
+        json.dumps(classifications, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    index = {
+        "comparison_dir": str(base_dir),
+        "pocket_video_count": len(payloads),
+        "day_name": args.day.upper(),
+        "started_at_utc": now.isoformat(),
+        "runs": [
+            {
+                "label": r["label"],
+                "pipeline": r["pipeline"],
+                "map_model": r["map_model"],
+                "map_concurrency": r["map_concurrency"],
+                "ok": r["ok"],
+                "elapsed_seconds": r["elapsed_seconds"],
+                "error": r.get("error"),
+                "map_metrics": r.get("map_metrics"),
+            }
+            for r in runs
+        ],
+    }
+    (base_dir / "index.json").write_text(
+        json.dumps(index, indent=2, ensure_ascii=False, default=str),
+        encoding="utf-8",
+    )
+    logger.info("Comparison complete. Index written to %s/index.json", base_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/unit/test_youtube_daily_digest_email_failures.py
+++ b/tests/unit/test_youtube_daily_digest_email_failures.py
@@ -57,7 +57,10 @@ def digest_module(monkeypatch, tmp_path):
         },
     )
 
-    async def _fake_generate(prompt: str) -> str:
+    async def _fake_generate(**kwargs) -> str:
+        # Accepts both legacy (full_prompt=...) and new map_reduce
+        # (videos=..., day_name=..., date_str=...) keyword signatures so the
+        # outer orchestration test doesn't care which pipeline ran.
         return "# Fake Digest\n\nSummary content.\n\n```json\n{\"decisions\": []}\n```"
 
     monkeypatch.setattr(ydd, "_generate_digest_content", _fake_generate)

--- a/tests/unit/test_youtube_daily_digest_map_reduce.py
+++ b/tests/unit/test_youtube_daily_digest_map_reduce.py
@@ -1,0 +1,390 @@
+"""Unit tests for the map-reduce pipeline added to youtube_daily_digest.py.
+
+We mock the AsyncAnthropic client at the boundary (the messages.create call)
+so the tests don't need network access. The point is to exercise the
+parse/assemble/dispatch logic and verify the env-var knobs flow correctly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from universal_agent.scripts import youtube_daily_digest as ydd
+
+
+def test_parse_map_output_extracts_classification_and_thesis():
+    raw = """## Video Title Here
+
+**Video ID:** abc123
+
+### Retelling
+Some retelling text here.
+
+### Actionable Insights
+- Do thing A.
+- Do thing B.
+
+### Thesis
+The video argues that X is the way forward because of reasons.
+
+```per_video_classification
+{
+  "video_id": "abc123",
+  "value_score": 87,
+  "value_tier": "high",
+  "code_implementation_prospect": true,
+  "concept_only": false,
+  "evidence_quality": "transcript",
+  "reason": "Concrete code walkthrough."
+}
+```
+"""
+    parsed = ydd._parse_map_output(raw, video_id="abc123", fallback_title="Title")
+    assert parsed["classification"]["value_score"] == 87
+    assert parsed["classification"]["value_tier"] == "high"
+    assert parsed["classification"]["code_implementation_prospect"] is True
+    assert "X is the way forward" in parsed["thesis_line"]
+    # Classification block should be stripped from the markdown.
+    assert "per_video_classification" not in parsed["retell_markdown"]
+    assert "### Retelling" in parsed["retell_markdown"]
+
+
+def test_parse_map_output_degrades_gracefully_on_bad_json():
+    raw = """## Title
+
+### Retelling
+Body.
+
+### Thesis
+Short thesis line.
+
+```per_video_classification
+{ "video_id": "abc", "value_score": "not-a-number"  // bad json
+```
+"""
+    parsed = ydd._parse_map_output(raw, video_id="abc", fallback_title="Title")
+    # On bad JSON we still get a default classification so the digest can proceed.
+    assert parsed["classification"]["video_id"] == "abc"
+    assert parsed["classification"]["value_tier"] == "unknown"
+    assert parsed["classification"]["code_implementation_prospect"] is False
+
+
+def test_parse_map_output_thesis_falls_back_to_reason_when_missing():
+    raw = """## Title
+
+```per_video_classification
+{
+  "video_id": "abc",
+  "value_score": 50,
+  "value_tier": "medium",
+  "code_implementation_prospect": false,
+  "concept_only": true,
+  "evidence_quality": "transcript",
+  "reason": "Concept-only commentary."
+}
+```
+"""
+    parsed = ydd._parse_map_output(raw, video_id="abc", fallback_title="Title")
+    assert parsed["thesis_line"] == "Concept-only commentary."
+
+
+def test_is_rate_limit_error_matches_zai_fup_1313():
+    fup_err = Exception(
+        "Error code: 429 - {'error': {'code': '1313', 'message': 'Fair Usage Policy'}}"
+    )
+    assert ydd._is_rate_limit_error(fup_err) is True
+    assert ydd._is_rate_limit_error(Exception("connection refused")) is False
+    assert ydd._is_rate_limit_error(Exception("too many requests")) is True
+    assert ydd._is_rate_limit_error(Exception("high concurrency detected")) is True
+
+
+def test_assemble_map_reduce_digest_threads_retellings_before_json_block():
+    map_results = [
+        ydd.MapResult(
+            video_id="a",
+            title="A",
+            retell_markdown="## A\n\n### Retelling\nA's retelling body.",
+            thesis_line="A's thesis.",
+            classification={"video_id": "a", "value_score": 90},
+        ),
+        ydd.MapResult(
+            video_id="b",
+            title="B",
+            retell_markdown="## B\n\n### Retelling\nB's retelling body.",
+            thesis_line="B's thesis.",
+            classification={"video_id": "b", "value_score": 70},
+        ),
+    ]
+    reduce_output = (
+        "# Daily YouTube Digest: Sunday, 2026-05-18\n\n"
+        "## Meta-Synthesis: Daily Digest\n\n"
+        "### Cross-Video Themes\nSomething about both videos.\n\n"
+        "```youtube_digest_decisions\n"
+        '{ "ranked_videos": [] }\n'
+        "```\n"
+    )
+    digest = ydd._assemble_map_reduce_digest(
+        reduce_output=reduce_output, map_results=map_results
+    )
+    # Both retellings must appear in the body.
+    assert "A's retelling body." in digest
+    assert "B's retelling body." in digest
+    # And the JSON block must still be at the end, intact.
+    jsonidx = digest.index("```youtube_digest_decisions")
+    retellings_idx = digest.index("## Per-Video Retellings")
+    assert retellings_idx < jsonidx, "retellings must precede the JSON block so _extract_decision_json still works"
+
+
+def test_assemble_map_reduce_digest_handles_missing_json_block():
+    map_results = [
+        ydd.MapResult(
+            video_id="a",
+            title="A",
+            retell_markdown="## A retelling",
+            thesis_line="A.",
+            classification={"video_id": "a"},
+        )
+    ]
+    # No JSON block at all in reducer output (degenerate but should not crash).
+    digest = ydd._assemble_map_reduce_digest(
+        reduce_output="# Just meta-synthesis with no JSON.\n", map_results=map_results
+    )
+    assert "A retelling" in digest
+
+
+@pytest.mark.asyncio
+async def test_retell_one_video_calls_llm_and_parses_response(monkeypatch):
+    """Exercise the map call end-to-end with a stubbed Anthropic client."""
+
+    class _FakeBlock:
+        def __init__(self, text: str):
+            self.text = text
+
+    class _FakeResponse:
+        def __init__(self, text: str):
+            self.content = [_FakeBlock(text)]
+
+    canned = """## Test Video
+
+**Video ID:** vid1
+
+### Retelling
+This is a retelling.
+
+### Thesis
+This is the thesis.
+
+```per_video_classification
+{
+  "video_id": "vid1",
+  "value_score": 80,
+  "value_tier": "high",
+  "code_implementation_prospect": true,
+  "concept_only": false,
+  "evidence_quality": "transcript",
+  "reason": "Concrete tutorial."
+}
+```
+"""
+
+    class _FakeMessages:
+        async def create(self, **kwargs):
+            return _FakeResponse(canned)
+
+    class _FakeClient:
+        messages = _FakeMessages()
+
+    # Stub the rate limiter to no-op.
+    class _NoopLimiter:
+        def acquire(self, *a, **k):
+            # The real limiter's acquire() returns an async context manager
+            # directly (it's NOT an async function). Mirror that here so
+            # `async with limiter.acquire(context):` works.
+            class _Ctx:
+                async def __aenter__(_self): return None
+                async def __aexit__(_self, *a): return False
+            return _Ctx()
+        async def record_success(self): pass
+        async def record_429(self, *a): pass
+        def get_backoff(self, attempt): return 0.0
+
+    monkeypatch.setattr(ydd.ZAIRateLimiter, "get_instance", lambda: _NoopLimiter())
+
+    result = await ydd._retell_one_video(
+        client=_FakeClient(),
+        model="glm-4.5-air",
+        video=ydd.VideoTranscriptPayload(
+            video_id="vid1",
+            title="Test Video",
+            transcript_text="Original transcript content",
+        ),
+        max_tokens=2000,
+        transcript_char_limit=50_000,
+    )
+    assert result.video_id == "vid1"
+    assert result.classification["value_score"] == 80
+    assert result.thesis_line == "This is the thesis."
+    assert result.error is None
+    assert result.map_model == "glm-4.5-air"
+
+
+@pytest.mark.asyncio
+async def test_retell_one_video_returns_error_result_when_llm_fails(monkeypatch):
+    class _FailingMessages:
+        async def create(self, **kwargs):
+            raise RuntimeError("API exploded")
+
+    class _FailingClient:
+        messages = _FailingMessages()
+
+    class _NoopLimiter:
+        def acquire(self, *a, **k):
+            # The real limiter's acquire() returns an async context manager
+            # directly (it's NOT an async function). Mirror that here so
+            # `async with limiter.acquire(context):` works.
+            class _Ctx:
+                async def __aenter__(_self): return None
+                async def __aexit__(_self, *a): return False
+            return _Ctx()
+        async def record_success(self): pass
+        async def record_429(self, *a): pass
+        def get_backoff(self, attempt): return 0.0
+
+    monkeypatch.setattr(ydd.ZAIRateLimiter, "get_instance", lambda: _NoopLimiter())
+
+    result = await ydd._retell_one_video(
+        client=_FailingClient(),
+        model="glm-4.5-air",
+        video=ydd.VideoTranscriptPayload(video_id="vid", title="Title", transcript_text="x"),
+        max_tokens=2000,
+        transcript_char_limit=50_000,
+    )
+    assert result.error is not None
+    assert "API exploded" in result.error
+    assert result.classification["value_score"] == 0
+    assert result.classification["code_implementation_prospect"] is False
+
+
+def test_dispatcher_routes_to_single_call_when_env_says_so(monkeypatch):
+    monkeypatch.setenv("UA_YOUTUBE_DIGEST_PIPELINE", "single_call")
+    calls = {}
+
+    async def _fake_single(prompt):
+        calls["got_prompt"] = prompt
+        return "single-call output"
+
+    async def _fake_mapreduce(**kwargs):
+        calls["got_mapreduce"] = kwargs
+        return "map-reduce output"
+
+    monkeypatch.setattr(ydd, "_generate_digest_content_single_call", _fake_single)
+    monkeypatch.setattr(ydd, "_generate_digest_content_map_reduce", _fake_mapreduce)
+
+    result = asyncio.run(
+        ydd._generate_digest_content(full_prompt="hello world")
+    )
+    assert result == "single-call output"
+    assert calls["got_prompt"] == "hello world"
+    assert "got_mapreduce" not in calls
+
+
+def test_dispatcher_routes_to_map_reduce_by_default(monkeypatch):
+    monkeypatch.delenv("UA_YOUTUBE_DIGEST_PIPELINE", raising=False)
+    calls = {}
+
+    async def _fake_single(prompt):
+        calls["single"] = prompt
+        return "single"
+
+    async def _fake_mapreduce(**kwargs):
+        calls["mapreduce"] = kwargs
+        return "mapreduce"
+
+    monkeypatch.setattr(ydd, "_generate_digest_content_single_call", _fake_single)
+    monkeypatch.setattr(ydd, "_generate_digest_content_map_reduce", _fake_mapreduce)
+
+    result = asyncio.run(
+        ydd._generate_digest_content(
+            videos=[ydd.VideoTranscriptPayload(video_id="a", title="A", transcript_text="t")],
+            day_name="MONDAY",
+            date_str="2026-05-18",
+        )
+    )
+    assert result == "mapreduce"
+    assert "mapreduce" in calls
+    assert "single" not in calls
+
+
+def test_dispatcher_explicit_override_wins_over_env(monkeypatch):
+    monkeypatch.setenv("UA_YOUTUBE_DIGEST_PIPELINE", "map_reduce")
+    calls = {}
+
+    async def _fake_single(prompt):
+        calls["single"] = True
+        return "x"
+
+    monkeypatch.setattr(ydd, "_generate_digest_content_single_call", _fake_single)
+    asyncio.run(ydd._generate_digest_content(full_prompt="p", pipeline_override="single_call"))
+    assert calls.get("single") is True
+
+
+def test_dispatcher_raises_when_missing_required_args():
+    # map_reduce path needs videos+day_name+date_str
+    with pytest.raises(ValueError):
+        asyncio.run(ydd._generate_digest_content(pipeline_override="map_reduce"))
+    # single_call path needs full_prompt
+    with pytest.raises(ValueError):
+        asyncio.run(ydd._generate_digest_content(pipeline_override="single_call"))
+
+
+@pytest.mark.asyncio
+async def test_map_step_respects_concurrency_semaphore(monkeypatch):
+    """At map_concurrency=2 we should never have >2 in-flight calls at once."""
+    in_flight = 0
+    peak = 0
+    lock = asyncio.Lock()
+
+    async def _slow_create(**kwargs):
+        nonlocal in_flight, peak
+        async with lock:
+            in_flight += 1
+            peak = max(peak, in_flight)
+        await asyncio.sleep(0.05)
+        async with lock:
+            in_flight -= 1
+
+        class _Resp:
+            content = [type("B", (), {"text": "## T\n\n### Retelling\nbody.\n\n### Thesis\nshort thesis.\n\n```per_video_classification\n{\"video_id\":\"x\",\"value_score\":50,\"value_tier\":\"medium\",\"code_implementation_prospect\":false,\"concept_only\":true,\"evidence_quality\":\"transcript\",\"reason\":\"r\"}\n```"})()]
+        return _Resp()
+
+    class _FakeMessages:
+        create = _slow_create
+
+    class _FakeClient:
+        messages = _FakeMessages()
+
+    monkeypatch.setattr(ydd, "_build_anthropic_client_for_zai", lambda timeout_seconds: _FakeClient())
+
+    class _NoopLimiter:
+        def acquire(self, *a, **k):
+            class _Ctx:
+                async def __aenter__(_self): return None
+                async def __aexit__(_self, *a): return False
+            return _Ctx()
+        async def record_success(self): pass
+        async def record_429(self, *a): pass
+        def get_backoff(self, attempt): return 0.0
+
+    monkeypatch.setattr(ydd.ZAIRateLimiter, "get_instance", lambda: _NoopLimiter())
+
+    videos = [
+        ydd.VideoTranscriptPayload(video_id=f"v{i}", title=f"T{i}", transcript_text="t")
+        for i in range(6)
+    ]
+    results = await ydd._map_retell_videos(videos, concurrency=2)
+    assert len(results) == 6
+    assert peak <= 2, f"semaphore breached: peak={peak}"


### PR DESCRIPTION
## Summary

Refactors the daily-digest synthesis from one big-context LLM call into a two-step **map-reduce** shape, and adds a standalone comparison harness so we can A/B-evaluate output quality across different (model, concurrency) configurations without touching the live cron.

### Why

Today's pipeline:
- One LLM call with ~145k input tokens (29 transcripts concatenated)
- Asks for "concise, dense summary" per video — gets summaries, not retellings
- Single point of failure; 180s default timeout was killing 29-video days until #356 bumped to 900s
- Sequential by construction; can't scale beyond ~30 videos before context limits or timeouts bite

New pipeline:
- **Map** step: one LLM call per video, in parallel. Prompt asks for a 30-40% length **retelling** that preserves specific examples, numbers, quotes, and the speaker's reasoning structure — not a summary.
- **Reduce** step: one LLM call that sees only titles + per-video thesis lines + classifications (NOT full retellings), so context stays small. Emits the cross-video meta-synthesis and the ranked `youtube_digest_decisions` JSON block.
- Python assembles the final markdown: meta-synthesis + retellings + JSON block, in an order that keeps the existing `_extract_decision_json` parser working unchanged.

### Models + concurrency

| Step | Default model | Why |
|---|---|---|
| Map | `glm-4.5-air` (Z.AI haiku-equivalent) | 2026-05-18 probe showed ~30% faster per call than `glm-5-turbo` and stable at concurrency 1-3 for this prompt shape. The historical `model_resolution.py` comment about preflight wedging no longer matches reality; the 429s we now see at conc≥5 are account-level Fair-Usage-Policy (Z.AI error 1313), not per-model. |
| Reduce | `resolve_model("opus")` → `glm-5.1` | Same as today's default. Reduce context is small (titles + classifications), so cost stays low. |

Concurrency is bounded by min(internal map semaphore, global `ZAI_MAX_CONCURRENT`). Default internal semaphore is 3; global is 2. Both are env-tunable.

### Env knobs (all overridable, no live-config required)

```
UA_YOUTUBE_DIGEST_PIPELINE              map_reduce|single_call   (default map_reduce)
UA_YOUTUBE_DIGEST_MAP_MODEL             e.g. glm-4.5-air | glm-5-turbo
UA_YOUTUBE_DIGEST_MAP_CONCURRENCY       int (default 3)
UA_YOUTUBE_DIGEST_MAP_TIMEOUT_SECONDS   int (default 180)
UA_YOUTUBE_DIGEST_MAP_MAX_TOKENS        int (default 4000)
UA_YOUTUBE_DIGEST_REDUCE_MODEL          model id (default resolve_model("opus"))
UA_YOUTUBE_DIGEST_REDUCE_TIMEOUT_SECONDS int (default 600)
UA_YOUTUBE_DIGEST_REDUCE_MAX_TOKENS     int (default 8000)
UA_YOUTUBE_DIGEST_LLM_TIMEOUT_SECONDS   int (single_call path; default 900)
```

### Comparison harness

`src/universal_agent/scripts/youtube_digest_compare.py` lets us run multiple labeled configs against the **same** input transcripts and dump outputs side-by-side for human evaluation.

```bash
uv run python -m universal_agent.scripts.youtube_digest_compare \
  --day SUNDAY \
  --runs single_call:default \
  --runs map_reduce:glm-4.5-air@conc=3 \
  --runs map_reduce:glm-5-turbo@conc=3
```

Outputs go to `AGENT_RUN_WORKSPACES/daily_digests/comparison_<date>_<DAY>/` with one subdirectory per labeled run plus a top-level `classifications_diff.json` so you can see how each model rated each video.

### Legacy path kept

The single-call pipeline stays intact at `_generate_digest_content_single_call` and is selectable via the `UA_YOUTUBE_DIGEST_PIPELINE=single_call` env var. We can flip back in one env var if map-reduce regresses output quality.

### Tests

- 13 new unit tests in `test_youtube_daily_digest_map_reduce.py` covering parsing, rate-limit detection, assembly, map happy/failure paths, dispatcher routing, and semaphore enforcement.
- Existing pocket + email-failure suites updated to the new dispatcher signature.
- 24/24 pass.

## Coordination with prior digest PRs

Stacks cleanly on `main` alongside #356 (digest restoration + cron preflight hardening) and #357 (demo-worthiness gate). All three branch from `main` and touch non-overlapping regions of `youtube_daily_digest.py`.

## Test plan

- [ ] Run `youtube_digest_compare.py` against the SUNDAY pocket with three configs (single_call, map_reduce glm-4.5-air, map_reduce glm-5-turbo) and human-review the per-video retelling depth side-by-side before flipping production to map_reduce
- [ ] Tomorrow's 6 AM Central cron with `UA_YOUTUBE_DIGEST_PIPELINE` unset uses `map_reduce` and emails the digest
- [ ] If quality regresses, set `UA_YOUTUBE_DIGEST_PIPELINE=single_call` in Infisical and confirm next run reverts cleanly
- [ ] Concurrency sweep: rerun the comparison with `UA_YOUTUBE_DIGEST_MAP_CONCURRENCY=5` to characterize FUP 429 behavior under load