### PR TITLE
feat(dashboard): API timeout helper + ServiceStatusBanner for deploy warm-up

### DIFF
--- a/web-ui/app/dashboard/layout.tsx
+++ b/web-ui/app/dashboard/layout.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { LayoutDashboard } from "lucide-react";
 import SimoneChatBar from "@/components/dashboard/SimoneChatBar";
 import { GlobalSidebar } from "@/components/dashboard/GlobalSidebar";
+import { ServiceStatusBanner } from "@/components/dashboard/ServiceStatusBanner";
 
 /* ------------------------------------------------------------------ */
 /* Types                                                               */
@@ -205,6 +206,9 @@ export default function DashboardLayout({ children }: { children: ReactNode }) {
           <span>⚠️</span>
         </div>
       )}
+
+      {/* Gateway availability banner — shows during deploy warm-up or when API is unreachable. */}
+      <ServiceStatusBanner />
 
       <div className="flex flex-1 overflow-hidden relative">
         <GlobalSidebar ownerId={session.owner_id || ownerId} showCorporationNav={showCorporationNav} />

--- a/web-ui/components/dashboard/ServiceStatusBanner.tsx
+++ b/web-ui/components/dashboard/ServiceStatusBanner.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { getGatewayStatus, type GatewayStatus } from "@/lib/api";
+
+/**
+ * Sticky top-of-dashboard banner that surfaces gateway availability.
+ *
+ * Three states:
+ *
+ *   1. Healthy & stable: nothing rendered (no UI noise).
+ *
+ *   2. Recently restarted (`process_started_at` within 60s): yellow
+ *      "service updating" banner. Backgrounds the deploy warm-up window so
+ *      the operator understands why the dashboard panels are blank instead
+ *      of staring at frozen "Refreshing..." spinners.
+ *
+ *   3. Unreachable (timeout or HTTP error on `/api/v1/version`): red
+ *      "gateway unreachable" banner with a manual retry button.
+ *
+ * Poll cadence: 30s when healthy, 5s while in a degraded/updating state. The
+ * faster cadence lets the banner clear quickly once the gateway recovers.
+ */
+
+const HEALTHY_POLL_MS = 30_000;
+const DEGRADED_POLL_MS = 5_000;
+
+export function ServiceStatusBanner() {
+  const [status, setStatus] = useState<GatewayStatus | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const scheduleNext = (s: GatewayStatus | null) => {
+      const inDegraded = Boolean(s && (!s.ok || s.recentlyRestarted));
+      const delay = inDegraded ? DEGRADED_POLL_MS : HEALTHY_POLL_MS;
+      timerRef.current = setTimeout(poll, delay);
+    };
+
+    const poll = async () => {
+      const next = await getGatewayStatus();
+      if (cancelled) return;
+      setStatus(next);
+      scheduleNext(next);
+    };
+
+    poll();
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleRetry = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      const next = await getGatewayStatus();
+      setStatus(next);
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  if (!status) return null;
+
+  if (status.recentlyRestarted) {
+    const ageSec =
+      status.processAgeMs !== undefined ? Math.max(0, Math.round(status.processAgeMs / 1000)) : "?";
+    return (
+      <div className="flex shrink-0 items-center justify-center gap-2 bg-amber-400 px-4 py-1.5 text-xs font-semibold text-amber-950">
+        <span>🟡</span>
+        <span>
+          Gateway just updated ({String(ageSec)}s ago
+          {status.shortSha ? ` · ${status.shortSha}` : ""}) — dashboard refreshing
+        </span>
+      </div>
+    );
+  }
+
+  if (!status.ok) {
+    return (
+      <div className="flex shrink-0 items-center justify-center gap-3 bg-red-500 px-4 py-1.5 text-xs font-semibold text-red-50">
+        <span>🔴</span>
+        <span>
+          Gateway unreachable ({status.error ?? "unknown error"}) — some panels will be empty
+        </span>
+        <button
+          type="button"
+          className="rounded border border-red-50/40 px-2 py-0.5 text-[11px] font-medium hover:bg-red-50/10 disabled:opacity-60"
+          onClick={handleRetry}
+          disabled={refreshing}
+        >
+          {refreshing ? "retrying…" : "retry"}
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/web-ui/lib/api.test.ts
+++ b/web-ui/lib/api.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the shared fetch utilities.
+ *
+ * Covers:
+ *   - fetchWithTimeout: succeeds on fast responses, throws ApiTimeoutError on slow,
+ *     respects caller-supplied AbortSignals.
+ *   - getGatewayStatus: parses the version envelope, computes recentlyRestarted
+ *     correctly, and degrades cleanly on network failure.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+import {
+  ApiTimeoutError,
+  DEFAULT_API_TIMEOUT_MS,
+  GATEWAY_VERSION_PATH,
+  RECENT_RESTART_WINDOW_MS,
+  fetchWithTimeout,
+  getGatewayStatus,
+} from "./api";
+
+describe("fetchWithTimeout", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns the response when the fetch resolves before the timeout", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+
+    const resp = await fetchWithTimeout("/test", {}, 1000);
+
+    expect(resp.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("throws ApiTimeoutError if the fetch exceeds the timeout", async () => {
+    // Mock fetch with a fetch that respects the AbortController signal.
+    global.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    });
+
+    await expect(fetchWithTimeout("/slow", {}, 50)).rejects.toBeInstanceOf(ApiTimeoutError);
+  });
+
+  it("propagates non-timeout fetch errors unchanged", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("network down"));
+
+    await expect(fetchWithTimeout("/down", {}, 1000)).rejects.toThrow("network down");
+  });
+
+  it("aborts when the caller-supplied signal fires (not as ApiTimeoutError)", async () => {
+    global.fetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    });
+
+    const controller = new AbortController();
+    const p = fetchWithTimeout("/cancellable", { signal: controller.signal }, 5000);
+    controller.abort();
+
+    await expect(p).rejects.not.toBeInstanceOf(ApiTimeoutError);
+  });
+
+  it("uses DEFAULT_API_TIMEOUT_MS when no timeout is supplied", () => {
+    expect(DEFAULT_API_TIMEOUT_MS).toBe(5000);
+  });
+});
+
+describe("getGatewayStatus", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("marks gateway as recentlyRestarted when process_started_at is within the window", async () => {
+    const now = new Date("2026-05-19T03:00:00Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          commit_sha: "abc123",
+          short_sha: "abc123",
+          branch: "main",
+          process_started_at: new Date(now - 10_000).toISOString(),
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const status = await getGatewayStatus();
+
+    expect(status.ok).toBe(true);
+    expect(status.reachable).toBe(true);
+    expect(status.recentlyRestarted).toBe(true);
+    expect(status.processAgeMs).toBe(10_000);
+    expect(status.shortSha).toBe("abc123");
+    const url = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(url).toBe(GATEWAY_VERSION_PATH);
+  });
+
+  it("does not mark recentlyRestarted when the process is old", async () => {
+    const now = new Date("2026-05-19T03:00:00Z").getTime();
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          process_started_at: new Date(now - (RECENT_RESTART_WINDOW_MS + 5_000)).toISOString(),
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const status = await getGatewayStatus();
+
+    expect(status.ok).toBe(true);
+    expect(status.recentlyRestarted).toBe(false);
+  });
+
+  it("returns an unreachable status when the fetch fails", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new TypeError("network down"));
+
+    const status = await getGatewayStatus();
+
+    expect(status.ok).toBe(false);
+    expect(status.reachable).toBe(false);
+    expect(status.recentlyRestarted).toBe(false);
+    expect(status.error).toContain("network down");
+  });
+
+  it("returns ok=false reachable=true when the gateway returns a non-200", async () => {
+    global.fetch = vi.fn().mockResolvedValue(new Response("oops", { status: 503 }));
+
+    const status = await getGatewayStatus();
+
+    expect(status.ok).toBe(false);
+    expect(status.reachable).toBe(true);
+    expect(status.error).toContain("503");
+  });
+});

--- a/web-ui/lib/api.ts
+++ b/web-ui/lib/api.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared HTTP utilities for talking to the UA Gateway through the dashboard proxy.
+ *
+ * Two helpers are exported:
+ *
+ *   - `fetchWithTimeout(url, init, timeoutMs)` — drop-in `fetch` replacement that
+ *     aborts after `timeoutMs` (default 5000). Existing components can adopt this
+ *     incrementally; nothing in this file changes how `fetch` works for legacy code.
+ *
+ *   - `getGatewayStatus()` — polls `/api/v1/version` (via the dashboard gateway
+ *     proxy) and returns a `GatewayStatus` shape that `ServiceStatusBanner` uses
+ *     to decide whether to show the "updating" banner.
+ *
+ * Background: the Universal Agent gateway restarts on every merge-to-main
+ * deploy. During the ~30–45s warm-up window, dashboard API calls that fired
+ * during the restart sit with "Refreshing..." spinners indefinitely. This
+ * utility caps that wait at 5s and surfaces the state to the banner so the
+ * operator sees "service updating" instead of a frozen UI.
+ */
+
+export const DEFAULT_API_TIMEOUT_MS = 5000;
+export const GATEWAY_VERSION_PATH = "/api/dashboard/gateway/api/v1/version";
+
+/** Recent-restart window — banner stays visible while the gateway is this fresh. */
+export const RECENT_RESTART_WINDOW_MS = 60_000;
+
+export class ApiTimeoutError extends Error {
+  constructor(public url: string, public timeoutMs: number) {
+    super(`Request to ${url} timed out after ${timeoutMs}ms`);
+    this.name = "ApiTimeoutError";
+  }
+}
+
+/**
+ * `fetch` wrapper with a hard timeout via AbortController.
+ *
+ * The caller can still pass their own `signal` — both signals will be honored
+ * (whichever fires first wins). Errors are unchanged from `fetch`'s native
+ * behavior, with one exception: an abort caused by `timeoutMs` elapsing is
+ * re-raised as `ApiTimeoutError` so callers can distinguish "user cancelled"
+ * from "request took too long".
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: RequestInit = {},
+  timeoutMs: number = DEFAULT_API_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  // If caller supplied a signal, abort our controller when theirs fires.
+  const callerSignal = init.signal;
+  const onCallerAbort = () => controller.abort();
+  if (callerSignal) {
+    if (callerSignal.aborted) controller.abort();
+    else callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+  }
+
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err) {
+    if (controller.signal.aborted && !(callerSignal?.aborted)) {
+      // Our timer fired (not the caller's signal) — surface as a typed error.
+      throw new ApiTimeoutError(url, timeoutMs);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeoutId);
+    if (callerSignal) callerSignal.removeEventListener("abort", onCallerAbort);
+  }
+}
+
+export interface GatewayStatus {
+  ok: boolean;
+  reachable: boolean;
+  commitSha?: string;
+  shortSha?: string;
+  branch?: string;
+  processStartedAt?: string;
+  processAgeMs?: number;
+  recentlyRestarted: boolean;
+  error?: string;
+}
+
+/**
+ * Hit `/api/v1/version` through the dashboard gateway proxy.
+ *
+ * Returns a `GatewayStatus` describing whether the gateway is reachable and
+ * how recently it (re)started. Never throws — failures are encoded into the
+ * return value so the banner component can render a degraded state cleanly.
+ *
+ * Uses a tight 4s timeout so the banner's poll cycle doesn't itself stall the
+ * UI if the gateway is wedged.
+ */
+export async function getGatewayStatus(
+  timeoutMs: number = 4000,
+): Promise<GatewayStatus> {
+  try {
+    const resp = await fetchWithTimeout(
+      GATEWAY_VERSION_PATH,
+      { cache: "no-store" },
+      timeoutMs,
+    );
+    if (!resp.ok) {
+      return {
+        ok: false,
+        reachable: true,
+        recentlyRestarted: false,
+        error: `gateway returned HTTP ${resp.status}`,
+      };
+    }
+    const data = (await resp.json()) as {
+      commit_sha?: string;
+      short_sha?: string;
+      branch?: string;
+      process_started_at?: string;
+    };
+    const startedAt = data.process_started_at
+      ? new Date(data.process_started_at).getTime()
+      : NaN;
+    const processAgeMs = Number.isFinite(startedAt) ? Date.now() - startedAt : undefined;
+    const recentlyRestarted =
+      processAgeMs !== undefined && processAgeMs >= 0 && processAgeMs < RECENT_RESTART_WINDOW_MS;
+    return {
+      ok: true,
+      reachable: true,
+      commitSha: data.commit_sha,
+      shortSha: data.short_sha,
+      branch: data.branch,
+      processStartedAt: data.process_started_at,
+      processAgeMs,
+      recentlyRestarted,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      reachable: false,
+      recentlyRestarted: false,
+      error: message,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Frontend resilience for the ~30–45s dashboard "frozen panels" window that fires every time a PR merges and the gateway restarts. PR A of three (B: backend pre-warm, C: batched dashboard endpoint to follow).

## The problem (observed live tonight)

After tonight's PR #358 / #362 / #371 deploys, the operator opened `/dashboard/proactive-signals` mid-deploy and saw the panels stuck on "Refreshing..." spinners. The page shell loaded in 3.7ms but the parallel API calls behind it sat waiting on a gateway warming up — `/api/v1/version` took 15s to return, `/api/v1/dashboard/proactive-signals` 12.9s before rejecting 401. No signal to the operator that a deploy was in flight.

## Changes

### 1. `web-ui/lib/api.ts` (NEW) — shared HTTP utilities

- **`fetchWithTimeout(url, init, timeoutMs=5000)`**: drop-in `fetch` replacement that aborts after a hard deadline via `AbortController`. Honors caller-supplied signals (whichever aborts first wins). Timer-driven aborts re-raise as a typed `ApiTimeoutError` so callers can distinguish "user cancelled" from "took too long".
- **`getGatewayStatus()`**: hits `/api/v1/version` through the dashboard gateway proxy, returns a structured `GatewayStatus` with reachability, `recentlyRestarted` flag (within 60s of `process_started_at`), commit SHA. Never throws — failures encode into the return value.
- 4s tight timeout on the version poll so the banner itself can't stall the UI when the gateway is wedged.
- Existing components keep using bare `fetch`. Adoption is incremental — `fetchWithTimeout` is offered, not forced.

### 2. `web-ui/components/dashboard/ServiceStatusBanner.tsx` (NEW)

Sticky banner at the top of the dashboard, right after the existing staging-environment banner. Three states:

| State | UI |
|---|---|
| Healthy & stable | Nothing rendered (no noise) |
| `process_started_at` within 60s | 🟡 "Gateway just updated (12s ago · 4d613673) — dashboard refreshing" |
| Unreachable (timeout or non-2xx) | 🔴 "Gateway unreachable (timeout) — some panels will be empty" + retry button |

Poll cadence: 30s when healthy, 5s while degraded — so the banner clears quickly once the gateway recovers.

### 3. `web-ui/app/dashboard/layout.tsx`

One-line render: `<ServiceStatusBanner />` right after the existing `STAGING ENVIRONMENT` banner. Same visual slot, same pattern.

## Tests

`web-ui/lib/api.test.ts` — 9 tests covering:
- Fast-path response succeeds
- Timeout produces `ApiTimeoutError`
- Non-timeout fetch errors propagate unchanged
- Caller-supplied AbortSignal cancellation isn't mis-classified as a timeout
- `recentlyRestarted` true within 60s window
- `recentlyRestarted` false outside window
- Network failure → `reachable=false` with error preserved
- Non-200 response → `reachable=true ok=false` with status code in error
- `DEFAULT_API_TIMEOUT_MS === 5000`

```
Test Files  1 passed (1)
     Tests  9 passed (9)
```

`tsc --noEmit` clean. ESLint clean on touched files (one pre-existing error at `layout.tsx:89` from before this PR — untouched).

## Followups (separate PRs)

- **PR B: Backend pre-warm** — gateway startup hook fires dummy queries against hot paths so first-request latency drops from ~30s to ~5s. Reduces the window where the banner is needed in the first place.
- **PR C: Batched dashboard endpoint** — consolidate the 7 parallel API calls per page load into 1–2 batched endpoints. Faster + less server load.
- Adopt `fetchWithTimeout` in existing dashboard panels (incremental, non-blocking).

## Test plan

- [x] `vitest run lib/api.test.ts` — 9 passed
- [x] `tsc --noEmit` — clean on touched files
- [x] `eslint` — clean on touched files
- [ ] Post-merge: verify on next deploy that banner appears for ~60s after restart, then auto-clears
- [ ] Post-merge: kill gateway temporarily and verify red unreachable banner with working retry button

🤖 Generated with [Claude Code](https://claude.com/claude-code)