### PR TITLE
feat(watchdog): run every heartbeat tick + email on new critical findings

### DIFF
--- a/src/universal_agent/heartbeat_service.py
+++ b/src/universal_agent/heartbeat_service.py
@@ -2478,6 +2478,58 @@ class HeartbeatService:
                 },
             )
 
+            # Proactive health pre-flight — runs every tick regardless of
+            # skip-mode so the watchdog can't be silenced by an empty Task Hub.
+            # Best-effort: errors are logged but never block the heartbeat.
+            try:
+                from universal_agent import gateway_server as _gs
+                from universal_agent.services.proactive_health import (
+                    build_proactive_health_payload,
+                )
+                from universal_agent.services.proactive_health_notifier import (
+                    run_pre_flight_check,
+                )
+
+                def _build_payload():
+                    activity_path = get_activity_db_path()
+                    activity_conn = connect_runtime_db(activity_path)
+                    activity_conn.row_factory = sqlite3.Row  # type: ignore[attr-defined]
+                    try:
+                        cron_jobs = (
+                            list(_gs._cron_service.list_jobs())
+                            if getattr(_gs, "_cron_service", None)
+                            else []
+                        )
+                        csi_db_path = None
+                        if hasattr(_gs, "_csi_default_db_path"):
+                            try:
+                                csi_db_path = _gs._csi_default_db_path()
+                            except Exception:  # noqa: BLE001
+                                csi_db_path = None
+                        return build_proactive_health_payload(
+                            activity_conn=activity_conn,
+                            cron_jobs=cron_jobs,
+                            csi_db_path=csi_db_path,
+                        )
+                    finally:
+                        try:
+                            activity_conn.close()
+                        except Exception:  # noqa: BLE001
+                            pass
+
+                await run_pre_flight_check(
+                    workspace_dir=Path(str(session.workspace_dir)),
+                    payload_builder=_build_payload,
+                    agentmail_service=getattr(_gs, "_agentmail_service", None),
+                    notifications_list=getattr(_gs, "_notifications", None),
+                    add_notification_fn=getattr(_gs, "_add_notification", None),
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Heartbeat proactive-health pre-flight failed (non-fatal)",
+                    exc_info=True,
+                )
+
             if should_skip_agent_run:
                 full_response = schedule.ok_tokens[0] if schedule.ok_tokens else DEFAULT_OK_TOKENS[0]
                 logger.info(

--- a/src/universal_agent/services/proactive_health_notifier.py
+++ b/src/universal_agent/services/proactive_health_notifier.py
@@ -1,0 +1,259 @@
+"""Heartbeat pre-flight that always runs the proactive watchdog.
+
+Background: the prior wiring lived in `memory/HEARTBEAT.md` as a directive for
+Simone to call `GET /api/v1/ops/proactive_health` each cycle. That directive
+sits inside the agent prompt, so it never runs when the heartbeat takes the
+skip-mode or quick-heartbeat short-circuit. Two consequences:
+
+1. The endpoint exists and works, but Simone never called it in production.
+2. Even if she had, the directive only wrote findings to a JSON file — it
+   never emailed Kevin.
+
+This module fixes both. It runs as code, not as an agent directive, so it
+fires every tick regardless of skip-mode. For critical invariants it sends
+Kevin one email per finding_id with a 6h cooldown so a stuck pipeline
+doesn't spam the inbox.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import logging
+import os
+from pathlib import Path
+import time
+from typing import Any, Awaitable, Callable, Iterable, Optional, Protocol
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COOLDOWN_SECONDS = 21600  # 6h
+KEVIN_EMAIL = "kevinjdragan@gmail.com"
+NOTIFICATION_KIND_PREFIX = "proactive_health_critical"
+
+
+def _truthy(value: Optional[str], default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _enabled() -> bool:
+    return _truthy(os.getenv("UA_HEARTBEAT_PROACTIVE_HEALTH_ENABLED"), True)
+
+
+def _email_enabled() -> bool:
+    return _truthy(os.getenv("UA_HEARTBEAT_PROACTIVE_HEALTH_EMAIL_CRITICAL"), True)
+
+
+def _cooldown_seconds() -> int:
+    raw = os.getenv("UA_HEARTBEAT_PROACTIVE_HEALTH_COOLDOWN_SECONDS")
+    if not raw:
+        return DEFAULT_COOLDOWN_SECONDS
+    try:
+        return max(60, int(raw))
+    except ValueError:
+        return DEFAULT_COOLDOWN_SECONDS
+
+
+class _AgentMailLike(Protocol):
+    async def send_email(
+        self, *, to: str, subject: str, text: str, force_send: bool = False, **kwargs: Any
+    ) -> dict[str, Any]: ...
+
+
+def _parse_iso_timestamp(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    s = str(value).strip()
+    if not s:
+        return None
+    try:
+        # tolerate Z suffix
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+    except (ValueError, AttributeError):
+        return None
+
+
+def _within_cooldown(
+    *,
+    kind: str,
+    cooldown_seconds: int,
+    notifications_list: Iterable[dict[str, Any]],
+) -> bool:
+    """Return True if a notification of this kind was emitted within the cooldown.
+
+    Walks the in-memory _notifications cache (the same one populated by
+    gateway_server._add_notification). Treats either `updated_at` or
+    `created_at` as the recency marker.
+    """
+    now = time.time()
+    for n in notifications_list or ():
+        if str(n.get("kind") or "") != kind:
+            continue
+        ts = _parse_iso_timestamp(n.get("updated_at") or n.get("created_at"))
+        if ts is None:
+            continue
+        if now - ts < cooldown_seconds:
+            return True
+    return False
+
+
+def _write_sidecar(workspace_dir: Path, payload: dict[str, Any]) -> None:
+    out_dir = workspace_dir / "work_products"
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_dir.joinpath("proactive_health_latest.json").write_text(
+            json.dumps(payload, indent=2, default=str)
+        )
+    except Exception:  # noqa: BLE001 — best-effort artifact write
+        logger.warning("proactive_health: sidecar write failed", exc_info=True)
+
+
+def _critical_invariants(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        f
+        for f in (payload.get("invariants") or [])
+        if str(f.get("severity") or "").lower() == "critical"
+    ]
+
+
+def _format_email(finding: dict[str, Any], payload_generated_at: str) -> tuple[str, str]:
+    title = finding.get("title") or "Proactive health finding"
+    metric_key = finding.get("metric_key") or "?"
+    recommendation = finding.get("recommendation") or ""
+    runbook = finding.get("runbook_command") or "(no runbook provided)"
+    observed = finding.get("observed_value")
+    observed_str = json.dumps(observed, indent=2, default=str) if observed is not None else "(none)"
+
+    subject = f"[Proactive Health CRITICAL] {title}"
+    text = (
+        f"Critical proactive_health invariant fired.\n"
+        f"\n"
+        f"metric_key: {metric_key}\n"
+        f"generated_at: {payload_generated_at}\n"
+        f"\n"
+        f"What's wrong:\n"
+        f"  {recommendation}\n"
+        f"\n"
+        f"Observed:\n"
+        f"{observed_str}\n"
+        f"\n"
+        f"Runbook (run this on the VPS to investigate):\n"
+        f"  {runbook}\n"
+        f"\n"
+        f"You will not be re-notified about this same finding for "
+        f"{_cooldown_seconds() // 3600}h. To force a fresh alert, run:\n"
+        f"  curl -X POST -H \"Authorization: Bearer $UA_OPS_TOKEN\" "
+        f"http://127.0.0.1:8002/api/v1/ops/proactive_health\n"
+        f"\n"
+        f"— Proactive Health Watchdog\n"
+    )
+    return subject, text
+
+
+async def _notify_critical(
+    *,
+    finding: dict[str, Any],
+    payload_generated_at: str,
+    agentmail_service: _AgentMailLike,
+    notifications_list: list[dict[str, Any]],
+    add_notification_fn: Callable[..., dict[str, Any]],
+    cooldown_seconds: int,
+) -> bool:
+    finding_id = str(finding.get("finding_id") or finding.get("metric_key") or "unknown")
+    kind = f"{NOTIFICATION_KIND_PREFIX}:{finding_id}"
+
+    if _within_cooldown(
+        kind=kind,
+        cooldown_seconds=cooldown_seconds,
+        notifications_list=notifications_list,
+    ):
+        logger.debug("proactive_health: suppressed (within %ds cooldown): %s", cooldown_seconds, kind)
+        return False
+
+    subject, text = _format_email(finding, payload_generated_at)
+    try:
+        await agentmail_service.send_email(
+            to=KEVIN_EMAIL,
+            subject=subject,
+            text=text,
+            force_send=True,
+        )
+    except Exception:  # noqa: BLE001 — never crash the heartbeat over a send failure
+        logger.warning("proactive_health: send_email failed for %s", finding_id, exc_info=True)
+        return False
+
+    # Record for dedup tracking.
+    try:
+        add_notification_fn(
+            kind=kind,
+            title=finding.get("title") or "Proactive health finding",
+            message=finding.get("recommendation") or "",
+            summary=f"Critical proactive health finding emailed: {finding_id}",
+            severity="critical",
+            requires_action=True,
+            metadata={
+                "finding_id": finding_id,
+                "metric_key": finding.get("metric_key"),
+                "runbook_command": finding.get("runbook_command"),
+                "category": finding.get("category"),
+            },
+        )
+    except Exception:  # noqa: BLE001
+        logger.warning("proactive_health: failed to record dedup notification", exc_info=True)
+    return True
+
+
+async def run_pre_flight_check(
+    *,
+    workspace_dir: Path,
+    payload_builder: Callable[[], dict[str, Any]],
+    agentmail_service: Optional[_AgentMailLike],
+    notifications_list: Optional[list[dict[str, Any]]],
+    add_notification_fn: Optional[Callable[..., dict[str, Any]]],
+) -> dict[str, Any]:
+    """Run the proactive watchdog as a pre-flight before any agent invocation.
+
+    Always-on side of the heartbeat. Caller passes a `payload_builder` thunk
+    that invokes `build_proactive_health_payload(...)` with whatever DB / cron
+    state is locally available — this keeps the notifier free of import-time
+    coupling to gateway_server.
+
+    Returns the payload dict (with possibly an `error` field) so the caller
+    can log it. Never raises.
+    """
+    if not _enabled():
+        return {"status": "disabled"}
+
+    try:
+        payload = payload_builder()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("proactive_health: payload builder failed", exc_info=True)
+        return {"error": f"payload_builder_failed: {type(exc).__name__}: {exc}"}
+
+    _write_sidecar(workspace_dir, payload)
+
+    if not _email_enabled() or agentmail_service is None or add_notification_fn is None:
+        return payload
+
+    cooldown = _cooldown_seconds()
+    generated_at = str(payload.get("generated_at_utc") or datetime.now(timezone.utc).isoformat())
+    notifications = notifications_list if notifications_list is not None else []
+
+    sent_count = 0
+    for finding in _critical_invariants(payload):
+        sent = await _notify_critical(
+            finding=finding,
+            payload_generated_at=generated_at,
+            agentmail_service=agentmail_service,
+            notifications_list=notifications,
+            add_notification_fn=add_notification_fn,
+            cooldown_seconds=cooldown,
+        )
+        if sent:
+            sent_count += 1
+
+    if sent_count:
+        logger.info("proactive_health: emailed %d new critical finding(s)", sent_count)
+    return payload

--- a/tests/unit/test_proactive_health_notifier.py
+++ b/tests/unit/test_proactive_health_notifier.py
@@ -1,0 +1,363 @@
+"""Unit tests for the proactive health pre-flight notifier.
+
+Locks the behavior described in the 2026-05-18 incident analysis:
+the watchdog must run every heartbeat tick (no skip-mode dependency), email
+Kevin on new critical findings, and dedup repeats within a 6h cooldown so a
+stuck pipeline doesn't spam his inbox.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import time
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from universal_agent.services import proactive_health_notifier as notifier
+from universal_agent.services.proactive_health_notifier import (
+    DEFAULT_COOLDOWN_SECONDS,
+    KEVIN_EMAIL,
+    NOTIFICATION_KIND_PREFIX,
+    _within_cooldown,
+    run_pre_flight_check,
+)
+
+
+def _critical_payload(finding_id: str = "youtube_enrichment_coverage") -> dict:
+    return {
+        "overall_status": "critical",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "crons": [],
+        "stale_tasks": {"count": 0, "samples": []},
+        "parked_tasks": {"count": 0, "samples": []},
+        "invariants": [
+            {
+                "finding_id": f"invariant:{finding_id}",
+                "category": "proactive_health",
+                "severity": "critical",
+                "metric_key": finding_id,
+                "observed_value": {"coverage_pct": 0.0, "total_events": 349},
+                "title": "Test critical invariant",
+                "recommendation": "fix it",
+                "runbook_command": "sqlite3 ... SELECT ...",
+                "metadata": {},
+            }
+        ],
+    }
+
+
+def _ok_payload() -> dict:
+    return {
+        "overall_status": "ok",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "crons": [],
+        "stale_tasks": {"count": 0, "samples": []},
+        "parked_tasks": {"count": 0, "samples": []},
+        "invariants": [],
+    }
+
+
+@pytest.fixture
+def fake_agentmail():
+    mock = AsyncMock()
+    mock.send_email = AsyncMock(return_value={"message_id": "abc", "status": "sent"})
+    return mock
+
+
+@pytest.fixture
+def notifications_list() -> list:
+    return []
+
+
+@pytest.fixture
+def add_notification_fn(notifications_list):
+    """Mirror gateway_server._add_notification just enough for dedup tracking."""
+
+    def _add(*, kind, title, message, summary=None, severity="info", requires_action=False, metadata=None, **_):
+        record = {
+            "kind": kind,
+            "title": title,
+            "message": message,
+            "summary": summary,
+            "severity": severity,
+            "requires_action": requires_action,
+            "metadata": dict(metadata or {}),
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        notifications_list.append(record)
+        return record
+
+    return _add
+
+
+# === sidecar artifact ===
+
+
+@pytest.mark.asyncio
+async def test_pre_flight_writes_sidecar_even_on_ok(tmp_path: Path, fake_agentmail, notifications_list, add_notification_fn):
+    payload_returned = await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_ok_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    sidecar = tmp_path / "work_products" / "proactive_health_latest.json"
+    assert sidecar.exists()
+    body = sidecar.read_text()
+    assert "ok" in body
+    assert payload_returned["overall_status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_pre_flight_writes_sidecar_on_critical(tmp_path: Path, fake_agentmail, notifications_list, add_notification_fn):
+    payload = _critical_payload()
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=lambda: payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    sidecar = tmp_path / "work_products" / "proactive_health_latest.json"
+    assert sidecar.exists()
+    assert "youtube_enrichment_coverage" in sidecar.read_text()
+
+
+# === email-on-critical ===
+
+
+@pytest.mark.asyncio
+async def test_critical_finding_emails_kevin(tmp_path, fake_agentmail, notifications_list, add_notification_fn):
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    fake_agentmail.send_email.assert_awaited_once()
+    call = fake_agentmail.send_email.call_args
+    assert call.kwargs["to"] == KEVIN_EMAIL
+    assert call.kwargs["force_send"] is True
+    assert "CRITICAL" in call.kwargs["subject"]
+    assert "youtube_enrichment_coverage" in call.kwargs["text"]
+    # dedup record was inserted
+    assert len(notifications_list) == 1
+    assert notifications_list[0]["kind"].startswith(NOTIFICATION_KIND_PREFIX)
+    assert notifications_list[0]["severity"] == "critical"
+
+
+@pytest.mark.asyncio
+async def test_no_email_when_overall_ok(tmp_path, fake_agentmail, notifications_list, add_notification_fn):
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_ok_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    fake_agentmail.send_email.assert_not_called()
+    assert notifications_list == []
+
+
+@pytest.mark.asyncio
+async def test_warn_severity_does_not_trigger_email(tmp_path, fake_agentmail, notifications_list, add_notification_fn):
+    payload = _critical_payload()
+    payload["invariants"][0]["severity"] = "warn"
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=lambda: payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    fake_agentmail.send_email.assert_not_called()
+
+
+# === dedup / cooldown ===
+
+
+@pytest.mark.asyncio
+async def test_second_call_within_cooldown_suppresses_email(tmp_path, fake_agentmail, notifications_list, add_notification_fn):
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    assert fake_agentmail.send_email.await_count == 1
+
+    # Second tick, same finding — should be suppressed because the dedup
+    # record is now in notifications_list and within the cooldown window.
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    assert fake_agentmail.send_email.await_count == 1
+    assert len(notifications_list) == 1  # no new dedup record either
+
+
+@pytest.mark.asyncio
+async def test_distinct_finding_ids_each_send_independently(tmp_path, fake_agentmail, notifications_list, add_notification_fn):
+    """A critical for invariant A must not silence invariant B's first fire."""
+    p = _critical_payload("invariant_a")
+    p["invariants"].append({
+        "finding_id": "invariant:invariant_b",
+        "category": "proactive_health",
+        "severity": "critical",
+        "metric_key": "invariant_b",
+        "title": "B",
+        "recommendation": "fix B",
+        "runbook_command": "ls",
+        "observed_value": None,
+        "metadata": {},
+    })
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=lambda: p,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    assert fake_agentmail.send_email.await_count == 2
+    assert len(notifications_list) == 2
+    kinds = {n["kind"] for n in notifications_list}
+    assert any(k.endswith("invariant:invariant_a") for k in kinds)
+    assert any(k.endswith("invariant:invariant_b") for k in kinds)
+
+
+def test_within_cooldown_helper_respects_window():
+    now = datetime.now(timezone.utc)
+    notifs = [
+        {
+            "kind": "proactive_health_critical:test",
+            "created_at": (now - timedelta(seconds=100)).isoformat(),
+            "updated_at": (now - timedelta(seconds=100)).isoformat(),
+        }
+    ]
+    # 100s ago is well within a 600s cooldown.
+    assert _within_cooldown(
+        kind="proactive_health_critical:test",
+        cooldown_seconds=600,
+        notifications_list=notifs,
+    ) is True
+    # Same record vs a 50s cooldown — outside.
+    assert _within_cooldown(
+        kind="proactive_health_critical:test",
+        cooldown_seconds=50,
+        notifications_list=notifs,
+    ) is False
+    # Different kind — not in cooldown for "test".
+    assert _within_cooldown(
+        kind="proactive_health_critical:other",
+        cooldown_seconds=600,
+        notifications_list=notifs,
+    ) is False
+
+
+def test_within_cooldown_ignores_malformed_timestamps():
+    notifs = [
+        {"kind": "proactive_health_critical:test", "created_at": "not-a-date"},
+        {"kind": "proactive_health_critical:test"},  # no timestamps at all
+    ]
+    assert _within_cooldown(
+        kind="proactive_health_critical:test",
+        cooldown_seconds=600,
+        notifications_list=notifs,
+    ) is False
+
+
+# === env-var disable ===
+
+
+@pytest.mark.asyncio
+async def test_disabled_via_env_returns_short_circuit(tmp_path, fake_agentmail, notifications_list, add_notification_fn, monkeypatch):
+    monkeypatch.setenv("UA_HEARTBEAT_PROACTIVE_HEALTH_ENABLED", "0")
+    result = await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    assert result == {"status": "disabled"}
+    fake_agentmail.send_email.assert_not_called()
+    # Sidecar should NOT exist when disabled.
+    assert not (tmp_path / "work_products" / "proactive_health_latest.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_email_disabled_via_env_still_writes_sidecar(tmp_path, fake_agentmail, notifications_list, add_notification_fn, monkeypatch):
+    monkeypatch.setenv("UA_HEARTBEAT_PROACTIVE_HEALTH_EMAIL_CRITICAL", "0")
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    fake_agentmail.send_email.assert_not_called()
+    assert (tmp_path / "work_products" / "proactive_health_latest.json").exists()
+
+
+# === resilience ===
+
+
+@pytest.mark.asyncio
+async def test_payload_builder_failure_does_not_crash(tmp_path, fake_agentmail, notifications_list, add_notification_fn):
+    def _boom():
+        raise RuntimeError("DB down")
+
+    result = await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_boom,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    assert "error" in result
+    assert "DB down" in result["error"]
+    fake_agentmail.send_email.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_email_failure_does_not_crash(tmp_path, fake_agentmail, notifications_list, add_notification_fn):
+    fake_agentmail.send_email.side_effect = RuntimeError("smtp down")
+    # Should NOT raise.
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    # No dedup record should be created when send failed — we want to retry
+    # next cycle, not silence ourselves.
+    assert notifications_list == []
+
+
+@pytest.mark.asyncio
+async def test_no_agentmail_service_still_writes_sidecar(tmp_path):
+    # Heartbeat boot before agentmail is initialized — must degrade gracefully.
+    payload = await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=None,
+        notifications_list=None,
+        add_notification_fn=None,
+    )
+    assert payload["overall_status"] == "critical"
+    assert (tmp_path / "work_products" / "proactive_health_latest.json").exists()
+
+
+def test_default_cooldown_is_6h():
+    assert DEFAULT_COOLDOWN_SECONDS == 21600


### PR DESCRIPTION
## Summary
Closes the loop on the proactive activity watchdog shipped in PR #367. The endpoint and directive were live, but in production Simone never called the endpoint and Kevin never got emailed when invariants flipped critical. Two gaps fixed here:

1. **Skip-mode bypass.** The HEARTBEAT.md directive lives inside the agent prompt. The heartbeat service has a fast-path that skips the agent entirely on most ticks (no actionable Task Hub items), and a "quick heartbeat" path that re-uses the prior cycle's assessment without re-traversing the directives. Confirmed live: zero calls to `/api/v1/ops/proactive_health` from Simone's process since PR #367 merged.
2. **No notification step.** Even if the directive had run, it only wrote findings to a JSON file. Kevin had to open the dashboard to see anything. A confirmed-critical `youtube_enrichment_coverage` finding (349 events, 0% coverage) has been active for hours with zero email sent.

This PR moves the watchdog call out of the agent prompt and into a code-side pre-flight that runs every tick regardless of skip-mode, plus adds an email-on-critical step with cooldown-based dedup.

## What it does

- **Every heartbeat tick** (full, quick, OR skip): calls `build_proactive_health_payload` directly (in-process, no HTTP) and writes a sidecar artifact to `{workspace}/work_products/proactive_health_latest.json` — always inspectable on disk.
- **For each invariant with severity='critical'**: sends Kevin an email via the existing `AgentMailService.send_email` (to `kevinjdragan@gmail.com`) and records a dedup row via `gateway_server._add_notification`.
- **Cooldown dedup**: suppresses repeated emails for the same `finding_id` within 6h (configurable). A stuck pipeline won't spam the inbox 48× a day.
- **Resilient**: notifier failures are caught and logged, never block the heartbeat. Send failures specifically do NOT record a dedup row — we want next-cycle retry, not silent suppression.

## Files
**New**:
- `src/universal_agent/services/proactive_health_notifier.py` (~230 lines) — the pre-flight module
- `tests/unit/test_proactive_health_notifier.py` (~290 lines) — 15 unit tests

**Modified**:
- `src/universal_agent/heartbeat_service.py` — ~50 line wire-in just after the "Heartbeat started" broadcast and before the skip-mode branch, so it fires on every tick. Wrapped in try/except.

## Config knobs (all default ON)
| Env var | Default | Purpose |
|---|---|---|
| `UA_HEARTBEAT_PROACTIVE_HEALTH_ENABLED` | `1` | Master switch for the pre-flight |
| `UA_HEARTBEAT_PROACTIVE_HEALTH_EMAIL_CRITICAL` | `1` | Email Kevin on new critical findings |
| `UA_HEARTBEAT_PROACTIVE_HEALTH_COOLDOWN_SECONDS` | `21600` (6h) | Per-finding_id dedup window |

## Email body shape
Subject: `[Proactive Health CRITICAL] YouTube enrichment coverage over last 7 days`. Body includes `metric_key`, `recommendation`, `observed_value` JSON, the exact `runbook_command` SQL, and a `curl` snippet to force-refresh the alert.

## Test plan
- [x] `uv run pytest tests/unit/test_proactive_health_notifier.py` → 15/15 pass
- [x] Full proactive-health test stack still green: 50/50 across `test_proactive_health_notifier.py` (15 new) + `test_pipeline_invariants.py` (12) + `test_youtube_transcript_coverage_invariant.py` (14) + `test_proactive_health_payload.py` (9)
- [x] `uv run ruff check` clean on all changed files
- [ ] **Post-deploy on VPS**: next heartbeat tick after deploy should write `proactive_health_latest.json` AND send Kevin an email about the active `youtube_enrichment_coverage` critical finding within ~30 min. After that first email, the 6h cooldown should suppress repeats until either (a) the underlying issue resolves or (b) cooldown elapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)