### PR TITLE
fix(watchdog): log skip reason + add manual email-test endpoint

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -16060,6 +16060,45 @@ async def ops_proactive_health(request: Request):
     return payload
 
 
+@app.post("/api/v1/ops/proactive_health/email_test")
+async def ops_proactive_health_email_test(
+    request: Request,
+    confirm: bool = False,
+    note: str = "",
+):
+    """Manual email-deliverability test for the proactive_health notifier.
+
+    Synthesizes a clearly-labeled [TEST] critical finding and sends it via
+    the same AgentMail path real critical findings use, bypassing the 6h
+    dedup. Lets the operator verify the email path is alive without waiting
+    for a real critical to flip.
+
+    Requires ``?confirm=true`` to prevent accidental triggering (e.g. a
+    misconfigured monitoring poll). Auth uses the same ops-token convention
+    as the other /api/v1/ops/* endpoints.
+    """
+    _require_ops_auth(request)
+    if not confirm:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Refusing to send test email without explicit confirmation. "
+                "Re-call with ?confirm=true to trigger."
+            ),
+        )
+
+    from universal_agent.services.proactive_health_notifier import (
+        send_test_critical_email,
+    )
+
+    agentmail_service = globals().get("_agentmail_service")
+    result = await send_test_critical_email(
+        agentmail_service=agentmail_service,
+        note=str(note or "").strip(),
+    )
+    return result
+
+
 class FactoryUpdateRequest(BaseModel):
     """Request to trigger a factory self-update via delegation bus."""
     target_factory_id: Optional[str] = None  # None = broadcast to all workers

--- a/src/universal_agent/services/proactive_health_notifier.py
+++ b/src/universal_agent/services/proactive_health_notifier.py
@@ -31,6 +31,41 @@ DEFAULT_COOLDOWN_SECONDS = 21600  # 6h
 KEVIN_EMAIL = "kevinjdragan@gmail.com"
 NOTIFICATION_KIND_PREFIX = "proactive_health_critical"
 
+# Module-level counter tracking consecutive skipped notifications per finding
+# fingerprint. Lets operators grep journalctl for "consecutive=N" to spot
+# long-running blocked email paths. Reset to 0 when a finding successfully
+# notifies (or when the finding stops appearing in payloads — implicitly,
+# since we only increment on observed skips).
+_skipped_consecutive: dict[str, int] = {}
+
+
+def _reset_skipped(fingerprint: str) -> None:
+    """Drop a fingerprint from the consecutive-skip counter (called on send)."""
+    _skipped_consecutive.pop(fingerprint, None)
+
+
+def _bump_skipped(fingerprint: str) -> int:
+    """Increment and return the consecutive-skip counter for a fingerprint."""
+    _skipped_consecutive[fingerprint] = _skipped_consecutive.get(fingerprint, 0) + 1
+    return _skipped_consecutive[fingerprint]
+
+
+def _resolve_agentmail_service_via_gateway() -> Optional[Any]:
+    """Lazy lookup against gateway_server._agentmail_service.
+
+    The heartbeat wires this in at tick time via getattr; if the gateway's
+    init hadn't completed at the first tick (race between
+    `_start_heartbeat_service()` and `_agentmail_service = AgentMailService(...)`)
+    the passed-in value is None. Re-resolving at notify time gives us one
+    more chance before logging the skip. Best-effort — never raises.
+    """
+    try:
+        import importlib
+        gs = importlib.import_module("universal_agent.gateway_server")
+        return getattr(gs, "_agentmail_service", None)
+    except Exception:  # noqa: BLE001
+        return None
+
 
 def _truthy(value: Optional[str], default: bool) -> bool:
     if value is None:
@@ -184,6 +219,10 @@ async def _notify_critical(
         logger.warning("proactive_health: send_email failed for %s", finding_id, exc_info=True)
         return False
 
+    # Email landed — reset the consecutive-skip counter for this fingerprint
+    # so the next blocked tick starts counting from 1.
+    _reset_skipped(finding_id)
+
     # Record for dedup tracking.
     try:
         add_notification_fn(
@@ -234,8 +273,39 @@ async def run_pre_flight_check(
 
     _write_sidecar(workspace_dir, payload)
 
+    # If email is disabled OR plumbing isn't ready, log explicitly per
+    # critical finding so the operator can grep for blocked-email evidence.
+    # This is the diagnostic fix for the 2026-05-20 race where the heartbeat
+    # fires before gateway_server._agentmail_service is initialized.
     if not _email_enabled() or agentmail_service is None or add_notification_fn is None:
-        return payload
+        # One last attempt to resolve _agentmail_service via gateway_server
+        # in case the wire-in raced with lifespan init.
+        if agentmail_service is None:
+            resolved = _resolve_agentmail_service_via_gateway()
+            if resolved is not None:
+                agentmail_service = resolved
+
+        if not _email_enabled() or agentmail_service is None or add_notification_fn is None:
+            criticals = _critical_invariants(payload)
+            for f in criticals:
+                fp = str(f.get("finding_id") or f.get("metric_key") or "unknown")
+                consecutive = _bump_skipped(fp)
+                if not _email_enabled():
+                    reason = "email_disabled (UA_HEARTBEAT_PROACTIVE_HEALTH_EMAIL_CRITICAL=0)"
+                elif agentmail_service is None and add_notification_fn is None:
+                    reason = "agentmail_service=None AND add_notification_fn=None"
+                elif agentmail_service is None:
+                    reason = "agentmail_service=None (gateway race or init pending)"
+                else:
+                    reason = "add_notification_fn=None"
+                logger.warning(
+                    "proactive_health: notification SKIPPED — reason=%s, "
+                    "fingerprint=%r, consecutive=%d",
+                    reason,
+                    fp,
+                    consecutive,
+                )
+            return payload
 
     cooldown = _cooldown_seconds()
     generated_at = str(payload.get("generated_at_utc") or datetime.now(timezone.utc).isoformat())
@@ -257,3 +327,65 @@ async def run_pre_flight_check(
     if sent_count:
         logger.info("proactive_health: emailed %d new critical finding(s)", sent_count)
     return payload
+
+
+async def send_test_critical_email(
+    *,
+    agentmail_service: Optional[_AgentMailLike],
+    note: str = "",
+) -> dict[str, Any]:
+    """Bypass-dedup synthetic critical-email send, for operator verification.
+
+    Used by the POST /api/v1/ops/proactive_health/email_test endpoint. Builds
+    a clearly-labeled fake finding, calls the real send path, returns a
+    structured result so the endpoint can report what happened.
+
+    Never raises — wraps the send in try/except and returns the exception
+    name in the dict on failure.
+    """
+    if agentmail_service is None:
+        agentmail_service = _resolve_agentmail_service_via_gateway()
+    if agentmail_service is None:
+        return {
+            "sent": False,
+            "reason": "agentmail_service=None (gateway init pending or disabled)",
+        }
+
+    ts = datetime.now(timezone.utc).isoformat()
+    finding = {
+        "finding_id": f"manual_test_{int(time.time())}",
+        "category": "proactive_health",
+        "severity": "critical",
+        "metric_key": "manual_test",
+        "title": "[TEST] Manual proactive_health email verification",
+        "recommendation": (
+            "[TEST] This is a synthetic notification triggered via "
+            "POST /api/v1/ops/proactive_health/email_test. If you received "
+            "this, the watchdog's email path is working end-to-end. "
+            + (f"Note: {note}" if note else "")
+        ),
+        "runbook_command": "(no runbook — this is a test ping)",
+        "observed_value": {"trigger": "manual_test_endpoint", "timestamp": ts},
+        "metadata": {"test": True},
+    }
+    subject, text = _format_email(finding, ts)
+    try:
+        await agentmail_service.send_email(
+            to=KEVIN_EMAIL,
+            subject=subject,
+            text=text,
+            force_send=True,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "proactive_health: test email failed (%s)", type(exc).__name__, exc_info=True
+        )
+        return {"sent": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+    logger.info("proactive_health: test email sent to %s", KEVIN_EMAIL)
+    return {
+        "sent": True,
+        "to": KEVIN_EMAIL,
+        "subject": subject,
+        "finding_id": finding["finding_id"],
+    }

--- a/tests/gateway/test_proactive_health_endpoint.py
+++ b/tests/gateway/test_proactive_health_endpoint.py
@@ -64,6 +64,15 @@ def client(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(
         gateway_server, "_csi_default_db_path", lambda: tmp_path / "csi.db"
     )
+    # Pin artifacts_dir to a tmp path so layer-2 file-based invariants
+    # (morning_briefing_freshness, nightly_wiki_daily_output, hackernews_
+    # snapshot_cadence) don't see the worktree's real artifacts tree —
+    # which has no today files in a sandbox, false-firing the warn probes.
+    from universal_agent.services import proactive_health as _ph
+    monkeypatch.setattr(
+        "universal_agent.artifacts.resolve_artifacts_dir",
+        lambda: tmp_path / "fake_artifacts",
+    )
     return TestClient(gateway_server.app), activity_db, tmp_path
 
 
@@ -145,3 +154,62 @@ def test_endpoint_requires_ops_auth_when_token_configured(client, monkeypatch):
     resp = test_client.get("/api/v1/ops/proactive_health")
     # _require_ops_auth raises HTTPException(401 or 403); accept either
     assert resp.status_code in (401, 403)
+
+
+# === Manual email-test endpoint (WS1, 2026-05-20) ===
+
+
+def test_email_test_endpoint_requires_confirm_param(client):
+    test_client, _activity_db, _tmp = client
+    resp = test_client.post("/api/v1/ops/proactive_health/email_test")
+    assert resp.status_code == 400
+    assert "confirm" in resp.text.lower()
+
+
+def test_email_test_endpoint_requires_ops_auth(client, monkeypatch):
+    test_client, _activity_db, _tmp = client
+    monkeypatch.setattr(gateway_server, "OPS_TOKEN", "secret")
+    resp = test_client.post(
+        "/api/v1/ops/proactive_health/email_test?confirm=true"
+    )
+    assert resp.status_code in (401, 403)
+
+
+def test_email_test_endpoint_returns_unsent_when_no_agentmail(client, monkeypatch):
+    """No agentmail wired in test fixture → endpoint returns sent=False
+    with a structured reason (does NOT 500)."""
+    test_client, _activity_db, _tmp = client
+    # The test fixture doesn't initialize _agentmail_service, so the
+    # endpoint should report "agentmail_service=None" rather than crash.
+    monkeypatch.setattr(gateway_server, "_agentmail_service", None, raising=False)
+    resp = test_client.post(
+        "/api/v1/ops/proactive_health/email_test?confirm=true"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sent"] is False
+    assert "agentmail_service=None" in data["reason"]
+
+
+def test_email_test_endpoint_sends_when_agentmail_present(client, monkeypatch):
+    """Stub the agentmail service and confirm endpoint calls send_email
+    with a [TEST]-prefixed payload addressed to Kevin."""
+    from unittest.mock import AsyncMock
+
+    test_client, _activity_db, _tmp = client
+    fake_mail = AsyncMock()
+    fake_mail.send_email = AsyncMock(return_value={"message_id": "abc"})
+    monkeypatch.setattr(gateway_server, "_agentmail_service", fake_mail, raising=False)
+
+    resp = test_client.post(
+        "/api/v1/ops/proactive_health/email_test?confirm=true&note=smoke"
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["sent"] is True
+    assert data["to"] == "kevinjdragan@gmail.com"
+    assert "[TEST]" in data["subject"]
+    fake_mail.send_email.assert_awaited_once()
+    call = fake_mail.send_email.call_args
+    assert "[TEST]" in call.kwargs["text"]
+    assert "smoke" in call.kwargs["text"]

--- a/tests/unit/test_proactive_health_notifier.py
+++ b/tests/unit/test_proactive_health_notifier.py
@@ -361,3 +361,186 @@ async def test_no_agentmail_service_still_writes_sidecar(tmp_path):
 
 def test_default_cooldown_is_6h():
     assert DEFAULT_COOLDOWN_SECONDS == 21600
+
+
+# === Skip-logging diagnostics (WS1, 2026-05-20) ===
+#
+# The 2026-05-19 production check revealed the notifier silently skipped emails
+# when `_agentmail_service` was None — no log line, no counter. These tests pin
+# the new diagnostic behavior so a future regression that re-silences the skip
+# path fails loudly.
+
+
+@pytest.fixture(autouse=True)
+def _reset_skip_counter():
+    """Each test starts with an empty consecutive-skip counter."""
+    notifier._skipped_consecutive.clear()
+    yield
+    notifier._skipped_consecutive.clear()
+
+
+@pytest.mark.asyncio
+async def test_skip_logs_warning_when_agentmail_is_none(
+    tmp_path, caplog, notifications_list, add_notification_fn
+):
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="universal_agent.services.proactive_health_notifier")
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=None,  # the production failure mode
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    skip_records = [r for r in warnings if "SKIPPED" in r.getMessage()]
+    assert len(skip_records) >= 1, f"expected a SKIPPED warning, got {[r.getMessage() for r in warnings]}"
+    msg = skip_records[0].getMessage()
+    assert "agentmail_service" in msg
+    assert "consecutive=1" in msg
+    # Sidecar still written even when email path blocked.
+    assert (tmp_path / "work_products" / "proactive_health_latest.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_skip_counter_increments_across_consecutive_calls(
+    tmp_path, notifications_list, add_notification_fn
+):
+    # Three consecutive blocked ticks should produce consecutive=1, 2, 3.
+    for _ in range(3):
+        await run_pre_flight_check(
+            workspace_dir=tmp_path,
+            payload_builder=_critical_payload,
+            agentmail_service=None,
+            notifications_list=notifications_list,
+            add_notification_fn=add_notification_fn,
+        )
+    # The fake fingerprint from _critical_payload defaults to
+    # "invariant:youtube_enrichment_coverage".
+    fp = "invariant:youtube_enrichment_coverage"
+    assert notifier._skipped_consecutive[fp] == 3
+
+
+@pytest.mark.asyncio
+async def test_skip_counter_resets_on_successful_send(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn
+):
+    # First call with no agentmail → bumps counter.
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=None,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    fp = "invariant:youtube_enrichment_coverage"
+    assert notifier._skipped_consecutive[fp] == 1
+
+    # Second call with working agentmail → email sends, counter resets.
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    fake_agentmail.send_email.assert_awaited_once()
+    assert fp not in notifier._skipped_consecutive
+
+
+@pytest.mark.asyncio
+async def test_lazy_fallback_resolves_agentmail_via_gateway(
+    tmp_path, monkeypatch, fake_agentmail, notifications_list, add_notification_fn
+):
+    """If the caller passed None but gateway_server._agentmail_service is set,
+    the notifier should fall through and use it instead of skipping."""
+    import sys
+    import types
+
+    fake_gateway = types.ModuleType("universal_agent.gateway_server")
+    fake_gateway._agentmail_service = fake_agentmail
+    monkeypatch.setitem(sys.modules, "universal_agent.gateway_server", fake_gateway)
+
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=None,  # passed None
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+    )
+    # Lazy fallback found the gateway-side instance and used it.
+    fake_agentmail.send_email.assert_awaited_once()
+    assert len(notifications_list) == 1
+
+
+# === Manual test endpoint helper (send_test_critical_email) ===
+
+
+@pytest.mark.asyncio
+async def test_send_test_critical_email_uses_agentmail_and_returns_sent(fake_agentmail):
+    from universal_agent.services.proactive_health_notifier import (
+        send_test_critical_email,
+    )
+
+    result = await send_test_critical_email(agentmail_service=fake_agentmail, note="ping")
+    assert result["sent"] is True
+    assert result["to"] == KEVIN_EMAIL
+    assert result["subject"].startswith("[Proactive Health CRITICAL]")
+    assert "[TEST]" in result["subject"]
+    fake_agentmail.send_email.assert_awaited_once()
+    call = fake_agentmail.send_email.call_args
+    assert "[TEST]" in call.kwargs["text"]
+    assert "ping" in call.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_test_critical_email_handles_send_failure(fake_agentmail):
+    from universal_agent.services.proactive_health_notifier import (
+        send_test_critical_email,
+    )
+
+    fake_agentmail.send_email.side_effect = RuntimeError("smtp down")
+    result = await send_test_critical_email(agentmail_service=fake_agentmail)
+    assert result["sent"] is False
+    assert "smtp down" in result["reason"]
+
+
+@pytest.mark.asyncio
+async def test_send_test_critical_email_falls_back_via_gateway(
+    monkeypatch, fake_agentmail
+):
+    """If no agentmail passed and gateway has it, fall back automatically."""
+    import sys
+    import types
+
+    from universal_agent.services.proactive_health_notifier import (
+        send_test_critical_email,
+    )
+
+    fake_gateway = types.ModuleType("universal_agent.gateway_server")
+    fake_gateway._agentmail_service = fake_agentmail
+    monkeypatch.setitem(sys.modules, "universal_agent.gateway_server", fake_gateway)
+
+    result = await send_test_critical_email(agentmail_service=None)
+    assert result["sent"] is True
+    fake_agentmail.send_email.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_test_critical_email_returns_unsent_when_no_agentmail(monkeypatch):
+    """No injected agentmail AND no gateway fallback → returns sent=False with reason."""
+    import sys
+    import types
+
+    from universal_agent.services.proactive_health_notifier import (
+        send_test_critical_email,
+    )
+
+    fake_gateway = types.ModuleType("universal_agent.gateway_server")
+    fake_gateway._agentmail_service = None
+    monkeypatch.setitem(sys.modules, "universal_agent.gateway_server", fake_gateway)
+
+    result = await send_test_critical_email(agentmail_service=None)
+    assert result["sent"] is False
+    assert "agentmail_service=None" in result["reason"]


### PR DESCRIPTION
## Summary
WS1 from the [watchdog close-out plan](https://github.com/Kjdragan/universal_agent/blob/main/lrepos/universal_agent/plans/create-a-plan-to-gentle-pebble.md). Makes the proactive_health notifier observable when the email path is blocked, and adds a manual test endpoint so the operator can verify deliverability without waiting for a real critical.

## Problem
2026-05-19 live verification: `/api/v1/ops/proactive_health` returned `overall_status: critical` with `youtube_enrichment_coverage` at 20.6% coverage, yet Kevin received zero emails. The notifier silently skipped all sends with no log line.

**Root cause** (confirmed via Explore agent trace): race in `gateway_server.py:lifespan`:
- Line 14339: `await _start_heartbeat_service()` runs **before**
- Line 14765: `_agentmail_service = AgentMailService(...)`
- Line 14773: `_agentmail_service.startup()` spawned as background task

The notifier wire-in does `getattr(gateway_server, "_agentmail_service", None)`; on the first heartbeat tick the attribute is still `None`, and the notifier's silent early-return swallows all evidence.

## Fix (Option A per plan-agent review)
Tolerant logging — NOT a lifespan re-order (high-risk per CLAUDE.md), NOT a poll-and-wait helper (over-engineered before evidence). Get visibility first, then escalate to WS1.5 only if needed.

### `src/universal_agent/services/proactive_health_notifier.py`
- New `_skipped_consecutive` counter keyed by finding fingerprint
- New `_resolve_agentmail_service_via_gateway()` lazy fallback — one more chance to find `_agentmail_service` via module re-import before logging the skip
- Replaced silent early-return with WARNING log naming reason (`email_disabled`, `agentmail_service=None (gateway race or init pending)`, or `add_notification_fn=None`) + fingerprint + consecutive-skip count
- Counter resets on successful send so next blocked tick starts from 1
- New public `send_test_critical_email(agentmail_service, note)` synthesizes a `[TEST]`-prefixed fake critical finding, bypasses dedup, calls the real send path

### `src/universal_agent/gateway_server.py`
- New endpoint `POST /api/v1/ops/proactive_health/email_test?confirm=true&note=...`
- Requires `_require_ops_auth` + explicit `confirm=true` so a misconfigured monitor can't accidentally trigger
- Returns `{sent, reason}` JSON; never 500s

## Test coverage
**8 new notifier tests + 4 new endpoint tests + 1 fixture fix:**
- skip-path logs WARNING when agentmail is None
- consecutive counter increments and resets correctly
- lazy gateway fallback resolves agentmail when caller passed None
- `send_test_critical_email` happy + failure + fallback + unavailable paths
- `/email_test` requires `?confirm=true` and ops auth
- `/email_test` reports `sent=false` cleanly when agentmail unavailable
- `/email_test` sends with `[TEST]` payload and returns full result

**Pre-existing test fixture fix**: `test_proactive_health_endpoint.py` was false-firing the empty-state test because the new layer-2 file-based invariants (`morning_briefing_freshness`, `nightly_wiki_daily_output`) probe the real artifacts tree. Added monkeypatch of `resolve_artifacts_dir` to a tmp path.

Full proactive-health + dormancy suite: **87/87 pass**. Ruff clean on all changed files.

## Verification (post-deploy)
1. `ssh ua@uaonvps 'journalctl -u universal-agent-gateway --since "30 min ago" | grep proactive_health'` — expect either `"emailed N new critical finding(s)"` OR `"notification SKIPPED — reason=... consecutive=N"`. Either outcome is **actionable visibility** vs. the prior silence.
2. `curl -X POST -H "Authorization: Bearer $UA_OPS_TOKEN" "http://127.0.0.1:8002/api/v1/ops/proactive_health/email_test?confirm=true&note=verify"` → expect `{"sent": true, ...}` and a `[TEST]` email at kevinjdragan@gmail.com.
3. Wait one heartbeat cycle; check inbox for real `[Proactive Health CRITICAL] YouTube enrichment coverage...` email OR a WARN log line. If WARN persists, escalate to WS1.5 (lifespan re-order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)