### PR TITLE
fix(digest-reminder): prefer UA_OPERATOR_TELEGRAM_BOT_TOKEN for ping + dismissal

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -10018,7 +10018,16 @@ async def _digest_reminder_dismissal_sweep(stop_event: asyncio.Event) -> None:
         try:
             due = await asyncio.to_thread(_claim_due_telegram_reminders)
             if due:
-                token = (os.getenv("TELEGRAM_BOT_TOKEN") or "").strip()
+                # Same fallback chain as digest_delivery_reminder._resolve_bot_token:
+                # UA_OPERATOR_TELEGRAM_BOT_TOKEN takes priority because the
+                # generic TELEGRAM_BOT_TOKEN (@ClaudeKevBot) is not a member of
+                # the "UA Tutorial Feed" channel where digest reminders land.
+                # Without this fallback the deleteMessage will fail with 400
+                # "chat not found" and the reminders will persist past TTL.
+                token = (
+                    (os.getenv("UA_OPERATOR_TELEGRAM_BOT_TOKEN") or "").strip()
+                    or (os.getenv("TELEGRAM_BOT_TOKEN") or "").strip()
+                )
                 if not token:
                     # Token missing: mark rows as skipped so we don't retry forever.
                     for row_id, _chat, _msg in due:

--- a/src/universal_agent/services/digest_delivery_reminder.py
+++ b/src/universal_agent/services/digest_delivery_reminder.py
@@ -116,6 +116,30 @@ def _resolve_chat_id(override: Optional[str | int]) -> Optional[str]:
     return None
 
 
+def _resolve_bot_token(override: Optional[str]) -> Optional[str]:
+    """Resolve the bot token to use for sending the digest reminder.
+
+    Priority: explicit override > UA_OPERATOR_TELEGRAM_BOT_TOKEN > TELEGRAM_BOT_TOKEN.
+
+    Background: the generic ``TELEGRAM_BOT_TOKEN`` (``@ClaudeKevBot``) is not
+    a member of the operator's "UA Tutorial Feed" channel where the digest
+    reminders are intended to land — sending against that bot returns HTTP
+    400 "chat not found".  ``@KDUniversalAgent_bot`` (the CSI Reddit/RSS
+    bot) IS a member and is the correct sender for operator-facing channel
+    pings.  Surfacing the choice via ``UA_OPERATOR_TELEGRAM_BOT_TOKEN``
+    keeps the chat<->bot pairing explicit and reversible without code edits.
+    """
+    if override:
+        text = str(override).strip()
+        if text:
+            return text
+    for env_name in ("UA_OPERATOR_TELEGRAM_BOT_TOKEN", "TELEGRAM_BOT_TOKEN"):
+        raw = (os.getenv(env_name) or "").strip()
+        if raw:
+            return raw
+    return None
+
+
 def _format_houston(dt_utc: datetime) -> str:
     """e.g. '6:14 AM Tue May 19 CDT' — Houston-local, never UTC."""
     local = dt_utc.astimezone(HOUSTON_TZ)
@@ -281,7 +305,7 @@ def send_digest_delivery_reminder(
         try:
             ok, payload, err = telegram_send_with_response_sync(
                 chat_id, text,
-                bot_token=bot_token,
+                bot_token=_resolve_bot_token(bot_token),
                 disable_preview=True,
             )
             telegram_ok = bool(ok)


### PR DESCRIPTION
## Summary

Follow-up to PR #391. Production smoke of the digest delivery reminder against the operator's "UA Tutorial Feed" channel returned HTTP 400 "chat not found": the generic \`TELEGRAM_BOT_TOKEN\` (\`@ClaudeKevBot\`) is not a member of that channel. \`@KDUniversalAgent_bot\` (the bot used by CSI Reddit/RSS, already a member of the channel) succeeds.

Fix is surgical — make the bot-token resolver in the reminder service AND the dismissal sweep prefer an operator-specific env var.

## Changes

- \`digest_delivery_reminder._resolve_bot_token\` (new helper): priority is \`override > UA_OPERATOR_TELEGRAM_BOT_TOKEN > TELEGRAM_BOT_TOKEN\`. Threaded into the existing \`telegram_send_with_response_sync\` call.
- \`gateway_server._digest_reminder_dismissal_sweep\`: same fallback chain so the 90-min \`deleteMessage\` uses whichever bot actually has access to the chat. Without this the dismissal would also 400 and reminders would persist past TTL.
- Both code paths still treat token absence as graceful no-op (\`skipped_no_token\` for the dismissal sweep).
- No test changes needed — existing fixtures stub the \`bot_token\` parameter end-to-end. 15/15 reminder tests still pass.

## Infisical side (already applied to production env, out of band)

\`\`\`
UA_OPERATOR_TELEGRAM_BOT_TOKEN = <copy of CSI_RSS_TELEGRAM_BOT_TOKEN value>
\`\`\`

\`@KDUniversalAgent_bot\` is already a member of the "UA Tutorial Feed" channel (chat_id ending in 4010), so the digest ping path is functional immediately after this PR deploys.

## End-to-end after this lands

Tomorrow's 6 AM Houston digest cron will:
1. Send the digest email via AgentMail (as before).
2. Send a Telegram ping via \`@KDUniversalAgent_bot\` to the UA Tutorial Feed channel.
3. After 90 min, the gateway sweep calls \`deleteMessage\` with the same bot token, cleaning the message up.

## Coordination

Sits on top of #391 (delivery reminders + TTL infrastructure). Both must be live for the end-to-end Telegram path to work. Auto-merge eligible.

## Test plan

- [ ] CI green + auto-merge fires
- [ ] Deploy lands on VPS
- [ ] Operator-side: run the same smoke that returned 400 today — should now succeed
- [ ] Tomorrow's 6 AM Houston digest cron: Telegram message appears in the channel
- [ ] 90 min after the message appears: it deletes itself