### PR TITLE
docs(tutorial-pipeline): correct Telegram notifier references — code-verified

### DIFF
--- a/docs/03_Operations/99_Tutorial_Pipeline_Architecture_And_Operations.md
+++ b/docs/03_Operations/99_Tutorial_Pipeline_Architecture_And_Operations.md
@@ -24,7 +24,7 @@ Playlist Watch → New Video Detection → Webhook Dispatch → Agent Session
 | Hooks Service | `hooks_service.py` | Receives webhook events, manages dispatch queue, throttling, retry policies |
 | Gateway Server | `gateway_server.py` | Notification system, tutorial dashboard API, persistence |
 | YouTube Ingestion | `youtube_ingest.py` | Fetches transcripts via rotating residential proxy (Webshare or DataImpulse, selected by `PROXY_PROVIDER`) |
-| Telegram Notifier | `services/tutorial_telegram_notifier.py` | Per-video dedup Telegram alerts for tutorial events |
+| Telegram Notifier | `services/notification_dispatcher.py` + `services/telegram_send.py` | Generic out-of-band Telegram delivery; per-video dedup is upstream via `_add_notification()` video-level upsert in `gateway_server.py` |
 | Dashboard (Tutorials) | `web-ui/app/dashboard/tutorials/page.tsx` | Tutorial runs, review jobs, bootstrap jobs, notifications with client-side dedup |
 | Dashboard (Main) | `web-ui/app/dashboard/page.tsx` | Notification panel with video-level dedup |
 
@@ -240,9 +240,13 @@ The `visibleNotifications` memo in the dashboard page applies a post-filter dedu
 
 The tutorials tab has its own `visibleNotifications` memo that uses `notificationEntityKey()` to group by video and keeps only the latest notification per entity.
 
-### 3.4 Telegram — Per-Video Cooldown (`tutorial_telegram_notifier.py`)
+### 3.4 Telegram delivery — generic dispatcher + upstream upsert dedup
 
-`TutorialTelegramNotifier.maybe_send()` implements per-video dedup for `youtube_tutorial_ready` and `youtube_playlist_new_video` kinds using a TTL cache, preventing duplicate Telegram messages within a cooldown window.
+Telegram messages for `youtube_tutorial_ready` and `youtube_playlist_new_video` notifications are sent by the generic `NotificationDispatcher` (`services/notification_dispatcher.py`), not a tutorial-specific notifier. The dispatcher polls the `notifications` table for undelivered high-severity rows on a fixed interval (`UA_NOTIFICATION_DISPATCHER_INTERVAL_SECONDS`, default 30s) and delivers each row via `telegram_send_async` from `services/telegram_send.py`.
+
+Per-video dedup is **upstream** of the dispatcher, not inside it. `_add_notification()` in `gateway_server.py` upserts using `notificationEntityKey()` so that as a single `video_id` progresses through pipeline stages (`new_video` → `started` → `progress` → `ready`), only the latest notification per video sits in the undelivered queue. The dispatcher's `UA_NOTIFICATION_DISPATCHER_COOLDOWN_SECONDS` (default 300s) is a global flap-protection floor, not a per-video TTL.
+
+Test coverage: `tests/unit/test_tutorial_notification_dedup.py` exercises the video-level upsert path in `_add_notification()`.
 
 ---
 
@@ -408,11 +412,11 @@ Optional video/vision analysis in `youtube-tutorial-creation` is gated to `conce
 | `tests/unit/test_youtube_daily_digest_email_failures.py` | Email delivery → processed-videos DB write gating (success path, failure path, no-email mode). |
 | `src/universal_agent/scripts/vp_coder_workspace_pruner.py` | Weekly archive of stale VP-coder workspace subdirectories (7-day default retention) |
 | `src/universal_agent/services/youtube_playlist_watcher.py` | Playlist polling |
-| `src/universal_agent/services/tutorial_telegram_notifier.py` | Telegram notification sink with per-video dedup |
+| `src/universal_agent/services/notification_dispatcher.py` | Generic out-of-band notification dispatcher (Telegram + email) for undelivered high-severity rows; polls every `UA_NOTIFICATION_DISPATCHER_INTERVAL_SECONDS` (default 30s) |
+| `src/universal_agent/services/telegram_send.py` | Low-level Telegram send utility with retry policy, rate-limit awareness, structured logging |
 | `web-ui/app/dashboard/page.tsx` | Main dashboard with notification dedup |
 | `web-ui/app/dashboard/tutorials/page.tsx` | Tutorials tab with entity-level dedup |
 | `tests/unit/test_tutorial_notification_dedup.py` | Backend video-level dedup tests |
-| `tests/unit/test_tutorial_telegram_dedup.py` | Telegram notifier dedup tests |
 | `scripts/check_proxy.py` | Provider-agnostic proxy connectivity diagnostic (TCP, HTTP, HTTPS, YouTube) |
 | `scripts/purge_youtube_backlog.py` | Operational script: reset playlist watcher state, finalize stale runs, purge pending signal cards |
 | `.claude/skills/youtube-tutorial-creation/scripts/extract_description_links.py` | LLM-judged URL classification and content extraction from video descriptions |


### PR DESCRIPTION
## Summary

Surfaced during the canvas tutorial-pipeline refresh (PR #365): the canonical doc \`docs/03_Operations/99_Tutorial_Pipeline_Architecture_And_Operations.md\` referenced \`services/tutorial_telegram_notifier.py\` in three places + \`tests/unit/test_tutorial_telegram_dedup.py\` in one. Neither file exists in the codebase. The doc described a \`TutorialTelegramNotifier.maybe_send()\` class with TTL cache — also doesn't exist.

This PR replaces the bogus references with what's actually in the code, verified by reading the gateway and notification-dispatcher modules.

## What the code actually does (code-verified)

- **Delivery**: Telegram messages for tutorial notification kinds use the **generic** \`NotificationDispatcher\` (\`services/notification_dispatcher.py\`), set up at gateway boot around \`gateway_server.py:14800\`. Same path used for email and any other high-severity row.
- **Low-level send**: \`services/telegram_send.py\` (\`telegram_send_async\` / \`telegram_send_sync\`).
- **Per-video dedup** lives **upstream** of the dispatcher in \`_add_notification()\` (\`gateway_server.py\`) via \`notificationEntityKey()\` video-level upsert. Only the latest stage notification per \`video_id\` is ever in the undelivered queue. No TTL cache, no per-video cooldown class.
- **Dispatcher cooldown**: \`UA_NOTIFICATION_DISPATCHER_COOLDOWN_SECONDS\` (default 300s) is a global flap-protection floor, not per-video.
- **Real test coverage**: \`tests/unit/test_tutorial_notification_dedup.py\` (already in §8 as "Backend video-level dedup tests").

## Edits

1. **§1 Key Components table** — "Telegram Notifier" row: file ref + description corrected.
2. **§3.4 Telegram subsection** — title + body rewritten to describe the real two-layer mechanism (upstream upsert + generic dispatcher) with accurate env-var knobs.
3. **§8 Key Source Files table** — removed the two bogus rows, added two real rows for \`notification_dispatcher.py\` and \`telegram_send.py\`.

## Verification

\`grep -nE "tutorial_telegram_notifier|tutorial_telegram_dedup|TutorialTelegramNotifier" docs/03_Operations/99_Tutorial_Pipeline_Architecture_And_Operations.md\` returns no matches.

## Followup observation (out of scope here)

The Last-updated header line of the doc (line 6) describes substantive functional updates with PR refs (#356/#357/#360/#361/#363). The bogus Telegram-notifier references were not introduced by those PRs — they're older inaccuracies. No-op for this PR; mentioning only for context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)