### PR TITLE
feat(csi): swap batch_brief LLM Gemini→Z.AI + startup guard for missing emitter creds

### DIFF
--- a/CSI_Ingester/development/csi_ingester/batch_brief.py
+++ b/CSI_Ingester/development/csi_ingester/batch_brief.py
@@ -18,10 +18,10 @@ from csi_ingester.store import events as event_store
 
 logger = logging.getLogger(__name__)
 
-# ── Gemini Flash summarisation ───────────────────────────────────────────
+# ── Z.AI summarisation (haiku-tier glm-4.5-air via Anthropic-compatible API) ─
 
-_GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
-_DEFAULT_MODEL = "gemini-3-flash-preview"
+_ZAI_BASE = "https://api.z.ai/api/anthropic"
+_DEFAULT_MODEL = "glm-4.5-air"
 
 _SYSTEM_PROMPT = """\
 You are a concise trend analyst.  Given a batch of creator-signal events
@@ -51,24 +51,43 @@ def _build_prompt(rows: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
-async def _call_gemini(api_key: str, prompt: str, *, model: str = _DEFAULT_MODEL, timeout: int = 60) -> str:
-    """Call Gemini Flash and return the generated text."""
-    payload = {
-        "system_instruction": {"parts": [{"text": _SYSTEM_PROMPT}]},
-        "contents": [{"role": "user", "parts": [{"text": prompt}]}],
-        "generationConfig": {"temperature": 0.3, "maxOutputTokens": 2048},
+async def _call_zai(api_key: str, prompt: str, *, model: str = _DEFAULT_MODEL, timeout: int = 60) -> str:
+    """Call Z.AI's Anthropic-compatible chat API and return the generated text.
+
+    Default model is ``glm-4.5-air`` (haiku-tier). The lane is known to be
+    occasionally flaky (~6 min hangs documented in
+    ``src/universal_agent/utils/model_resolution.py``), so the timeout is
+    bounded and the caller falls back to ``_fallback_brief`` on any failure.
+    """
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
     }
-    url = f"{_GEMINI_BASE}/{model}:generateContent?key={api_key}"
+    payload = {
+        "model": model,
+        "max_tokens": 2048,
+        "temperature": 0.3,
+        "system": _SYSTEM_PROMPT,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    url = f"{_ZAI_BASE}/v1/messages"
     async with httpx.AsyncClient(timeout=timeout) as client:
-        resp = await client.post(url, json=payload)
+        resp = await client.post(url, headers=headers, json=payload)
         resp.raise_for_status()
         body = resp.json()
-    # Extract text from Gemini response
-    candidates = body.get("candidates", [])
-    if not candidates:
-        raise ValueError("Gemini returned no candidates")
-    parts = candidates[0].get("content", {}).get("parts", [])
-    return "".join(p.get("text", "") for p in parts).strip()
+    content_blocks = body.get("content") or []
+    if not content_blocks:
+        raise ValueError("Z.AI returned no content blocks")
+    text_parts = [
+        str(block.get("text") or "")
+        for block in content_blocks
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    text = "".join(text_parts).strip()
+    if not text:
+        raise ValueError("Z.AI returned empty text")
+    return text
 
 
 def _fallback_brief(rows: list[dict[str, Any]]) -> str:
@@ -158,20 +177,20 @@ async def run_batch_cycle(
     event_ids = [r["event_id"] for r in rows]
 
     # ── Generate Markdown brief ──
-    gemini_key = config.gemini_api_key
+    zai_key = config.zai_api_key
     prompt = _build_prompt(rows)
     brief_md: str
     llm_used = False
 
-    if gemini_key:
+    if zai_key:
         try:
-            brief_md = await _call_gemini(gemini_key, prompt, model=config.gemini_model)
+            brief_md = await _call_zai(zai_key, prompt, model=config.zai_model)
             llm_used = True
         except Exception as exc:
-            logger.warning("Gemini batch brief failed, using fallback: %s", exc)
+            logger.warning("Z.AI batch brief failed, using fallback: %s", exc)
             brief_md = _fallback_brief(rows)
     else:
-        logger.info("No Gemini API key configured; using plain-text batch brief")
+        logger.info("No Z.AI API key configured; using plain-text batch brief")
         brief_md = _fallback_brief(rows)
 
     # Extract headline from brief — find first heading with real content

--- a/CSI_Ingester/development/csi_ingester/config.py
+++ b/CSI_Ingester/development/csi_ingester/config.py
@@ -107,25 +107,31 @@ class CSIConfig:
         return 3
 
     @property
-    def gemini_api_key(self) -> str:
-        return (os.getenv("CSI_GEMINI_API_KEY") or os.getenv("GEMINI_API_KEY") or "").strip()
+    def zai_api_key(self) -> str:
+        """Z.AI API key for batch_brief summarisation.
+
+        Resolution order: ``CSI_ZAI_API_KEY`` → ``ZAI_API_KEY``. Empty means
+        skip LLM and use the plain-text fallback brief.
+        """
+        return (os.getenv("CSI_ZAI_API_KEY") or os.getenv("ZAI_API_KEY") or "").strip()
 
     @property
-    def gemini_model(self) -> str:
-        """Gemini model for batch briefs.
+    def zai_model(self) -> str:
+        """Z.AI model for batch briefs.
 
-        Default: gemini-3-flash-preview
-        Low-cost alternative: gemini-3.1-flash-lite-preview (set via CSI_GEMINI_MODEL)
+        Default: ``glm-4.5-air`` (haiku-tier, fast/cheap). Lane is occasionally
+        flaky; ``batch_brief.run_batch_cycle`` falls back to plain-text on
+        failure so a hang here doesn't block delivery.
         """
-        env = (os.getenv("CSI_GEMINI_MODEL") or "").strip()
+        env = (os.getenv("CSI_ZAI_MODEL") or "").strip()
         if env:
             return env
         raw_delivery = self.raw.get("delivery", {})
         if isinstance(raw_delivery, dict):
-            val = raw_delivery.get("gemini_model")
+            val = raw_delivery.get("zai_model")
             if val:
                 return str(val).strip()
-        return "gemini-3-flash-preview"
+        return "glm-4.5-air"
 
 
 def load_config(config_path: str | None = None) -> CSIConfig:

--- a/CSI_Ingester/development/csi_ingester/service.py
+++ b/CSI_Ingester/development/csi_ingester/service.py
@@ -118,6 +118,23 @@ class CSIService:
         if endpoint and secret:
             self.emitter = UAEmitter(endpoint=endpoint, shared_secret=secret, instance_id=self.config.instance_id)
         else:
+            # Startup guard — previously the absence of these two values caused
+            # batch_brief to silently no-op for ~65 days (2026-03-15 cleanup
+            # commit removed the legacy per-event emission path without ensuring
+            # the new aggregator could actually reach UA Gateway). Log loudly so
+            # an operator notices on next deploy / restart.
+            missing = []
+            if not endpoint:
+                missing.append("CSI_UA_ENDPOINT")
+            if not secret:
+                missing.append("CSI_UA_SHARED_SECRET")
+            logger.critical(
+                "CSI emitter NOT configured — batch_brief will skip emission. "
+                "Missing env vars: %s. Events will pile up at delivered=0 until "
+                "this is fixed. Set values in /opt/universal_agent/CSI_Ingester/"
+                "development/deployment/systemd/csi-ingester.env then restart.",
+                ", ".join(missing),
+            )
             self.emitter = None
 
     def _poll_interval_for_adapter(self, name: str) -> float:

--- a/CSI_Ingester/development/tests/unit/test_batch_brief.py
+++ b/CSI_Ingester/development/tests/unit/test_batch_brief.py
@@ -118,8 +118,8 @@ class TestRunBatchCycle:
         _insert_event(conn, "e1")  # Only 1 event, threshold is 3
         config = MagicMock()
         config.batch_min_events = 3
-        config.gemini_api_key = ""
-        config.gemini_model = "gemini-3-flash-preview"
+        config.zai_api_key = ""
+        config.zai_model = "glm-4.5-air"
         config.batch_interval_seconds = 7200
 
         result = await run_batch_cycle(conn=conn, config=config, emitter=None)
@@ -133,8 +133,8 @@ class TestRunBatchCycle:
             _insert_event(conn, f"e{i}", title=f"Video {i}", source="youtube_channel_rss")
         config = MagicMock()
         config.batch_min_events = 3
-        config.gemini_api_key = ""
-        config.gemini_model = "gemini-3-flash-preview"
+        config.zai_api_key = ""
+        config.zai_model = "glm-4.5-air"
         config.batch_interval_seconds = 7200
 
         result = await run_batch_cycle(conn=conn, config=config, emitter=None)
@@ -148,26 +148,26 @@ class TestRunBatchCycle:
         assert len(remaining) == 0
 
     @pytest.mark.asyncio
-    async def test_calls_gemini_when_key_set(self, conn: sqlite3.Connection) -> None:
+    async def test_calls_zai_when_key_set(self, conn: sqlite3.Connection) -> None:
         for i in range(3):
             _insert_event(conn, f"e{i}", title=f"V{i}")
         config = MagicMock()
         config.batch_min_events = 3
-        config.gemini_api_key = "fake-key"
-        config.gemini_model = "gemini-3-flash-preview"
+        config.zai_api_key = "fake-key"
+        config.zai_model = "glm-4.5-air"
         config.batch_interval_seconds = 7200
 
-        with patch("csi_ingester.batch_brief._call_gemini", new_callable=AsyncMock) as mock_gemini:
-            mock_gemini.return_value = "# AI Trends Digest\n\nThree new signals detected."
+        with patch("csi_ingester.batch_brief._call_zai", new_callable=AsyncMock) as mock_zai:
+            mock_zai.return_value = "# AI Trends Digest\n\nThree new signals detected."
             result = await run_batch_cycle(conn=conn, config=config, emitter=None)
 
         assert result["status"] == "generated"
         assert result["llm_used"] is True
         assert result["brief_headline"] == "AI Trends Digest"
-        mock_gemini.assert_called_once()
+        mock_zai.assert_called_once()
         # Check model was passed
-        call_kwargs = mock_gemini.call_args
-        assert call_kwargs.kwargs["model"] == "gemini-3-flash-preview"
+        call_kwargs = mock_zai.call_args
+        assert call_kwargs.kwargs["model"] == "glm-4.5-air"
 
     @pytest.mark.asyncio
     async def test_fallback_on_llm_failure(self, conn: sqlite3.Connection) -> None:
@@ -175,12 +175,12 @@ class TestRunBatchCycle:
             _insert_event(conn, f"e{i}", title=f"V{i}")
         config = MagicMock()
         config.batch_min_events = 3
-        config.gemini_api_key = "fake-key"
-        config.gemini_model = "gemini-3-flash-preview"
+        config.zai_api_key = "fake-key"
+        config.zai_model = "glm-4.5-air"
         config.batch_interval_seconds = 7200
 
-        with patch("csi_ingester.batch_brief._call_gemini", new_callable=AsyncMock) as mock_gemini:
-            mock_gemini.side_effect = Exception("API error")
+        with patch("csi_ingester.batch_brief._call_zai", new_callable=AsyncMock) as mock_zai:
+            mock_zai.side_effect = Exception("API error")
             result = await run_batch_cycle(conn=conn, config=config, emitter=None)
 
         assert result["status"] == "generated"
@@ -193,8 +193,8 @@ class TestRunBatchCycle:
             _insert_event(conn, f"e{i}", title=f"V{i}")
         config = MagicMock()
         config.batch_min_events = 3
-        config.gemini_api_key = ""
-        config.gemini_model = "gemini-3-flash-preview"
+        config.zai_api_key = ""
+        config.zai_model = "glm-4.5-air"
         config.batch_interval_seconds = 7200
 
         emitter = MagicMock()
@@ -207,20 +207,20 @@ class TestRunBatchCycle:
         emitter.emit_with_retries.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_uses_lite_model(self, conn: sqlite3.Connection) -> None:
-        """Test that an alternative model like gemini-3.1-flash-lite-preview is passed."""
+    async def test_uses_alt_zai_model(self, conn: sqlite3.Connection) -> None:
+        """Test that an alternative Z.AI model (e.g. glm-5-turbo) is passed through."""
         for i in range(3):
             _insert_event(conn, f"e{i}", title=f"V{i}")
         config = MagicMock()
         config.batch_min_events = 3
-        config.gemini_api_key = "fake-key"
-        config.gemini_model = "gemini-3.1-flash-lite-preview"
+        config.zai_api_key = "fake-key"
+        config.zai_model = "glm-5-turbo"
         config.batch_interval_seconds = 7200
 
-        with patch("csi_ingester.batch_brief._call_gemini", new_callable=AsyncMock) as mock_gemini:
-            mock_gemini.return_value = "# Lite Brief\n\nQuick summary."
+        with patch("csi_ingester.batch_brief._call_zai", new_callable=AsyncMock) as mock_zai:
+            mock_zai.return_value = "# Alt Brief\n\nQuick summary."
             result = await run_batch_cycle(conn=conn, config=config, emitter=None)
 
-        call_kwargs = mock_gemini.call_args
-        assert call_kwargs.kwargs["model"] == "gemini-3.1-flash-lite-preview"
+        call_kwargs = mock_zai.call_args
+        assert call_kwargs.kwargs["model"] == "glm-5-turbo"
         assert result["llm_used"] is True


### PR DESCRIPTION
## Summary

Two related changes addressing the 65-day silent regression where CSI's `batch_brief` stopped emitting on 2026-03-15.

**Context:** A separate operational hot-fix tonight restored the missing `csi-ingester.env` file (containing `CSI_UA_ENDPOINT` + `CSI_UA_SHARED_SECRET` + `CSI_INSTANCE_ID=csi-vps-01`), which unblocked `batch_brief` emission. Verified end-to-end: 500 events drained in one cycle, `delivered=True, status_code=200`. While verifying, two more issues surfaced — addressed here.

## Changes

### 1. `batch_brief.py` — Gemini→Z.AI LLM swap

Default Gemini model `gemini-3-flash-preview` returns 403 from Google's API (invalid/unavailable for our key). Plain-text fallback emits OK but is operator-unfriendly. Swapping to Z.AI per operator request.

- Replace `_call_gemini` with `_call_zai`. Uses Z.AI's Anthropic-compatible API at `https://api.z.ai/api/anthropic/v1/messages`.
- Default model: `glm-4.5-air` (haiku-tier per the YouTube Tutorial Pipeline doc).
- Lane is known to be occasionally flaky (~6 min hangs documented in `src/universal_agent/utils/model_resolution.py`), but for `batch_brief` this is acceptable: **single async call every 2h with 60s timeout + `_fallback_brief` safety net**. If `glm-4.5-air` hangs, plain-text fallback brief still emits.
- Alternative model via `CSI_ZAI_MODEL` (e.g. `glm-5-turbo` for higher stability).

### 2. `config.py` — `zai_api_key` / `zai_model` properties

- `zai_api_key`: resolves `CSI_ZAI_API_KEY` → `ZAI_API_KEY`
- `zai_model`: resolves `CSI_ZAI_MODEL` env → `delivery.zai_model` YAML → default `glm-4.5-air`
- Old `gemini_api_key` / `gemini_model` properties removed.

### 3. `service.py` — startup guard (the real fix for the regression class)

`_build_emitter` previously set `self.emitter = None` silently when `CSI_UA_ENDPOINT` or `CSI_UA_SHARED_SECRET` was missing. **This silent fallback is what hid the 65-day outage.** Now logs CRITICAL with exact missing var names + path to the env file. Operator gets a loud alarm at deploy/restart time instead of 65 days later.

### 4. Tests

13 tests in `test_batch_brief.py`, all pass. Mock target swapped from `_call_gemini` to `_call_zai`.

## End-to-end recovery chain (combined with the env-file hot-fix)

1. CSI scheduler fires batch_brief every 2h
2. Z.AI summarises (or falls back to plain text)
3. Brief emits to UA Gateway with valid secret + allowed `instance_id=csi-vps-01`
4. Source events get marked `delivered=1`
5. `csi_rss_semantic_enrich` (every 4h) picks them up, fetches transcripts
6. Proactive signal cards regenerate with `transcript_status="ok"`
7. Operator `Create Wiki` clicks find real transcripts — no more `notebooklm-mcp` hangs

## Test plan

- [x] `pytest tests/unit/test_batch_brief.py` — 13 passed
- [x] `ruff check` on all touched files — clean
- [x] `py_compile` — clean
- [ ] Post-merge: confirm next scheduled `batch_brief` tick (≤2h) produces a Z.AI-summarised digest in csi-ingester logs
- [ ] Post-merge: kill `CSI_UA_ENDPOINT` in env temporarily and verify CRITICAL log fires

## Followups (separate PRs / operator actions)

- **Rotate `GEMINI_API_KEY`** — key leaked in chat transcript via httpx error URL during diagnosis (security finding).
- **`httpx` logger redaction** — bot tokens/API keys appear in URL paths in journal logs (separate hygiene PR).
- **`csi_simone_chat_auto_complete` bootstrap waste** — pending from PR #358 followups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)