### PR TITLE
feat(youtube-digest): bump retell target to 50% length (deeper per-video coverage)

### DIFF
--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -79,7 +79,7 @@ DIGEST_PIPELINE_DEFAULT = "map_reduce"
 DIGEST_MAP_MODEL_DEFAULT = "glm-4.5-air"
 DIGEST_MAP_CONCURRENCY_DEFAULT = 3
 DIGEST_MAP_TIMEOUT_SECONDS_DEFAULT = 180
-DIGEST_MAP_MAX_TOKENS_DEFAULT = 4000
+DIGEST_MAP_MAX_TOKENS_DEFAULT = 6000  # raised from 4000 alongside the 50% retell target — longest videos in the playlist need ~5300 tokens of headroom
 DIGEST_MAP_TRANSCRIPT_CHAR_LIMIT_DEFAULT = 50_000
 # Reduce-step model defaults. Reduce sees only titles + per-video classifications
 # + thesis lines (no full retellings), so context stays small.
@@ -193,7 +193,7 @@ Here are the videos:
 RETELL_PROMPT = """You are a technical knowledge synthesizer. You will be given the transcript and metadata for ONE YouTube video. Produce a "Compressed Retelling" that lets the reader skip watching the video while preserving its substance.
 
 REQUIREMENTS:
-- Length target: roughly 30-40% of the original transcript length. Be substantial, NOT a short summary. If the transcript is ~3000 words, your retelling should be ~900-1200 words.
+- Length target: roughly 50% of the original transcript length. Be substantial, NOT a short summary. If the transcript is ~3000 words, your retelling should be ~1500 words. Err toward more detail rather than less — preserve every concrete example, number, named tool, and "this works because" explanation.
 - Reproduce the speaker's argument in your own words, preserving the order and structure of their reasoning.
 - Preserve all specific examples, numbers, quoted phrases, library/tool names, file paths, code snippets, product names, and "this works because..." explanations. These details are what distinguish a retelling from a summary.
 - Do NOT add commentary, opinion, cross-references to other videos, or business context.


### PR DESCRIPTION
## Summary

After reviewing the SUNDAY map-reduce comparison output, operator wants more detail per video. The 30-40% length target produced strong retellings (DeepSeek V4 section preserved 1.6T params, 3.7× FLOP reduction, 90% KV cache reduction, Sinkhorn 20-iteration count, Z3 SMT solver, Putnam 120/120 score, the full 4K→16K→64K→1M curriculum) at ~738-1100 words per video. Bumping the target to 50% should add another ~25-67% detail without changing the architecture.

## Changes

- \`RETELL_PROMPT\` length target: 30-40% → 50%. Updated worked example (3000-word transcript → 1500-word retelling) and added explicit guidance to err toward more detail.
- \`DIGEST_MAP_MAX_TOKENS_DEFAULT\`: 4000 → 6000. The longest playlist videos truncate to 50k chars (~8k words); a 50% retelling of that ≈ 5,300 output tokens, just over the old cap. 6000 gives ~700 tokens of headroom. Cost is bounded — we only pay for tokens actually generated.

## What stays the same

- Default model: \`glm-4.5-air\` (haiku-tier on Z.AI)
- Default concurrency: 3
- Reduce model: \`resolve_model("opus")\` → \`glm-5.1\`
- Pipeline default: \`map_reduce\`

All overridable via the env knobs introduced in #360.

## Quality bar

The SUNDAY comparison run showed \`glm-4.5-air@conc=3\` cleanly handles 29 videos in 284s with 0 retries / 0 rate-limit hits at the 30-40% length target. The new 50% target adds ~25-67% per-call output length, which translates roughly to \`glm-4.5-air\`'s per-call latency p50 going from 19.4s → ~25-32s. Wall time should land in the 320-380s range — still well under the 900s reduce timeout and the 180s per-call map timeout.

## Concurrency-headroom decision

Operator chose not to push concurrency above 3 to avoid Z.AI Fair Usage Policy throttling (error code 1313, account-level account-wide throttle that an earlier probe confirmed hits at conc=5). The in-flight conc=5 sweep was killed mid-run to preserve quota.

## Tests

25/25 pass (no test changes — prompt + constant edits are covered by existing fixtures that mock the LLM at the boundary).

## Test plan

- [ ] Tomorrow's 6 AM Central cron fires with map_reduce + 50% retell prompt and emails the digest to \`kevinjdragan@gmail.com\`
- [ ] If desired, manually run \`youtube_digest_compare.py\` against the SUNDAY pocket at 50% to spot-check depth gain vs the merged 30-40% baseline