### PR TITLE
fix(tests): anchor invariant mtimes to mocked Houston time

### DIFF
--- a/tests/unit/test_proactive_pipeline_invariants.py
+++ b/tests/unit/test_proactive_pipeline_invariants.py
@@ -136,7 +136,9 @@ def test_morning_briefing_stale_emits_warn(tmp_path: Path, monkeypatch) -> None:
     target = base / "autonomous-briefings" / today_dt.strftime("%Y-%m-%d") / "DAILY_BRIEFING.md"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("# stale")
-    six_hours_ago = time.time() - 6 * 3600
+    # Anchor mtime to the mocked "now" so the freshness math doesn't depend
+    # on the real wall clock at test-run time.
+    six_hours_ago = today_dt.timestamp() - 6 * 3600
     os.utime(target, (six_hours_ago, six_hours_ago))
     findings = run_invariants({"artifacts_dir": base})
     matches = _only(findings, "morning_briefing_freshness")
@@ -232,13 +234,16 @@ def test_hn_fresh_snapshot_emits_nothing(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_hn_old_snapshot_emits_warn(tmp_path: Path, monkeypatch) -> None:
-    _set_now(monkeypatch, datetime(2026, 5, 19, 14, 0, tzinfo=HOUSTON))
+    fake_now = datetime(2026, 5, 19, 14, 0, tzinfo=HOUSTON)
+    _set_now(monkeypatch, fake_now)
     base = tmp_path / "artifacts"
     snaps = base / "hackernews" / "snapshots"
     snaps.mkdir(parents=True)
     f = snaps / "20260519100000.json"
     f.write_text("{}")
-    ninety_min_ago = time.time() - 90 * 60
+    # Anchor mtime to the mocked "now" so the age math doesn't depend on
+    # the real wall clock at test-run time.
+    ninety_min_ago = fake_now.timestamp() - 90 * 60
     os.utime(f, (ninety_min_ago, ninety_min_ago))
     findings = run_invariants({"artifacts_dir": base})
     matches = _only(findings, "hackernews_snapshot_cadence")


### PR DESCRIPTION
## Summary
- `test_morning_briefing_stale_emits_warn` and `test_hn_old_snapshot_emits_warn` were comparing file mtimes (set with real `time.time()`) against an invariant that uses the mocked `_now_houston()` returning a fixed `2026-05-19` datetime. As real wall-clock time drifts away from May 19 2026 (or even moves later in the day), the staleness offset collapses below the threshold and the tests stop firing — silently breaking PR Validate for every open PR.
- Fix: derive mtime from the mocked datetime (mirroring the pattern already used by the `_fresh_emits_nothing` siblings at lines 113 and 228).

## Root cause
Three open ci-failure issues (#381, #383, #385) all surfaced the same failure on three unrelated branches:
```
FAILED tests/unit/test_proactive_pipeline_invariants.py::test_morning_briefing_stale_emits_warn
- assert 0 == 1
```
Bug is clock-of-day flaky: PR runs early in the Houston day passed; runs late in the day failed.

## Test plan
- [x] `uv run pytest tests/unit/test_proactive_pipeline_invariants.py -x -q` — 21 passed
- [ ] PR Validate green
- [ ] Auto-merge fires (branch matches non-`codie|kevin|feature` allowlist)
- [ ] Deploy workflow green

🤖 Generated with [Claude Code](https://claude.com/claude-code)