### PR TITLE
feat(youtube-digest): per-call retry + error-class telemetry on map step (follow-up to #360)

### DIFF
--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -103,7 +103,12 @@ class VideoTranscriptPayload:
 
 @dataclass
 class MapResult:
-    """Output of a single map-step call (one video → one retell + classification)."""
+    """Output of a single map-step call (one video → one retell + classification).
+
+    `retries` / `rate_limit_hits` / `last_error_class` are populated for every
+    call (success or failure) so the comparison harness can correlate model
+    choice + concurrency level with the rate-limit error surface.
+    """
     video_id: str
     title: str
     retell_markdown: str
@@ -112,6 +117,9 @@ class MapResult:
     error: str | None = None
     elapsed_seconds: float = 0.0
     map_model: str = ""
+    retries: int = 0  # number of retry attempts before success (0 if first call worked)
+    rate_limit_hits: int = 0  # how many of those retries were due to 429/FUP
+    last_error_class: str = ""  # class name of last (or final-failing) exception
 
 
 
@@ -334,14 +342,23 @@ async def _zai_call_with_retry(
     context: str,
     max_retries: int = 5,
     temperature: float = 0.4,
+    stats_out: dict[str, Any] | None = None,
 ) -> str:
     """Send one messages.create() call to Z.AI with the global rate limiter
     and a 429/FUP-aware retry loop. Returns the concatenated text response.
 
     All non-rate-limit errors are re-raised immediately.
+
+    If `stats_out` is provided, it is populated in-place with:
+      - retries: int (number of retry attempts; 0 if first call succeeded)
+      - rate_limit_hits: int (subset of retries triggered by 429/FUP)
+      - last_error_class: str (class name of the most recent exception, "" if none)
+    The caller can use these to correlate model+concurrency choices with the
+    actual rate-limit error surface, especially in the A/B comparison harness.
     """
     limiter = ZAIRateLimiter.get_instance()
     last_error: Exception | None = None
+    rate_limit_hits = 0
     for attempt in range(max_retries):
         async with limiter.acquire(context):
             try:
@@ -355,11 +372,20 @@ async def _zai_call_with_retry(
                 text = "".join(getattr(block, "text", "") for block in response.content).strip()
                 if not text:
                     raise RuntimeError(f"LLM returned an empty response (context={context})")
+                if stats_out is not None:
+                    stats_out["retries"] = attempt
+                    stats_out["rate_limit_hits"] = rate_limit_hits
+                    stats_out["last_error_class"] = ""
                 return text
             except Exception as exc:
                 last_error = exc
                 if not _is_rate_limit_error(exc):
+                    if stats_out is not None:
+                        stats_out["retries"] = attempt
+                        stats_out["rate_limit_hits"] = rate_limit_hits
+                        stats_out["last_error_class"] = type(exc).__name__
                     raise
+                rate_limit_hits += 1
                 await limiter.record_429(context)
                 if attempt >= max_retries - 1:
                     break
@@ -373,6 +399,10 @@ async def _zai_call_with_retry(
                     str(exc)[:200],
                 )
                 await asyncio.sleep(delay)
+    if stats_out is not None:
+        stats_out["retries"] = max_retries - 1
+        stats_out["rate_limit_hits"] = rate_limit_hits
+        stats_out["last_error_class"] = type(last_error).__name__ if last_error else ""
     raise RuntimeError(
         f"ZAI call failed after {max_retries} attempts at context={context}: {last_error}"
     )
@@ -468,6 +498,7 @@ async def _retell_one_video(
     prompt = RETELL_PROMPT + prompt_body
     context = f"youtube_digest_map:{video.video_id}"
 
+    stats: dict[str, Any] = {}
     try:
         raw_text = await _zai_call_with_retry(
             client=client,
@@ -475,6 +506,7 @@ async def _retell_one_video(
             prompt=prompt,
             max_tokens=max_tokens,
             context=context,
+            stats_out=stats,
         )
         elapsed = (datetime.now(timezone.utc) - started).total_seconds()
         parsed = _parse_map_output(raw_text, video_id=video.video_id, fallback_title=video.title)
@@ -486,6 +518,9 @@ async def _retell_one_video(
             classification=parsed["classification"],
             elapsed_seconds=elapsed,
             map_model=model,
+            retries=int(stats.get("retries", 0)),
+            rate_limit_hits=int(stats.get("rate_limit_hits", 0)),
+            last_error_class=str(stats.get("last_error_class", "")),
         )
     except Exception as exc:
         elapsed = (datetime.now(timezone.utc) - started).total_seconds()
@@ -513,6 +548,9 @@ async def _retell_one_video(
             error=str(exc),
             elapsed_seconds=elapsed,
             map_model=model,
+            retries=int(stats.get("retries", 0)),
+            rate_limit_hits=int(stats.get("rate_limit_hits", 0)),
+            last_error_class=str(stats.get("last_error_class", "") or type(exc).__name__),
         )
 
 
@@ -590,19 +628,37 @@ async def _map_retell_videos(
     # Surface aggregate stats in the log so operators can spot regressions.
     successes = [r for r in results if r.error is None]
     failures = [r for r in results if r.error is not None]
+    total_retries = sum(r.retries for r in results)
+    total_rate_limit_hits = sum(r.rate_limit_hits for r in results)
+    error_class_breakdown: dict[str, int] = {}
+    for r in results:
+        cls = r.last_error_class
+        if cls:
+            error_class_breakdown[cls] = error_class_breakdown.get(cls, 0) + 1
     if successes:
         elapsed_list = sorted(r.elapsed_seconds for r in successes)
         median = elapsed_list[len(elapsed_list) // 2]
         logger.info(
-            "Map step complete: %d ok / %d failed; latency min=%.1fs p50=%.1fs max=%.1fs",
+            "Map step complete: %d ok / %d failed; latency min=%.1fs p50=%.1fs max=%.1fs; "
+            "retries=%d (%d rate_limit); error_classes=%s",
             len(successes),
             len(failures),
             min(elapsed_list),
             median,
             max(elapsed_list),
+            total_retries,
+            total_rate_limit_hits,
+            error_class_breakdown or "none",
         )
     else:
-        logger.error("Map step complete: 0 ok / %d failed (all videos failed)", len(failures))
+        logger.error(
+            "Map step complete: 0 ok / %d failed (all videos failed); "
+            "retries=%d (%d rate_limit); error_classes=%s",
+            len(failures),
+            total_retries,
+            total_rate_limit_hits,
+            error_class_breakdown or "none",
+        )
     return results
 
 

--- a/src/universal_agent/scripts/youtube_digest_compare.py
+++ b/src/universal_agent/scripts/youtube_digest_compare.py
@@ -224,12 +224,34 @@ async def _run_one(spec: RunSpec, payloads: list[ydd.VideoTranscriptPayload], *,
                 reduce_output=reduce_output,
                 map_results=map_results,
             )
+            # Error-class breakdown lets us correlate model+concurrency choice
+            # with the actual rate-limit error surface (e.g. does glm-4.5-air
+            # generate more or fewer FUP 429s than glm-5-turbo at conc=3?).
+            error_class_breakdown: dict[str, int] = {}
+            for r in map_results:
+                cls = r.last_error_class
+                if cls:
+                    error_class_breakdown[cls] = error_class_breakdown.get(cls, 0) + 1
             map_metrics = {
                 "videos": len(map_results),
                 "ok": sum(1 for r in map_results if r.error is None),
                 "failed": sum(1 for r in map_results if r.error is not None),
                 "latency_seconds": [r.elapsed_seconds for r in map_results],
                 "map_model": map_results[0].map_model if map_results else None,
+                "total_retries": sum(r.retries for r in map_results),
+                "total_rate_limit_hits": sum(r.rate_limit_hits for r in map_results),
+                "error_class_breakdown": error_class_breakdown,
+                "per_video_retries": [
+                    {
+                        "video_id": r.video_id,
+                        "retries": r.retries,
+                        "rate_limit_hits": r.rate_limit_hits,
+                        "last_error_class": r.last_error_class,
+                        "ok": r.error is None,
+                        "elapsed_seconds": r.elapsed_seconds,
+                    }
+                    for r in map_results
+                ],
             }
         elapsed = time.perf_counter() - started
         return {

--- a/tests/unit/test_youtube_daily_digest_map_reduce.py
+++ b/tests/unit/test_youtube_daily_digest_map_reduce.py
@@ -342,6 +342,84 @@ def test_dispatcher_raises_when_missing_required_args():
 
 
 @pytest.mark.asyncio
+async def test_retell_one_video_tracks_rate_limit_retries(monkeypatch):
+    """Verify a 429-then-success sequence is reflected in MapResult.retries
+    and MapResult.rate_limit_hits so the comparison harness can correlate
+    model+concurrency choices with rate-limit error surfaces."""
+    call_log: list[int] = []
+    canned_success = """## Test
+
+**Video ID:** vid
+
+### Retelling
+body.
+
+### Thesis
+Short thesis.
+
+```per_video_classification
+{
+  "video_id": "vid",
+  "value_score": 70,
+  "value_tier": "high",
+  "code_implementation_prospect": true,
+  "concept_only": false,
+  "evidence_quality": "transcript",
+  "reason": "Concrete."
+}
+```
+"""
+
+    class _Block:
+        def __init__(self, text: str): self.text = text
+
+    class _Resp:
+        def __init__(self, text: str): self.content = [_Block(text)]
+
+    class _Messages:
+        async def create(self, **kwargs):
+            call_log.append(len(call_log))
+            # First two attempts return 429 / FUP 1313; third succeeds.
+            if len(call_log) <= 2:
+                raise Exception(
+                    "Error code: 429 - {'error': {'code': '1313', 'message': 'Fair Usage Policy'}}"
+                )
+            return _Resp(canned_success)
+
+    class _Client:
+        messages = _Messages()
+
+    class _NoopLimiter:
+        def acquire(self, *a, **k):
+            class _Ctx:
+                async def __aenter__(_self): return None
+                async def __aexit__(_self, *a): return False
+            return _Ctx()
+        async def record_success(self): pass
+        async def record_429(self, *a): pass
+        def get_backoff(self, attempt): return 0.0
+
+    monkeypatch.setattr(ydd.ZAIRateLimiter, "get_instance", lambda: _NoopLimiter())
+    # Patch asyncio.sleep to a no-op coroutine so the test doesn't actually
+    # wait. Must NOT reference the real asyncio.sleep here or we recurse.
+    async def _noop_sleep(_s):
+        return None
+    monkeypatch.setattr(ydd.asyncio, "sleep", _noop_sleep)
+
+    result = await ydd._retell_one_video(
+        client=_Client(),
+        model="glm-4.5-air",
+        video=ydd.VideoTranscriptPayload(video_id="vid", title="T", transcript_text="t"),
+        max_tokens=2000,
+        transcript_char_limit=50_000,
+    )
+    assert result.error is None
+    assert result.retries == 2, f"expected 2 retries, got {result.retries}"
+    assert result.rate_limit_hits == 2, f"expected 2 rate-limit hits, got {result.rate_limit_hits}"
+    assert result.last_error_class == ""  # cleared on eventual success
+
+
+@pytest.mark.asyncio
 async def test_map_step_respects_concurrency_semaphore(monkeypatch):
     """At map_concurrency=2 we should never have >2 in-flight calls at once."""
     in_flight = 0


### PR DESCRIPTION
## Summary

Follow-up to #360. Adds the per-call telemetry needed to answer "does \`glm-4.5-air\` produce more or fewer rate-limit 429s than \`glm-5-turbo\` at a given concurrency?" — the original motivation for the comparison harness. Auto-merge on #360 fired before this telemetry made it onto that PR, so it lands separately here.

## Changes

- \`MapResult\` gains three fields populated for every map call (success or failure):
  - \`retries\`: retry attempts before success (0 if first call worked)
  - \`rate_limit_hits\`: subset of retries triggered by 429/FUP (Z.AI error 1313)
  - \`last_error_class\`: exception class name (empty string on success)
- \`_zai_call_with_retry\` accepts an optional \`stats_out: dict | None\` and populates it with the same triple in-place. Callers thread it through to MapResult.
- Map-step aggregate log now reports total retries, total rate-limit hits, and an error-class breakdown — so a live cron run's \`run.log\` surfaces the same signal we'd see in the harness.
- Comparison harness \`map_metrics\` gains:
  - \`total_retries\`
  - \`total_rate_limit_hits\`
  - \`error_class_breakdown\` (counter)
  - \`per_video_retries\` (per-call list so we can correlate latency vs retry pressure on a single video)

## Why this matters for the comparison

Without this, the harness output for two runs like \`map_reduce:glm-4.5-air@conc=3\` and \`map_reduce:glm-5-turbo@conc=3\` would only tell us "did they both finish." With it, the output JSON tells us which model survived the FUP throttle better at a given concurrency — exactly the question the operator wants to answer before bumping concurrency on a live cron.

## Tests

New test in \`test_youtube_daily_digest_map_reduce.py\` simulates a 429→429→success FUP sequence and asserts \`retries=2\`, \`rate_limit_hits=2\`, \`last_error_class=""\` on eventual success. \`asyncio.sleep\` is replaced with a true no-op coroutine (a previous draft recursed). 25/25 pass.

## Risk

None to the live cron — these are observability fields only. \`MapResult\` field defaults are backwards-compatible. The comparison harness gains new JSON output fields but its existing fields are unchanged.