### PR TITLE
feat(task-hub): needs_review SLA reaper + operator priority boost + curator backpressure

### DIFF
--- a/src/universal_agent/heartbeat_service.py
+++ b/src/universal_agent/heartbeat_service.py
@@ -2285,6 +2285,27 @@ class HeartbeatService:
                         except Exception as _sc_exc:
                             logger.debug("Signal curator unavailable: %s", _sc_exc)
                         # ────────────────────────────────────────────────────
+
+                        # ──── needs_review SLA reaper ───────────────────────
+                        # Recover tasks that fell through to needs_review
+                        # without an explicit close. Safe to run on every
+                        # heartbeat — it's a single indexed query + bounded
+                        # update. Operator-gated dispositions are left alone.
+                        try:
+                            from universal_agent.services.needs_review_reaper import (
+                                reap_stale_needs_review,
+                            )
+                            _reaper_summary = reap_stale_needs_review(conn)
+                            if _reaper_summary.get("recovered"):
+                                logger.info(
+                                    "needs_review reaper recovered %d task(s) for %s: %s",
+                                    _reaper_summary["recovered"],
+                                    session.session_id,
+                                    _reaper_summary["recovered_ids"],
+                                )
+                        except Exception as _rr_exc:
+                            logger.debug("needs_review reaper unavailable: %s", _rr_exc)
+                        # ────────────────────────────────────────────────────
                     else:
                         logger.info(
                             "Skipping proactive advisor for %s (task-focused mode, %d tasks claimed)",

--- a/src/universal_agent/proactive_signals.py
+++ b/src/universal_agent/proactive_signals.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import hashlib
 import json
+import logging
 from pathlib import Path
 import re
 import sqlite3
 from typing import Any, Optional
 
 from universal_agent import task_hub
+
+logger = logging.getLogger(__name__)
 
 CARD_STATUS_PENDING = "pending"
 CARD_STATUS_APPROVED = "approved"
@@ -628,6 +631,20 @@ def _discord_actions(topic: str) -> list[dict[str, str]]:
     ]
 
 
+def _resolve_followup_priority(*, card: dict[str, Any], actor: str) -> int:
+    """Resolve task priority for a proactive-signal follow-up.
+
+    Operator-clicked actions (``actor='dashboard_user'``) are boosted to
+    priority 1 so they jump ahead of auto-promoted background tasks in
+    the dispatch queue. The user's explicit click is a stronger signal
+    than the curator's auto-pick. Other actors honor the card's declared
+    priority (clamped to 1-4).
+    """
+    if actor == "dashboard_user":
+        return 1
+    return max(1, min(4, int(card.get("priority") or 2)))
+
+
 def _create_followup_task(
     conn: sqlite3.Connection,
     *,
@@ -661,7 +678,7 @@ def _create_followup_task(
             "title": f"{action_label}: {card.get('title')}",
             "description": description,
             "project_key": "proactive",
-            "priority": max(1, min(4, int(card.get("priority") or 2))),
+            "priority": _resolve_followup_priority(card=card, actor=actor),
             "labels": ["proactive-signal", str(card.get("source") or "signal"), str(action.get("id") or "action")],
             "status": task_hub.TASK_STATUS_OPEN,
             "agent_ready": str(action.get("id") or "") != "track_topic",

--- a/src/universal_agent/services/needs_review_reaper.py
+++ b/src/universal_agent/services/needs_review_reaper.py
@@ -1,0 +1,201 @@
+"""needs_review_reaper.py — SLA reaper for stuck-in-review tasks.
+
+``needs_review`` is the Task Hub's uncertainty-disposition escape hatch:
+the finalize sweep in ``task_hub.py`` parks a task there when a run
+finishes but didn't reach an explicit completed/failed disposition
+(see ``task_hub.py:3460+``). The status is overloaded — it covers
+both *"finished ambiguously, retry would be safe"* and *"side effects
+occurred, human must look"*.
+
+Until this module landed, there was no automatic recovery from
+``needs_review``. Tasks could rot for days. The 39-hour delay on the
+"Hermes AI Desktop App" wiki on 2026-05-17/18 was traced to exactly
+this hole.
+
+This reaper sweeps tasks whose ``metadata.dispatch.last_disposition_reason``
+indicates *disposition uncertainty* and re-opens them after an SLA.
+Operator-gated reasons (retry exhausted, side effects already happened)
+are deliberately left alone.
+
+Configuration:
+  - UA_NEEDS_REVIEW_SLA_HOURS (default: 4) — age before recovery
+  - UA_NEEDS_REVIEW_REAPER_LIMIT (default: 20) — per-sweep cap
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+import logging
+import os
+import sqlite3
+from typing import Any, Optional
+
+from universal_agent import task_hub
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SLA_HOURS = 4
+DEFAULT_PER_SWEEP_LIMIT = 20
+
+# Disposition reasons set by task_hub finalize when a run completes
+# without an explicit close. These are safe to retry.
+RECOVERABLE_REASONS = frozenset({
+    "heartbeat_completed_without_disposition",
+    "todo_completed_without_disposition",
+})
+
+# Disposition reasons that genuinely require operator attention — never
+# auto-recover. Side effects already occurred, or the task burned its
+# retry budget.
+OPERATOR_GATED_REASONS = frozenset({
+    "heartbeat_retry_exhausted",
+    "heartbeat_retryable_with_side_effects",
+    "todo_retryable_with_side_effects",
+})
+
+
+def _parse_int_env(key: str, default: int) -> int:
+    raw = (os.getenv(key) or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
+def _disposition_reason(metadata_json: str) -> str:
+    """Extract ``dispatch.last_disposition_reason`` from a metadata blob."""
+    try:
+        metadata = json.loads(metadata_json or "{}")
+    except (json.JSONDecodeError, TypeError):
+        return ""
+    if not isinstance(metadata, dict):
+        return ""
+    dispatch = metadata.get("dispatch") or {}
+    if not isinstance(dispatch, dict):
+        return ""
+    return str(dispatch.get("last_disposition_reason") or "")
+
+
+def reap_stale_needs_review(
+    conn: sqlite3.Connection,
+    *,
+    sla_hours: Optional[int] = None,
+    limit: Optional[int] = None,
+    now: Optional[datetime] = None,
+) -> dict[str, Any]:
+    """Re-open stale ``needs_review`` tasks with recoverable dispositions.
+
+    Args:
+        conn: Database connection (will commit when any recovery happens).
+        sla_hours: Override the SLA. Defaults to ``UA_NEEDS_REVIEW_SLA_HOURS``
+            or 4 hours.
+        limit: Maximum tasks to recover in one sweep. Defaults to
+            ``UA_NEEDS_REVIEW_REAPER_LIMIT`` or 20.
+        now: Test-injection point for "current time".
+
+    Returns:
+        Summary dict with counts and the recovered task IDs.
+    """
+    task_hub.ensure_schema(conn)
+    effective_sla = (
+        sla_hours
+        if sla_hours is not None
+        else _parse_int_env("UA_NEEDS_REVIEW_SLA_HOURS", DEFAULT_SLA_HOURS)
+    )
+    effective_limit = (
+        limit
+        if limit is not None
+        else _parse_int_env("UA_NEEDS_REVIEW_REAPER_LIMIT", DEFAULT_PER_SWEEP_LIMIT)
+    )
+    now_dt = now or datetime.now(timezone.utc)
+    cutoff = (now_dt - timedelta(hours=effective_sla)).isoformat()
+    now_iso = now_dt.isoformat()
+
+    # Over-fetch so the in-Python filter for disposition reason still
+    # gives us a reasonable working set even when many rows are
+    # operator-gated. Cap at limit * 4 to keep memory bounded.
+    rows = conn.execute(
+        """
+        SELECT task_id, metadata_json, updated_at
+        FROM task_hub_items
+        WHERE status = ?
+          AND updated_at < ?
+        ORDER BY updated_at ASC
+        LIMIT ?
+        """,
+        (task_hub.TASK_STATUS_REVIEW, cutoff, max(effective_limit * 4, effective_limit)),
+    ).fetchall()
+
+    recovered_ids: list[str] = []
+    skipped_gated = 0
+    skipped_unknown = 0
+
+    for row in rows:
+        if len(recovered_ids) >= effective_limit:
+            break
+        reason = _disposition_reason(row["metadata_json"])
+        if reason in OPERATOR_GATED_REASONS:
+            skipped_gated += 1
+            continue
+        if reason not in RECOVERABLE_REASONS:
+            skipped_unknown += 1
+            continue
+
+        try:
+            metadata = json.loads(row["metadata_json"] or "{}")
+            if not isinstance(metadata, dict):
+                metadata = {}
+        except (json.JSONDecodeError, TypeError):
+            metadata = {}
+        dispatch_meta = metadata.get("dispatch") or {}
+        if not isinstance(dispatch_meta, dict):
+            dispatch_meta = {}
+
+        dispatch_meta["last_disposition"] = "reopened"
+        dispatch_meta["last_disposition_reason"] = "needs_review_sla_recovered"
+        dispatch_meta["needs_review_recovered_at"] = now_iso
+        dispatch_meta["needs_review_prior_reason"] = reason
+        prior_count = 0
+        try:
+            prior_count = int(dispatch_meta.get("needs_review_recovery_count") or 0)
+        except (TypeError, ValueError):
+            prior_count = 0
+        dispatch_meta["needs_review_recovery_count"] = prior_count + 1
+        metadata["dispatch"] = dispatch_meta
+
+        # Guard against double-flip race by re-checking status in the WHERE.
+        conn.execute(
+            """
+            UPDATE task_hub_items
+            SET status = ?, seizure_state = 'unseized', metadata_json = ?, updated_at = ?
+            WHERE task_id = ? AND status = ?
+            """,
+            (
+                task_hub.TASK_STATUS_OPEN,
+                json.dumps(metadata),
+                now_iso,
+                row["task_id"],
+                task_hub.TASK_STATUS_REVIEW,
+            ),
+        )
+        recovered_ids.append(row["task_id"])
+        logger.info(
+            "needs_review SLA reaper: reopened task %s (prior_reason=%s, recovery_count=%d)",
+            row["task_id"],
+            reason,
+            prior_count + 1,
+        )
+
+    if recovered_ids:
+        conn.commit()
+
+    return {
+        "recovered": len(recovered_ids),
+        "recovered_ids": recovered_ids,
+        "skipped_gated": skipped_gated,
+        "skipped_unknown": skipped_unknown,
+        "sla_hours": effective_sla,
+    }

--- a/src/universal_agent/services/signal_curator.py
+++ b/src/universal_agent/services/signal_curator.py
@@ -32,7 +32,51 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 DEFAULT_MIN_CARDS = 10
 DEFAULT_MIN_HOURS = 12
+DEFAULT_MAX_OPEN_SIGNALS = 10
+DEFAULT_MAX_DISPATCH_QUEUE = 20
 _LAST_RUN_KEY = "signal_curator_last_run"
+
+
+def _proactive_queue_under_pressure(conn: sqlite3.Connection) -> tuple[bool, str]:
+    """Detect backpressure on the downstream task pipeline.
+
+    Returns ``(pressured, reason)``. The curator should skip its run
+    when either:
+      - Open/in-flight proactive_signal tasks exceed
+        ``UA_CURATOR_MAX_OPEN_SIGNALS`` (default: 10), or
+      - Eligible items in ``task_hub_dispatch_queue`` exceed
+        ``UA_CURATOR_MAX_DISPATCH_QUEUE`` (default: 20).
+
+    The goal is to avoid stacking new auto-promoted work onto a queue
+    that's already backed up — Simone's effective concurrency is 1.
+    """
+    max_open_signals = _parse_int_env("UA_CURATOR_MAX_OPEN_SIGNALS", DEFAULT_MAX_OPEN_SIGNALS)
+    max_dispatch_pending = _parse_int_env("UA_CURATOR_MAX_DISPATCH_QUEUE", DEFAULT_MAX_DISPATCH_QUEUE)
+
+    open_row = conn.execute(
+        """
+        SELECT COUNT(*) AS cnt FROM task_hub_items
+        WHERE source_kind = 'proactive_signal'
+          AND status IN ('open', 'in_progress', 'needs_review')
+        """,
+    ).fetchone()
+    open_count = int(open_row["cnt"]) if open_row and "cnt" in open_row.keys() else int(open_row[0] if open_row else 0)
+    if open_count > max_open_signals:
+        return True, f"open_proactive_signals={open_count}>{max_open_signals}"
+
+    try:
+        depth_row = conn.execute(
+            "SELECT COUNT(*) AS cnt FROM task_hub_dispatch_queue WHERE eligible = 1",
+        ).fetchone()
+    except sqlite3.OperationalError:
+        # Older DBs may lack the dispatch queue or the eligible column;
+        # in that case treat as no backpressure.
+        return False, ""
+    depth_count = int(depth_row["cnt"]) if depth_row and "cnt" in depth_row.keys() else int(depth_row[0] if depth_row else 0)
+    if depth_count > max_dispatch_pending:
+        return True, f"dispatch_queue_depth={depth_count}>{max_dispatch_pending}"
+
+    return False, ""
 
 
 def _parse_int_env(key: str, default: int) -> int:
@@ -73,6 +117,18 @@ def should_run_curation(conn: sqlite3.Connection) -> bool:
 
     # Never run if there are zero cards
     if pending_count == 0:
+        return False
+
+    # Backpressure: skip if the downstream queue is already saturated.
+    # Auto-curator output goes straight into Task Hub, so adding more
+    # when Simone is backed up just lengthens latency for everything.
+    pressured, pressure_reason = _proactive_queue_under_pressure(conn)
+    if pressured:
+        logger.info(
+            "Signal curator skipping run due to backpressure: %s (pending_cards=%d)",
+            pressure_reason,
+            pending_count,
+        )
         return False
 
     # Check card count threshold

--- a/tests/unit/test_needs_review_reaper.py
+++ b/tests/unit/test_needs_review_reaper.py
@@ -1,0 +1,244 @@
+"""Unit tests for needs_review_reaper.
+
+Covers the SLA recovery sweep that re-opens disposition-uncertain
+``needs_review`` tasks. Operator-gated dispositions and unknown
+dispositions must be left alone.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+import os
+import sqlite3
+from unittest import mock
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services import needs_review_reaper
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    """In-memory DB with the task_hub schema initialized."""
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    task_hub.ensure_schema(c)
+    return c
+
+
+def _insert_review_task(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    disposition_reason: str,
+    updated_at: str,
+    extra_dispatch: dict | None = None,
+) -> None:
+    """Insert a fake needs_review task with the given disposition reason."""
+    dispatch = {
+        "last_disposition": "needs_review",
+        "last_disposition_reason": disposition_reason,
+    }
+    if extra_dispatch:
+        dispatch.update(extra_dispatch)
+    metadata = {"dispatch": dispatch}
+    conn.execute(
+        """
+        INSERT INTO task_hub_items (
+            task_id, source_kind, source_ref, title, description, project_key,
+            priority, labels_json, status, metadata_json, created_at, updated_at
+        ) VALUES (?, 'proactive_signal', '', ?, '', 'proactive', 2, '[]', ?, ?, ?, ?)
+        """,
+        (
+            task_id,
+            f"test task {task_id}",
+            task_hub.TASK_STATUS_REVIEW,
+            json.dumps(metadata),
+            updated_at,
+            updated_at,
+        ),
+    )
+    conn.commit()
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 18, 18, 0, 0, tzinfo=timezone.utc)
+
+
+def _age(now: datetime, *, hours: float) -> str:
+    return (now - timedelta(hours=hours)).isoformat()
+
+
+def test_recovers_disposition_uncertain_task_past_sla(conn):
+    now = _now()
+    _insert_review_task(
+        conn,
+        task_id="t-uncertain-old",
+        disposition_reason="todo_completed_without_disposition",
+        updated_at=_age(now, hours=5),
+    )
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+
+    assert result["recovered"] == 1
+    assert result["recovered_ids"] == ["t-uncertain-old"]
+    row = conn.execute(
+        "SELECT status, metadata_json FROM task_hub_items WHERE task_id=?",
+        ("t-uncertain-old",),
+    ).fetchone()
+    assert row["status"] == task_hub.TASK_STATUS_OPEN
+    meta = json.loads(row["metadata_json"])
+    assert meta["dispatch"]["last_disposition"] == "reopened"
+    assert meta["dispatch"]["last_disposition_reason"] == "needs_review_sla_recovered"
+    assert meta["dispatch"]["needs_review_prior_reason"] == "todo_completed_without_disposition"
+    assert meta["dispatch"]["needs_review_recovery_count"] == 1
+
+
+def test_leaves_task_inside_sla_window(conn):
+    now = _now()
+    _insert_review_task(
+        conn,
+        task_id="t-fresh",
+        disposition_reason="todo_completed_without_disposition",
+        updated_at=_age(now, hours=2),  # 2h < 4h SLA
+    )
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+
+    assert result["recovered"] == 0
+    row = conn.execute(
+        "SELECT status FROM task_hub_items WHERE task_id=?",
+        ("t-fresh",),
+    ).fetchone()
+    assert row["status"] == task_hub.TASK_STATUS_REVIEW
+
+
+def test_skips_operator_gated_dispositions(conn):
+    now = _now()
+    for tid, reason in [
+        ("t-gated-1", "heartbeat_retry_exhausted"),
+        ("t-gated-2", "heartbeat_retryable_with_side_effects"),
+        ("t-gated-3", "todo_retryable_with_side_effects"),
+    ]:
+        _insert_review_task(conn, task_id=tid, disposition_reason=reason, updated_at=_age(now, hours=24))
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+
+    assert result["recovered"] == 0
+    assert result["skipped_gated"] == 3
+    for tid in ("t-gated-1", "t-gated-2", "t-gated-3"):
+        row = conn.execute(
+            "SELECT status FROM task_hub_items WHERE task_id=?", (tid,),
+        ).fetchone()
+        assert row["status"] == task_hub.TASK_STATUS_REVIEW
+
+
+def test_skips_unknown_disposition_reasons(conn):
+    """Unknown reasons might be from third-party / legacy / future code paths."""
+    now = _now()
+    _insert_review_task(
+        conn,
+        task_id="t-unknown",
+        disposition_reason="some_future_reason_we_dont_know",
+        updated_at=_age(now, hours=24),
+    )
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+
+    assert result["recovered"] == 0
+    assert result["skipped_unknown"] == 1
+
+
+def test_handles_missing_metadata_gracefully(conn):
+    """A task with no dispatch metadata should be skipped, not error."""
+    now = _now()
+    conn.execute(
+        """
+        INSERT INTO task_hub_items (
+            task_id, source_kind, source_ref, title, description, project_key,
+            priority, labels_json, status, metadata_json, created_at, updated_at
+        ) VALUES (?, 'manual', '', 'no metadata', '', 'proactive', 2, '[]', ?, '{}', ?, ?)
+        """,
+        ("t-bare", task_hub.TASK_STATUS_REVIEW, _age(now, hours=24), _age(now, hours=24)),
+    )
+    conn.commit()
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+
+    assert result["recovered"] == 0
+    # Bare metadata has no reason → falls into the "unknown" bucket, not gated.
+    assert result["skipped_unknown"] == 1
+
+
+def test_recovery_count_increments_across_runs(conn):
+    """A task that keeps falling back to needs_review should accumulate count."""
+    now = _now()
+    _insert_review_task(
+        conn,
+        task_id="t-loop",
+        disposition_reason="todo_completed_without_disposition",
+        updated_at=_age(now, hours=24),
+        extra_dispatch={"needs_review_recovery_count": 2},
+    )
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+    assert result["recovered"] == 1
+    row = conn.execute(
+        "SELECT metadata_json FROM task_hub_items WHERE task_id=?",
+        ("t-loop",),
+    ).fetchone()
+    meta = json.loads(row["metadata_json"])
+    assert meta["dispatch"]["needs_review_recovery_count"] == 3
+
+
+def test_honors_per_sweep_limit(conn):
+    now = _now()
+    for i in range(7):
+        _insert_review_task(
+            conn,
+            task_id=f"t-bulk-{i}",
+            disposition_reason="todo_completed_without_disposition",
+            updated_at=_age(now, hours=24 + i),
+        )
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now, limit=3)
+    assert result["recovered"] == 3
+    # Oldest-first ordering: bulk-6, bulk-5, bulk-4 (highest "hours" first).
+    assert result["recovered_ids"] == ["t-bulk-6", "t-bulk-5", "t-bulk-4"]
+
+
+def test_env_overrides_for_sla_and_limit(conn):
+    now = _now()
+    _insert_review_task(
+        conn,
+        task_id="t-env-1",
+        disposition_reason="todo_completed_without_disposition",
+        updated_at=_age(now, hours=1.5),  # would NOT recover at 4h SLA
+    )
+
+    with mock.patch.dict(os.environ, {"UA_NEEDS_REVIEW_SLA_HOURS": "1"}):
+        result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+    assert result["recovered"] == 1
+    assert result["sla_hours"] == 1
+
+
+def test_does_not_recover_tasks_outside_needs_review(conn):
+    """Only status=needs_review should be touched."""
+    now = _now()
+    conn.execute(
+        """
+        INSERT INTO task_hub_items (
+            task_id, source_kind, source_ref, title, description, project_key,
+            priority, labels_json, status, metadata_json, created_at, updated_at
+        ) VALUES (?, 'proactive_signal', '', 'open task', '', 'proactive', 2, '[]', 'open',
+                  '{"dispatch":{"last_disposition_reason":"todo_completed_without_disposition"}}',
+                  ?, ?)
+        """,
+        ("t-open", _age(now, hours=24), _age(now, hours=24)),
+    )
+    conn.commit()
+
+    result = needs_review_reaper.reap_stale_needs_review(conn, now=now)
+    assert result["recovered"] == 0


### PR DESCRIPTION
## Summary

Four related fixes addressing why proactive-signal tasks could sit for days in `needs_review` before completing — diagnosed during the post-mortem on the 39-hour delay on your Hermes AI Desktop App wiki (2026-05-17/18).

Root cause: `needs_review` is overloaded as both *"finished ambiguously, retry safe"* and *"operator must look before retry"* — but there was no automatic recovery for the first case. Tasks rotted.

## Changes

### 1. needs_review SLA reaper (NEW)
`services/needs_review_reaper.py`

Sweeps `needs_review` tasks past SLA and re-opens them when `dispatch.last_disposition_reason` indicates disposition uncertainty:
- `heartbeat_completed_without_disposition` → recover
- `todo_completed_without_disposition` → recover
- `heartbeat_retry_exhausted` → leave alone (operator-gated)
- `heartbeat_retryable_with_side_effects` → leave alone
- `todo_retryable_with_side_effects` → leave alone
- Unknown reasons → leave alone (forward-compat)

| Env var | Default |
|---|---|
| `UA_NEEDS_REVIEW_SLA_HOURS` | 4 |
| `UA_NEEDS_REVIEW_REAPER_LIMIT` | 20 (per sweep) |

Wired into `heartbeat_service.py` right after the existing signal_curator block. Cheap enough to run every heartbeat (single indexed SELECT + bounded UPDATEs).

Tracks `needs_review_recovery_count` in dispatch metadata so repeat-offenders can be identified later (a task that's been recovered 5+ times probably has a real bug, not a flaky disposition).

### 2. Operator-click priority boost
`proactive_signals.py:_create_followup_task`

When `actor='dashboard_user'` (the user explicitly clicked "Create Wiki" on the dashboard), force `priority=1`. Operator clicks now jump ahead of auto-promoted background tasks in the dispatch queue. Extracted into `_resolve_followup_priority` for testability.

### 3. Curator backpressure
`services/signal_curator.py:should_run_curation`

Skip auto-promotion when downstream is saturated:

| Env var | Default | Skips if |
|---|---|---|
| `UA_CURATOR_MAX_OPEN_SIGNALS` | 10 | Open/in-flight proactive_signal tasks exceed |
| `UA_CURATOR_MAX_DISPATCH_QUEUE` | 20 | Eligible items in `task_hub_dispatch_queue` exceed |

The existing 10/day budget cap was insufficient when Simone got backed up — backpressure adds queue-depth gating.

### 4. Pre-existing ruff fix (drive-by)
`proactive_signals.py` — added module-level `logger = logging.getLogger(__name__)`. Three exception handlers referenced an undefined `logger` and would crash if triggered. Pre-existing on main, not introduced by this PR; fixed here since I was editing the file anyway.

## Tests

9 new tests in `test_needs_review_reaper.py`:
- recovers disposition-uncertain task past SLA
- leaves task inside SLA window
- skips operator-gated dispositions (3 reason variants)
- skips unknown disposition reasons
- handles missing metadata gracefully
- recovery count increments across runs
- honors per-sweep limit
- env-var overrides for SLA and limit
- does not recover tasks outside needs_review

Plus existing `test_heartbeat_signal_curator.py` still passes.

```
13 passed, 1 skipped, 3559 deselected in 44.83s
```

## Followups (deferred to separate issues)

- **Dashboard visibility**: distinguish operator-clicked from auto-promoted tasks in the Proactive Signals UI, with lifecycle indicators for stuck tasks. Backend metadata is already there (`metadata.actor`, `dispatch.last_disposition_reason`, `dispatch.needs_review_recovery_count`); just needs UI surfacing.
- `cron_simone_chat_auto_complete` bootstrap waste (from PR #358 followups).
- Per-session MCP gating (from PR #358 followups).

## Test plan

- [x] 9 new reaper unit tests
- [x] Existing curator + heartbeat tests still pass
- [x] `ruff check` clean on touched files
- [x] `py_compile` on touched files
- [ ] Post-merge: confirm needs_review queue gets recovered within the 4h SLA window on production
- [ ] Post-merge: confirm operator-clicked tasks dispatch before auto-promoted on a backed-up queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)