### PR TITLE
chore(dormancy): widen active window to 10 PM; classify watchdog as 24/7 exception

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ The ClaudeDevs X intel pipeline is undergoing a v2 rebuild. Two living docs trac
 
 ## Operating Hours / Dormancy Default
 
-**Active window: 6:00 AM – 9:00 PM Houston time.** **Dormant: 9:00 PM – 6:00 AM.**
+**Active window: 6:00 AM – 10:00 PM Houston time.** **Dormant: 10:00 PM – 6:00 AM.**
 
 Default applies to **content-generation** work only — cron jobs / polling loops / scheduled GHA workflows that burn quota to produce intelligence nobody reads until morning. Use `default_timezone="America/Chicago"` (or `TZ=America/Chicago`) so DST handles itself; GitHub Actions schedules are UTC-only — express in UTC and accept the 1h DST drift.
 

--- a/docs/operations/operating_hours_dormancy.md
+++ b/docs/operations/operating_hours_dormancy.md
@@ -6,8 +6,8 @@
 
 By default, every cron job, polling loop, scheduled GitHub Actions workflow, or background service in this repo runs **only during waking hours** in Houston time:
 
-> **Active window: 6:00 AM → 9:00 PM Houston time (CDT/CST).**
-> **Dormant window: 9:00 PM → 6:00 AM Houston time.**
+> **Active window: 6:00 AM → 10:00 PM Houston time (CDT/CST).**
+> **Dormant window: 10:00 PM → 6:00 AM Houston time.**
 
 In UTC the active window translates to (DST-aware):
 - **Summer (CDT, UTC-5):** 11:00–02:00 UTC
@@ -29,7 +29,7 @@ Default-dormant moves the operating tempo to the operator's actual day.
 
 The dormancy default exists to suppress **wasteful work** — crons that burn quota or tokens to produce material no human will read until morning. It is **not** a license to turn off production-health automation overnight.
 
-**Subject to dormancy (default 6 AM – 9 PM Houston):**
+**Subject to dormancy (default 6 AM – 10 PM Houston):**
 
 - Content-generation crons: HackerNews snapshot, briefing materials, proactive reports, doc drift audit, openclaw release sync, intel pipeline material production
 - Quota-burning polls: scheduled LLM runs that synthesize observations into briefings
@@ -64,10 +64,11 @@ These services run inside the dormancy window with documented justification:
 | `nightly_wiki` | 3:15 AM Houston | Generates overnight wiki output that `morning_briefing` (6:30 AM) reads. Dormancy-window run gives the briefing fresh material. Exception #1 (downstream consumer). See [`gateway_server.py:18217`](../../src/universal_agent/gateway_server.py#L18217). |
 | `atlas_direct_dispatch` | Every 60s, 24/7, UTC | Hermes Phase C (PR #221) — independent dispatcher for tasks tagged `metadata.preferred_vp = "vp.general.primary"`. Exception #3 (latency-sensitive): Atlas-eligible tasks must dispatch within ~60s of being queued; waiting until 6 AM defeats the purpose. **Default OFF** via `UA_ATLAS_DIRECT_DISPATCH_ENABLED=0` — operator opts in after dry-run, so the 24/7 schedule has zero quota cost until enabled. The cron registration also goes through `_proactive_cron_enabled`, AND the script itself re-checks the env var before doing any work (belt-and-suspenders against accidental activation). See [`gateway_server.py:_ensure_atlas_direct_dispatch_cron_job`](../../src/universal_agent/gateway_server.py) and [`docs/reports/hermes-adaptation-phased-plan-2026-05-10.md`](../reports/hermes-adaptation-phased-plan-2026-05-10.md) § Phase C. |
 | `simone_chat_auto_complete` | Every 60s, 24/7, UTC | Mission-control PR #255 — pure-SQLite housekeeping that promotes `simone_chat` Task Hub rows from `status="in_progress"` to `status="completed"` once Simone has proposed completion and the operator has been silent past `UA_SIMONE_CHAT_IDLE_MINUTES` (default 10). **No LLM tokens, no external API, no network egress** — the work is a `UPDATE ... WHERE` on the activity DB. Exception #3 (latency-sensitive operator-facing state): a chat started at 8:55 PM has its 10-minute silence window cross into the dormant period; running only in active hours leaves rows in `in_progress` overnight and pollutes the dashboard the operator opens at 6 AM. Registered with `skip_task_hub_link=True` (Observability Protocol exemption — re-emitting Task Hub events for a job that IS Task Hub state-management would be circular). See [`gateway_server.py:_ensure_simone_chat_autocomplete_cron_job`](../../src/universal_agent/gateway_server.py) and [`src/universal_agent/scripts/simone_chat_auto_complete.py`](../../src/universal_agent/scripts/simone_chat_auto_complete.py). |
+| `heartbeat` + `proactive_health_watchdog` (pre-flight) | Every heartbeat tick, 24/7 | The Simone heartbeat is the runtime tick driver and is not a cron job; it fires on its own schedule (every ~30m) regardless of clock. Embedded in every tick — full, quick, and skip alike — is the `proactive_health_notifier.run_pre_flight_check` call ([`heartbeat_service.py:_run_heartbeat`](../../src/universal_agent/heartbeat_service.py) just after the "Heartbeat started" broadcast). This is a **health/infrastructure handler**, not content generation: it polls task_hub stale/parked counts, calls every registered pipeline invariant, writes `work_products/proactive_health_latest.json`, and emails Kevin on first occurrence of a new critical finding (with 6h per-finding-id cooldown). Exception #3 (latency-sensitive incident response): a pipeline breaking at 11 PM should email Kevin by 11:30 PM, not silently wait until 6 AM. Default ON; can be disabled per-knob via `UA_HEARTBEAT_PROACTIVE_HEALTH_ENABLED=0` (master), `UA_HEARTBEAT_PROACTIVE_HEALTH_EMAIL_CRITICAL=0` (mute email only — sidecar artifact still written). See [`src/universal_agent/services/proactive_health_notifier.py`](../../src/universal_agent/services/proactive_health_notifier.py) and the canonical doc [`docs/03_Operations/132_Proactive_Health_Watchdog.md`](../03_Operations/132_Proactive_Health_Watchdog.md). |
 
 ## Active-hour services (subject to dormancy default)
 
-These run only during 6 AM – 9 PM Houston:
+These run only during 6 AM – 10 PM Houston:
 
 All times Houston (America/Chicago) unless noted. Schedules spread on 2026-05-11 — see "Cron spread (2026-05-11)" below for rationale.
 
@@ -80,7 +81,7 @@ All times Houston (America/Chicago) unless noted. Schedules spread on 2026-05-11
 | `proactive_report_midday` | 12:05 PM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
 | `proactive_report_afternoon` | 4:05 PM daily | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
 | `vp_coder_workspace_pruning` | Sun 5:05 PM (weekly) | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
-| `hackernews_snapshot` | every 30m, 6 AM–9 PM (at :00 and :30) | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
+| `hackernews_snapshot` | every 30m, 6 AM–10 PM (at :00 and :30) | [`gateway_server.py`](../../src/universal_agent/gateway_server.py) |
 
 GitHub Actions schedules (UTC, no DST handling):
 

--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -18698,10 +18698,10 @@ def _ensure_hackernews_snapshot_cron_job() -> Optional[dict[str, Any]]:
     # actually moved on the front page overnight.
     return _register_system_cron_job(
         system_job="hackernews_snapshot",
-        default_cron="0,30 6-20 * * *",
+        default_cron="0,30 6-21 * * *",
         default_timezone="America/Chicago",
         command="!script universal_agent.scripts.hackernews_snapshot",
-        description="Half-hourly Hacker News snapshot (active hours only: 6 AM–9 PM Houston).",
+        description="Half-hourly Hacker News snapshot (active hours only: 6 AM–10 PM Houston).",
         timeout_seconds=300,
         enabled=_proactive_cron_enabled("UA_HACKERNEWS_SNAPSHOT_ENABLED"),
         cron_env_var="UA_HACKERNEWS_SNAPSHOT_CRON",

--- a/tests/unit/test_cron_dormancy_defaults.py
+++ b/tests/unit/test_cron_dormancy_defaults.py
@@ -1,7 +1,7 @@
 """Pin the operating-hours dormancy default for system cron jobs.
 
 Policy: cron schedules registered in `gateway_server.py:_ensure_*_cron_job`
-must fall inside the active window (6 AM – 9 PM Houston, America/Chicago)
+must fall inside the active window (6 AM – 10 PM Houston, America/Chicago)
 unless they're documented as an exception in
 `docs/operations/operating_hours_dormancy.md`.
 
@@ -12,7 +12,7 @@ side-effects); instead it does string-grep against the source file,
 which is good enough for catching the static `default_cron=` literals.
 
 The active window in cron-hour terms (Chicago TZ): hours 6, 7, 8, ...,
-20 are active. Hours 21, 22, 23, 0, 1, 2, 3, 4, 5 are dormant.
+21 are active. Hours 22, 23, 0, 1, 2, 3, 4, 5 are dormant.
 """
 from __future__ import annotations
 
@@ -52,9 +52,9 @@ DOCUMENTED_EXCEPTIONS = {
 }
 
 # Hours considered active in America/Chicago. 6 AM start (operator wakes),
-# 9 PM cutoff (last tick at 8:30 PM is fine; 21:00 itself is the start of
-# dormancy). So active hours are [6, 7, 8, ..., 20].
-ACTIVE_HOURS = set(range(6, 21))
+# 10 PM cutoff (last tick at 9:30 PM is fine; 22:00 itself is the start of
+# dormancy). So active hours are [6, 7, 8, ..., 21].
+ACTIVE_HOURS = set(range(6, 22))
 
 
 def _extract_cron_registrations(content: str) -> list[tuple[str, str, str]]:
@@ -126,7 +126,7 @@ def test_dormancy_doc_exists() -> None:
         f"canonical doc. CLAUDE.md links to it."
     )
     body = DORMANCY_DOC.read_text(encoding="utf-8")
-    assert "6:00 AM" in body and "9:00 PM" in body, (
+    assert "6:00 AM" in body and "10:00 PM" in body, (
         "Dormancy doc must state the active window in plain English"
     )
 
@@ -139,7 +139,7 @@ def test_claude_md_links_to_dormancy_doc() -> None:
     """
     body = Path("CLAUDE.md").read_text(encoding="utf-8")
     assert "operating_hours_dormancy.md" in body
-    assert "6:00 AM" in body and "9:00 PM" in body
+    assert "6:00 AM" in body and "10:00 PM" in body
     assert "Houston" in body
 
 
@@ -190,12 +190,14 @@ def test_hackernews_snapshot_uses_active_hour_range() -> None:
     """
     content = GATEWAY_SERVER.read_text(encoding="utf-8")
     assert (
-        'default_cron="0,30 6-20 * * *"' in content
+        'default_cron="0,30 6-21 * * *"' in content
         and '"hackernews_snapshot"' in content
     ), (
-        "hackernews_snapshot must default to '0,30 6-20 * * *' America/Chicago "
-        "(2026-05-10 dormancy default). Pre-2026-05-10 it was '*/30 * * * *' UTC; "
-        "if you need to change it, update docs/operations/operating_hours_dormancy.md."
+        "hackernews_snapshot must default to '0,30 6-21 * * *' America/Chicago "
+        "(2026-05-19 dormancy widened to 6 AM–10 PM Houston). Pre-2026-05-10 "
+        "it was '*/30 * * * *' UTC; 2026-05-10 through 2026-05-19 it was "
+        "'0,30 6-20 * * *'. If you need to change it, update "
+        "docs/operations/operating_hours_dormancy.md."
     )
 
 


### PR DESCRIPTION
## Summary
Two operator-requested changes addressed in one small PR:

1. **Dormancy active window 9 PM → 10 PM Houston.** Most days the operator is still active 9–10 PM; the prior boundary was clipping useful work. The active window is now 6 AM – 10 PM Houston (CDT/CST).
2. **`proactive_health_watchdog` explicitly classified as a 24/7 exception.** The watchdog (shipped in PR #372) already runs every heartbeat tick regardless of clock — confirmed live: a 02:04 UTC = 9:04 PM CDT heartbeat fired post-deploy and ran the pre-flight. But it was not documented as an exception in `operating_hours_dormancy.md`, so its 24/7 status was implicit rather than load-bearing. This PR makes it explicit.

No code change required for the watchdog itself — the pre-flight at `heartbeat_service.py:_run_heartbeat` (lines 2481–2531) is intentionally positioned BEFORE the skip-mode branch and outside any dormancy gate. The heartbeat tick driver itself is not dormancy-gated either. The dormancy default is, by policy, a content-generation gate (briefings, reports, snapshots) — not an infrastructure-handler gate.

## Files
- `docs/operations/operating_hours_dormancy.md` — text 9PM→10PM in three places; new row in the "Currently registered exceptions" table for `heartbeat + proactive_health_watchdog` citing Exception #3 (latency-sensitive incident response) with env-var knobs and cross-link to the canonical watchdog doc (132).
- `CLAUDE.md` line 151 — same 9PM→10PM update so both top-level summaries match.
- `src/universal_agent/gateway_server.py` — `hackernews_snapshot` default_cron extended from `"0,30 6-20 * * *"` to `"0,30 6-21 * * *"` so HN snapshots continue through 9:30 PM (last tick at 21:30 = 9:30 PM CDT, inside the new active window). Description string updated to match.
- `tests/unit/test_cron_dormancy_defaults.py` — `ACTIVE_HOURS = set(range(6, 22))` (was `range(6, 21)`); module docstring + inline comment updated; pinned HN cron value updated; assertion messages about `"9:00 PM"` → `"10:00 PM"` in two places.

## Test plan
- [x] `uv run pytest tests/unit/test_cron_dormancy_defaults.py` → 10/10 pass
- [x] `uv run ruff check` clean on all changed files
- [ ] **Post-deploy on VPS**: HN snapshot cron will start firing at 21:00 and 21:30 Houston time (was last firing at 20:30). Verify with `journalctl -u universal-agent-gateway --since "9 PM" | grep hackernews_snapshot` after the next 9:30 PM tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)