### PR TITLE
fix(tests): anchor model-usage-tile test to today UTC, not 30m ago

### DIFF
--- a/tests/unit/test_mission_control_phase1a.py
+++ b/tests/unit/test_mission_control_phase1a.py
@@ -410,12 +410,21 @@ def test_model_usage_tile_green_with_no_rate_limits(activity_db):
 
 
 def test_model_usage_tile_yellow_with_a_few_rate_limits(activity_db):
+    # Anchor to noon UTC today so the inserted row is unambiguously
+    # "today" for the tile's `created_at > date('now')` SQL filter,
+    # regardless of when CI happens to run. Using a relative offset
+    # like `_iso_minutes_ago(30)` flakes around UTC midnight.
+    today_noon_utc = (
+        datetime.now(timezone.utc)
+        .replace(hour=12, minute=0, second=0, microsecond=0)
+        .strftime("%Y-%m-%d %H:%M:%S")
+    )
     for i in range(2):
         _insert_event(
             activity_db,
             id=f"rl_{i}",
             summary="Got 429 from upstream",
-            created_at=_iso_minutes_ago(30),
+            created_at=today_noon_utc,
         )
     state = ModelUsageTodayTile().compute_state(activity_db)
     assert state.color == COLOR_YELLOW


### PR DESCRIPTION
## Summary
Companion fix to #386. `test_model_usage_tile_yellow_with_a_few_rate_limits` inserted events at `_iso_minutes_ago(30)` against `ModelUsageTodayTile`'s SQL filter `WHERE created_at > date('now')`. When CI runs within ~30 minutes after UTC midnight, "30 minutes ago" is the previous UTC calendar day; the filter drops the rows and the tile goes green while the test expects yellow.

PR Validate for #384 (dependabot) hit this at 00:03 UTC tonight.

## Fix
Anchor the inserted timestamp to noon UTC of today's date so it always lands inside the SQL filter window regardless of CI hour.

## Test plan
- [x] `uv run pytest tests/unit/test_mission_control_phase1a.py -x -q` — 46 passed
- [ ] PR Validate green
- [ ] Auto-merge fires + deploy workflow green
- [ ] Unblocks PR #384 (dependabot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)