### PR TITLE
fix(gateway): clear 3 F841 unused-variable warnings — 2 dead, 1 latent bug

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -12769,9 +12769,9 @@ def _calendar_project_task_events(
     try:
         conn = _task_hub_open_conn()
         try:
-            start_iso = datetime.fromtimestamp(start_ts, timezone.utc).isoformat()
-            end_iso = datetime.fromtimestamp(end_ts, timezone.utc).isoformat()
-            # Tasks with due_at in the calendar window OR overdue (due_at < now, not completed)
+            # Tasks with due_at in the calendar window OR overdue (due_at < now, not completed).
+            # The window filter is applied in Python below (is_in_window / is_overdue) so the
+            # SQL pulls the full due_at-bearing set and lets the loop classify.
             rows = conn.execute(
                 """
                 SELECT task_id, source_kind, source_ref, title, description,
@@ -16767,12 +16767,23 @@ async def upload_session_file(
     is_text = ext in _TEXT_EXTENSIONS
     is_image = ext in _IMAGE_EXTENSIONS
 
+    # ``_ALLOWED_EXTENSIONS = _TEXT_EXTENSIONS | _IMAGE_EXTENSIONS`` makes the
+    # text/image dichotomy exhaustive *today*, but check ``is_image`` explicitly
+    # so future expansions of the allowlist don't silently mislabel new file
+    # kinds as "image".
+    if is_text:
+        type_label = "text"
+    elif is_image:
+        type_label = "image"
+    else:
+        type_label = "file"
+
     result: dict = {
         "status": "ok",
         "filename": dest.name,
         "path": relative_path,
         "size": len(content_bytes),
-        "type": "text" if is_text else "image",
+        "type": type_label,
     }
 
     # For text files, also return content so frontend can inject it


### PR DESCRIPTION
## Summary

Three pre-existing ruff F841 errors in `gateway_server.py` flagged during last night's PR #375 work. Each one investigated to determine intent — found one latent bug, two truly dead vars.

## Each error

### 1. `start_iso` (line 12772) — DEAD ✂️

In `_project_taskhub_due_dates_into_events`. Computed an ISO timestamp from `start_ts`, then never used. The SQL pulls all due_at-bearing rows; the surrounding Python loop applies `is_in_window` / `is_overdue` filtering. The ISO strings were leftover from an earlier SQL-side-filter attempt that got rewritten in Python. Comment kept (still describes intent accurately); the dead assignment deleted.

### 2. `end_iso` (line 12773) — DEAD ✂️

Same as #1 — `end_ts`-based ISO that's never referenced.

### 3. `is_image` (line 16768) — LATENT BUG 🐛

In the file-upload handler `dashboard_session_upload`:

```python
# BEFORE
is_text = ext in _TEXT_EXTENSIONS
is_image = ext in _IMAGE_EXTENSIONS  # ← computed but never used

result: dict = {
    ...
    "type": "text" if is_text else "image",  # ← labels anything non-text as "image"
}
```

This is correct **today** because `_ALLOWED_EXTENSIONS = _TEXT_EXTENSIONS | _IMAGE_EXTENSIONS` makes the dichotomy exhaustive. **But** if anyone adds new categories to the allowlist (PDFs, archives, audio) without updating this branch, the result will silently mislabel them as "image". The `is_image` computation was clearly intended to gate the label.

```python
# AFTER — branch explicitly with a sensible fallback
if is_text:
    type_label = "text"
elif is_image:
    type_label = "image"
else:
    type_label = "file"
```

Net behavior unchanged today; future-safe when the allowlist grows.

## Verification

- `ruff check src/universal_agent/gateway_server.py` → **All checks passed!**
- `py_compile` → clean
- `pytest -k 'calendar or file_upload or sessions_upload or dashboard_metrics_coder'` → **38 passed, 1 skipped**

Diff: +15 / -4 across two hunks, no other touches.

## Test plan

- [x] ruff clean post-fix
- [x] py_compile clean
- [x] 38 related unit tests pass
- [ ] Post-merge: confirm `/api/v1/dashboard/calendar` (`_project_taskhub_due_dates_into_events` caller) still returns the same task projections
- [ ] Post-merge: confirm file uploads in the dashboard session still return `type=text` or `type=image` for existing supported extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)