### PR TITLE
feat(email): outbound subject-tag system — [ACTION/KIND] inbox triage

### DIFF
--- a/docs/03_Operations/82_Email_Architecture_And_AgentMail_Source_Of_Truth_2026-03-06.md
+++ b/docs/03_Operations/82_Email_Architecture_And_AgentMail_Source_Of_Truth_2026-03-06.md
@@ -1,6 +1,6 @@
 # Email Architecture and AgentMail Source of Truth
 
-> **Last updated: 2026-05-01** — added pre-triage deterministic security screening (injection scanner, unknown @agentmail.to auto-quarantine, sender reputation tracking with auto-escalation) so malicious content is blocked before reaching the triage LLM.
+> **Last updated: 2026-05-19** — added outbound subject-tag system (`[ACTION/KIND] subject` + body banner) so the operator can eyeball-triage their inbox. See `Outbound Subject Tagging` section. Prior: 2026-05-01 added pre-triage deterministic security screening (injection scanner, unknown @agentmail.to auto-quarantine, sender reputation tracking with auto-escalation).
 
 ## Purpose
 
@@ -527,6 +527,101 @@ To bypass this limitation, we provide specialized Python wrappers in the local t
 - `agentmail_reply_with_local_attachments`
 
 These bridge tools accept an `attachment_paths` array containing absolute paths to the local files instead of requiring Base64 conversion via `prepare_agentmail_attachment`. The backend securely loads the files into memory and sends them directly to the programmatic AgentMail HTTP API.
+
+---
+
+## Outbound Subject Tagging
+
+> **Status:** Active since 2026-05-19. Lives in `src/universal_agent/services/email_tags.py`. Opt-in per callsite — un-tagged sends remain backward compatible.
+
+### Motivation
+
+The operator gets a high volume of outbound email from UA principals (Simone, Codie, Atlas, dispatch sweep, ClaudeDevs intel, deploy/CI watchers, daily digests, weekly preference reports). Without a tag scheme, eyeball-triaging the inbox requires opening each message to figure out: is this actionable, FYI, an incident, a Codie suggestion, or a digest?
+
+### The 2-Dimension Scheme
+
+Two closed enums (intentionally small, no improvising):
+
+| Dimension | Values | Meaning |
+|---|---|---|
+| `ActionTag` (4) | `FYI`, `ACTION`, `DECISION`, `QUESTION` | What response, if any, is required |
+| `KindTag` (7) | `DIGEST`, `TUTORIAL`, `PROACTIVE`, `INCIDENT`, `CRON`, `SYSTEM`, `DEPLOY` | What kind of content the email contains |
+
+4 × 7 = 28 combos. Adding a new value requires editing the enum (and one PR review pass) — never improvise free-form tag strings.
+
+### Subject Format
+
+```
+[<ACTION>/<KIND>] <existing subject>
+```
+
+Examples:
+- `[FYI/DIGEST] Daily YouTube Digest: Monday`
+- `[DECISION/PROACTIVE] Codie proposes consolidating import ordering across 3 services`
+- `[ACTION/INCIDENT] CI failed on PR #364`
+- `[FYI/DEPLOY] Production deploy succeeded — sha=6f2e321f`
+- `[ACTION/DEPLOY] Production deploy FAILED — see workflow run 26052...`
+- `[QUESTION/PROACTIVE] Which import-ordering convention should I follow?`
+
+### Body Banner
+
+When tags are set, the wrapper injects a banner at the top of both the HTML and plaintext body:
+
+```
+Tags: ACTION/INCIDENT
+Source: proactive_health_notifier
+Related: finding_id=watchdog.heartbeat.idle
+Time: 2026-05-19T15:42:00-05:00
+---
+```
+
+`Related:` is optional context the caller passes (PR numbers, ticket IDs, file paths, artifact IDs). Time is Houston-local for operator readability.
+
+### Wrapper API
+
+`AgentMailService.send_email()` accepts four new optional kwargs:
+
+| Kwarg | Type | Notes |
+|---|---|---|
+| `action` | `ActionTag \| str \| None` | Required to enable tagging |
+| `kind` | `KindTag \| str \| None` | Required to enable tagging |
+| `source` | `str \| None` | Short producer identifier rendered in the banner |
+| `related` | `list[str] \| str \| None` | Optional related references |
+
+Tagging is gated on `action is not None AND kind is not None`. Partial tags are ignored (treated as un-tagged). Invalid enum strings raise `ValueError` at the call. The wrapper is **idempotent** — a subject that already starts with `[X/Y]` is left alone (catches accidental re-sends or replies).
+
+### Migrated Callsites (v1)
+
+| File | Tag | Source |
+|---|---|---|
+| `scripts/youtube_daily_digest.py` | `FYI/DIGEST` | `youtube_daily_digest cron` |
+| `services/intelligence_reporter.py::send_daily_digest` | `FYI/DIGEST` | `intelligence_reporter.send_daily_digest` |
+| `services/intelligence_reporter.py::send_weekly_preference_report` | `FYI/DIGEST` | `intelligence_reporter.send_weekly_preference_report` |
+| `services/intelligence_reporter.py::send_review_email` | `DECISION/PROACTIVE` | `intelligence_reporter.send_review_email` |
+| `services/proactive_health_notifier.py` (live alerts) | `ACTION/INCIDENT` | `proactive_health_notifier` |
+| `services/proactive_health_notifier.py` (test endpoint) | `FYI/INCIDENT` | `proactive_health_notifier (manual test)` |
+
+Less-frequent callsites (`hooks.py`, `cli_io.py`, `dependency_upgrade.py`, etc.) remain un-tagged for now and continue to work unchanged. Migration is mechanical — pass `action=`, `kind=`, `source=` to the existing `send_email` call.
+
+### Recommended Gmail Filters
+
+These six filters auto-apply a color label per KIND so the inbox segments visually. Paste into Gmail Settings → Filters → Create new:
+
+| Search query | Label (color) |
+|---|---|
+| `subject:[FYI/DIGEST] OR subject:[ACTION/DIGEST]` | `UA/Digest` (blue) |
+| `subject:[FYI/INCIDENT] OR subject:[ACTION/INCIDENT]` | `UA/Incident` (red) |
+| `subject:[DECISION/PROACTIVE] OR subject:[QUESTION/PROACTIVE] OR subject:[ACTION/PROACTIVE]` | `UA/Proactive` (orange) |
+| `subject:[ACTION/DEPLOY] OR subject:[FYI/DEPLOY]` | `UA/Deploy` (purple) |
+| `subject:[FYI/CRON] OR subject:[ACTION/CRON]` | `UA/Cron` (gray) |
+| `subject:[FYI/SYSTEM] OR subject:[ACTION/SYSTEM] OR subject:[FYI/TUTORIAL]` | `UA/System` (green) |
+
+### Implementation Files
+
+- `src/universal_agent/services/email_tags.py` — enums, `format_tagged_subject`, `format_body_header`.
+- `src/universal_agent/services/agentmail_service.py::send_email` — wrapper that prefixes the subject and prepends the banner when both `action` and `kind` are supplied.
+- `tests/unit/test_email_tags.py` — enum + helper unit tests.
+- `tests/unit/test_agentmail_send_tagged.py` — integration tests covering both the tagged and backward-compat paths.
 
 ---
 

--- a/docs/Documentation_Status.md
+++ b/docs/Documentation_Status.md
@@ -74,7 +74,7 @@ These are the authoritative references for each subsystem. When any other docume
 |---|---------|
 | 07 | WebSocket Architecture (`02_Flows/`) |
 | 08 | Auth & Session Security (`02_Flows/`) |
-| 82 | Email / AgentMail — includes pre-triage deterministic security screening (injection scanner, @agentmail.to auto-quarantine, sender reputation auto-escalation), multi-inbox VP routing (Cody/Atlas direct engagement), CC protocol, FYI suppression, trusted non-action reply auto-completion, stale failed queue auto-cancellation |
+| 82 | Email / AgentMail — includes outbound subject-tag system (`[ACTION/KIND]` + body banner, 2026-05-19), pre-triage deterministic security screening (injection scanner, @agentmail.to auto-quarantine, sender reputation auto-escalation), multi-inbox VP routing (Cody/Atlas direct engagement), CC protocol, FYI suppression, trusted non-action reply auto-completion, stale failed queue auto-cancellation |
 | 83 | Webhooks |
 | 85 | Infisical Secrets |
 | 86 | Residential Proxy — dual-provider architecture (Webshare + DataImpulse), `PROXY_PROVIDER` selection, approved paths, YouTube guardrails |

--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -49,6 +49,7 @@ from universal_agent.services.agentmail_service import AgentMailService
 from universal_agent.services.digest_delivery_reminder import (
     send_digest_delivery_reminder,
 )
+from universal_agent.services.email_tags import ActionTag, KindTag
 from universal_agent.services.youtube_playlist_manager import (
     YouTubeAPIError,
     YouTubeOAuthError,
@@ -1760,6 +1761,10 @@ def process_daily_digest(
                     text=full_content,
                     force_send=True,
                     require_approval=False,
+                    action=ActionTag.FYI,
+                    kind=KindTag.DIGEST,
+                    source="youtube_daily_digest cron",
+                    related=[f"day={day_name}", f"date={date_str}"],
                 )
             finally:
                 await mail.shutdown()

--- a/src/universal_agent/services/agentmail_service.py
+++ b/src/universal_agent/services/agentmail_service.py
@@ -36,6 +36,12 @@ from typing import Any, Callable, Coroutine, Optional
 import uuid
 
 from universal_agent.durable.db import connect_runtime_db, get_activity_db_path
+from universal_agent.services.email_tags import (
+    ActionTag,
+    KindTag,
+    format_body_header,
+    format_tagged_subject,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -647,6 +653,10 @@ class AgentMailService:
         labels: Optional[list[str]] = None,
         force_send: bool = False,
         require_approval: bool = False,
+        action: ActionTag | str | None = None,
+        kind: KindTag | str | None = None,
+        source: str | None = None,
+        related: list[str] | str | None = None,
     ) -> dict[str, Any]:
         """Send an email or create a draft when explicit approval is required.
 
@@ -659,12 +669,39 @@ class AgentMailService:
             labels: Optional labels to apply.
             force_send: Legacy/direct-send override.
             require_approval: When true, create a review draft instead of sending immediately.
+            action: Optional ActionTag (FYI / ACTION / DECISION / QUESTION). When
+                provided together with ``kind``, the subject is prefixed
+                ``[ACTION/KIND]`` and a banner is injected at the top of the
+                body. Callsites that do not pass both action+kind continue to
+                send uncategorized — the prefix/banner are pure additions.
+            kind: Optional KindTag (DIGEST / TUTORIAL / PROACTIVE / INCIDENT /
+                CRON / SYSTEM / DEPLOY).
+            source: Optional short string identifying the producer
+                (e.g. ``"youtube_daily_digest cron"``); rendered in the banner.
+            related: Optional related references (PR numbers, ticket IDs,
+                file paths). May be a list or a single pre-joined string.
 
         Returns:
             Dict with message_id/draft_id and status.
 
         """
         self._assert_ready()
+
+        # Apply tags BEFORE the draft-vs-send branching so both paths get
+        # the same prefixed subject and banner. Tagging is opt-in: both
+        # action AND kind must be supplied — otherwise leave the caller's
+        # subject/body untouched (backward compatible).
+        if action is not None and kind is not None:
+            subject = format_tagged_subject(action, kind, subject)
+            html_banner, text_banner = format_body_header(
+                action, kind, source or "", related=related,
+            )
+            text = text_banner + (text or "")
+            if html:
+                html = html_banner + html
+            else:
+                # If the caller only sent plaintext, keep it that way.
+                pass
 
         if require_approval:
             return await self._create_draft(

--- a/src/universal_agent/services/email_tags.py
+++ b/src/universal_agent/services/email_tags.py
@@ -1,0 +1,275 @@
+"""Bounded tag vocabulary for outbound UA email subjects + body banners.
+
+This module exposes a closed 2-dimension tag scheme so the operator can
+eyeball-triage their inbox without opening individual messages:
+
+    [<ACTION>/<KIND>] <existing subject>
+
+`ActionTag` captures *what response, if any, is required* (FYI vs. ACTION
+vs. DECISION vs. QUESTION). `KindTag` captures *what kind of message it is*
+(digest, tutorial, proactive proposal, incident, cron, system, deploy).
+
+The enum is intentionally closed:
+
+- 4 ActionTag values × 7 KindTag values = 28 combos total.
+- Callers must use the enum members; typos fail at import time.
+- If a brand-new source comes online, it either picks the closest existing
+  KIND or **one** entry is appended to `KindTag` — never improvise free-form
+  strings, that defeats the whole point of the scheme.
+
+Public API:
+    ActionTag                 — closed Enum (4 values)
+    KindTag                   — closed Enum (7 values)
+    format_tagged_subject     — idempotent subject prefixer
+    format_body_header        — (html, text) banner pair
+    SUBJECT_TAG_RE            — regex matching an already-tagged subject
+
+Houston time is used in any timestamp rendered in the banner so the operator
+sees their local clock without a mental conversion.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+import re
+from typing import Iterable, Optional
+
+try:  # Python 3.9+ has zoneinfo in stdlib
+    from zoneinfo import ZoneInfo  # type: ignore
+except ImportError:  # pragma: no cover — repo requires modern Python
+    ZoneInfo = None  # type: ignore
+
+
+__all__ = [
+    "ActionTag",
+    "KindTag",
+    "format_tagged_subject",
+    "format_body_header",
+    "SUBJECT_TAG_RE",
+]
+
+
+# ---------------------------------------------------------------------------
+# Closed enums
+# ---------------------------------------------------------------------------
+
+
+class ActionTag(str, Enum):
+    """What response, if any, the operator needs to take.
+
+    Values are intentionally short so the inbox preview keeps room for the
+    underlying subject. The class inherits from ``str`` so members serialize
+    cleanly via ``str(ActionTag.FYI)`` and compare equal to their bare value
+    in tests.
+    """
+
+    FYI = "FYI"
+    ACTION = "ACTION"
+    DECISION = "DECISION"
+    QUESTION = "QUESTION"
+
+
+class KindTag(str, Enum):
+    """What kind of content the email contains."""
+
+    DIGEST = "DIGEST"
+    TUTORIAL = "TUTORIAL"
+    PROACTIVE = "PROACTIVE"
+    INCIDENT = "INCIDENT"
+    CRON = "CRON"
+    SYSTEM = "SYSTEM"
+    DEPLOY = "DEPLOY"
+
+
+# Pre-compiled regex matching `[ACTION/KIND]` at the start of a subject.
+# Tolerates any of the enum values; if you add a new member, the regex
+# automatically picks it up because it's built from the enum at import time.
+_ACTION_ALTERNATION = "|".join(a.value for a in ActionTag)
+_KIND_ALTERNATION = "|".join(k.value for k in KindTag)
+SUBJECT_TAG_RE = re.compile(
+    rf"^\[\s*({_ACTION_ALTERNATION})\s*/\s*({_KIND_ALTERNATION})\s*\]\s*",
+    re.IGNORECASE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Subject prefix
+# ---------------------------------------------------------------------------
+
+
+def _coerce_action(action: ActionTag | str) -> ActionTag:
+    """Normalize an ``ActionTag`` or its string value; raise on bad input."""
+    if isinstance(action, ActionTag):
+        return action
+    if isinstance(action, str):
+        try:
+            return ActionTag(action.upper().strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"unknown ActionTag: {action!r}; valid: {[a.value for a in ActionTag]}"
+            ) from exc
+    raise TypeError(f"action must be ActionTag or str, got {type(action).__name__}")
+
+
+def _coerce_kind(kind: KindTag | str) -> KindTag:
+    """Normalize a ``KindTag`` or its string value; raise on bad input."""
+    if isinstance(kind, KindTag):
+        return kind
+    if isinstance(kind, str):
+        try:
+            return KindTag(kind.upper().strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"unknown KindTag: {kind!r}; valid: {[k.value for k in KindTag]}"
+            ) from exc
+    raise TypeError(f"kind must be KindTag or str, got {type(kind).__name__}")
+
+
+def format_tagged_subject(
+    action: ActionTag | str,
+    kind: KindTag | str,
+    subject: str,
+) -> str:
+    """Prepend ``[ACTION/KIND]`` to *subject*; idempotent.
+
+    Re-tagging an already-tagged subject is a no-op — the original tag is
+    preserved, even if it differs from what the caller passed. This protects
+    against accidental double-tagging when subjects flow through multiple
+    layers (e.g., reply chains, re-sends, forwarded digests).
+
+    Args:
+        action: ActionTag enum member or matching string value.
+        kind: KindTag enum member or matching string value.
+        subject: The pre-existing subject line. ``None`` is normalized to
+            an empty string before prefixing.
+
+    Returns:
+        ``"[ACTION/KIND] subject"`` — or the original subject untouched
+        if it already begins with a valid tag.
+
+    Raises:
+        ValueError: action or kind is not a recognized enum value.
+    """
+    action_enum = _coerce_action(action)
+    kind_enum = _coerce_kind(kind)
+    raw = "" if subject is None else str(subject)
+
+    if SUBJECT_TAG_RE.match(raw):
+        # Already tagged — leave it alone. The first tagger wins.
+        return raw
+
+    return f"[{action_enum.value}/{kind_enum.value}] {raw}".rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Body banner
+# ---------------------------------------------------------------------------
+
+
+def _houston_now_iso() -> str:
+    """Return the current time in America/Chicago as an ISO-ish string."""
+    if ZoneInfo is None:  # pragma: no cover
+        return datetime.now().isoformat(timespec="seconds")
+    return (
+        datetime.now(ZoneInfo("America/Chicago"))
+        .replace(microsecond=0)
+        .isoformat()
+    )
+
+
+def _related_to_str(related: Optional[Iterable[str]]) -> str:
+    """Render a Related: line value from a list or string."""
+    if related is None:
+        return ""
+    if isinstance(related, str):
+        return related.strip()
+    items = [str(r).strip() for r in related if str(r).strip()]
+    return ", ".join(items)
+
+
+def format_body_header(
+    action: ActionTag | str,
+    kind: KindTag | str,
+    source: str,
+    related: Optional[Iterable[str] | str] = None,
+    *,
+    include_timestamp: bool = True,
+) -> tuple[str, str]:
+    """Build the (html, text) banner pair injected at the top of the body.
+
+    Layout (plaintext)::
+
+        Tags: ACTION/KIND
+        Source: <source>
+        Related: <related-1>, <related-2>      (omitted if no related items)
+        Time: 2026-05-19T15:42:00-05:00         (omitted if include_timestamp=False)
+        ---
+
+    Args:
+        action: ActionTag enum or string value.
+        kind: KindTag enum or string value.
+        source: Free-form short string identifying the producer
+            (e.g. ``"youtube_daily_digest cron"``,
+            ``"ci-failure-watcher (cron / GitHub Actions)"``).
+        related: Optional list of related references (PR numbers, ticket
+            IDs, file paths). May also be a single pre-joined string.
+        include_timestamp: Include the Houston-time stamp line. Tests can
+            disable this to get a deterministic banner.
+
+    Returns:
+        A ``(html, text)`` tuple. Either can be concatenated with an
+        existing body — neither contains a trailing blank line beyond the
+        ``---`` separator.
+
+    Raises:
+        ValueError: action or kind is not a recognized enum value.
+    """
+    action_enum = _coerce_action(action)
+    kind_enum = _coerce_kind(kind)
+    src = (source or "").strip()
+    rel = _related_to_str(related)
+    ts = _houston_now_iso() if include_timestamp else ""
+
+    # ---- plaintext ----
+    lines = [f"Tags: {action_enum.value}/{kind_enum.value}"]
+    if src:
+        lines.append(f"Source: {src}")
+    if rel:
+        lines.append(f"Related: {rel}")
+    if ts:
+        lines.append(f"Time: {ts}")
+    lines.append("---")
+    text_banner = "\n".join(lines) + "\n"
+
+    # ---- html ----
+    # Lightweight monospace block — no external CSS dependency, no scripts.
+    # Style mirrors the GitHub PR-checklist look so it doesn't clash with
+    # rich markdown bodies underneath.
+    html_lines = [
+        '<div style="font-family: -apple-system, BlinkMacSystemFont, '
+        '\'Segoe UI\', sans-serif; font-size: 13px; color: #444; '
+        "background: #f6f8fa; border-left: 4px solid #0969da; "
+        'padding: 10px 14px; margin: 0 0 16px 0; border-radius: 4px;">',
+        f'  <div><strong>Tags:</strong> {action_enum.value}/{kind_enum.value}</div>',
+    ]
+    if src:
+        html_lines.append(f'  <div><strong>Source:</strong> {_html_escape(src)}</div>')
+    if rel:
+        html_lines.append(f'  <div><strong>Related:</strong> {_html_escape(rel)}</div>')
+    if ts:
+        html_lines.append(f'  <div><strong>Time:</strong> {_html_escape(ts)}</div>')
+    html_lines.append("</div>")
+    html_banner = "\n".join(html_lines) + "\n"
+
+    return html_banner, text_banner
+
+
+def _html_escape(value: str) -> str:
+    """Minimal HTML escape — avoids importing the whole html module."""
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )

--- a/src/universal_agent/services/intelligence_reporter.py
+++ b/src/universal_agent/services/intelligence_reporter.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from universal_agent import task_hub
 from universal_agent.services import proactive_artifacts
+from universal_agent.services.email_tags import ActionTag, KindTag
 from universal_agent.services.proactive_preferences import (
     build_weekly_preference_report,
     score_artifact_for_review,
@@ -157,6 +158,10 @@ class IntelligenceReporter:
             html=payload.html,
             force_send=True,
             require_approval=False,
+            action=ActionTag.DECISION,
+            kind=KindTag.PROACTIVE,
+            source="intelligence_reporter.send_review_email",
+            related=[f"artifact_id={artifact_id}"],
         )
         proactive_artifacts.record_email_delivery(
             self._conn,
@@ -190,6 +195,10 @@ class IntelligenceReporter:
             html=payload.html,
             force_send=True,
             require_approval=False,
+            action=ActionTag.FYI,
+            kind=KindTag.DIGEST,
+            source="intelligence_reporter.send_daily_digest",
+            related=[f"artifact_id={payload.artifact_id}"],
         )
         proactive_artifacts.record_email_delivery(
             self._conn,
@@ -217,6 +226,10 @@ class IntelligenceReporter:
             html=payload.html,
             force_send=True,
             require_approval=False,
+            action=ActionTag.FYI,
+            kind=KindTag.DIGEST,
+            source="intelligence_reporter.send_weekly_preference_report",
+            related=[f"artifact_id={payload.artifact_id}"],
         )
         proactive_artifacts.record_email_delivery(
             self._conn,

--- a/src/universal_agent/services/proactive_health_notifier.py
+++ b/src/universal_agent/services/proactive_health_notifier.py
@@ -25,6 +25,8 @@ from pathlib import Path
 import time
 from typing import Any, Awaitable, Callable, Iterable, Optional, Protocol
 
+from universal_agent.services.email_tags import ActionTag, KindTag
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_COOLDOWN_SECONDS = 21600  # 6h
@@ -214,6 +216,10 @@ async def _notify_critical(
             subject=subject,
             text=text,
             force_send=True,
+            action=ActionTag.ACTION,
+            kind=KindTag.INCIDENT,
+            source="proactive_health_notifier",
+            related=[f"finding_id={finding_id}"],
         )
     except Exception:  # noqa: BLE001 — never crash the heartbeat over a send failure
         logger.warning("proactive_health: send_email failed for %s", finding_id, exc_info=True)
@@ -375,6 +381,9 @@ async def send_test_critical_email(
             subject=subject,
             text=text,
             force_send=True,
+            action=ActionTag.FYI,
+            kind=KindTag.INCIDENT,
+            source="proactive_health_notifier (manual test)",
         )
     except Exception as exc:  # noqa: BLE001
         logger.warning(

--- a/tests/unit/test_agentmail_send_tagged.py
+++ b/tests/unit/test_agentmail_send_tagged.py
@@ -1,0 +1,190 @@
+"""Integration test for AgentMailService.send_email with tag parameters.
+
+Verifies that when both ``action`` and ``kind`` are supplied, the subject
+landed at the AgentMail client carries the ``[ACTION/KIND]`` prefix and the
+body has the tag banner prepended. Also verifies that omitting the tag
+params preserves backward compatibility (no prefix, no banner).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from universal_agent.services.email_tags import ActionTag, KindTag
+
+_BASE_ENV = {
+    "UA_AGENTMAIL_ENABLED": "1",
+    "AGENTMAIL_API_KEY": "test-api-key-123",
+    "UA_AGENTMAIL_INBOX_ADDRESS": "simone@testdomain.com",
+    "UA_AGENTMAIL_AUTO_SEND": "1",  # force-send path
+    "UA_AGENTMAIL_WS_ENABLED": "0",
+}
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch, tmp_path):
+    for k, v in _BASE_ENV.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.delenv("UA_AGENTMAIL_INBOX_ADDRESSES", raising=False)
+    monkeypatch.setenv("UA_ACTIVITY_DB_PATH", str(tmp_path / "activity_state.db"))
+
+
+@pytest.fixture
+def mock_client():
+    client = MagicMock()
+
+    mock_inbox = MagicMock()
+    mock_inbox.inbox_id = "simone@testdomain.com"
+    client.inboxes.get = AsyncMock(return_value=mock_inbox)
+    client.inboxes.create = AsyncMock(return_value=mock_inbox)
+
+    mock_msg = MagicMock()
+    mock_msg.message_id = "msg_test_tag_001"
+    client.inboxes.messages.send = AsyncMock(return_value=mock_msg)
+
+    mock_draft = MagicMock()
+    mock_draft.draft_id = "drf_test_tag_001"
+    client.inboxes.drafts.create = AsyncMock(return_value=mock_draft)
+
+    return client
+
+
+@pytest.fixture
+async def service(mock_client):
+    from universal_agent.services.agentmail_service import AgentMailService
+
+    svc = AgentMailService(
+        dispatch_fn=AsyncMock(return_value=(True, "agent")),
+        notification_sink=MagicMock(),
+    )
+    svc._client = mock_client
+    await svc._ensure_inbox()
+    svc._enabled = True
+    svc._started = True
+    yield svc
+    await svc.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# Tagged path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_email_with_tags_prefixes_subject_and_banner(service, mock_client):
+    await service.send_email(
+        to="kevin@example.com",
+        subject="Daily YouTube Digest: Monday",
+        text="raw body content",
+        html="<p>raw body content</p>",
+        action=ActionTag.FYI,
+        kind=KindTag.DIGEST,
+        source="youtube_daily_digest cron",
+        related=["day=monday"],
+        force_send=True,
+    )
+
+    call = mock_client.inboxes.messages.send.await_args
+    assert call is not None, "expected the AgentMail client to receive a send call"
+    kwargs = call.kwargs
+    assert kwargs["subject"] == "[FYI/DIGEST] Daily YouTube Digest: Monday"
+    # Plaintext body has the banner up top
+    assert kwargs["text"].startswith("Tags: FYI/DIGEST")
+    assert "Source: youtube_daily_digest cron" in kwargs["text"]
+    assert "Related: day=monday" in kwargs["text"]
+    assert "raw body content" in kwargs["text"]
+    # HTML body gets the html banner block
+    assert "FYI/DIGEST" in kwargs["html"]
+    assert "<p>raw body content</p>" in kwargs["html"]
+
+
+@pytest.mark.asyncio
+async def test_send_email_string_tag_inputs_are_accepted(service, mock_client):
+    await service.send_email(
+        to="kevin@example.com",
+        subject="hello",
+        text="body",
+        action="ACTION",
+        kind="INCIDENT",
+        source="ci-watcher",
+        force_send=True,
+    )
+
+    call = mock_client.inboxes.messages.send.await_args
+    assert call.kwargs["subject"] == "[ACTION/INCIDENT] hello"
+
+
+@pytest.mark.asyncio
+async def test_send_email_bad_tag_raises(service, mock_client):
+    with pytest.raises(ValueError):
+        await service.send_email(
+            to="kevin@example.com",
+            subject="hello",
+            text="body",
+            action="URGENT",  # not in the enum
+            kind=KindTag.INCIDENT,
+            source="ci-watcher",
+            force_send=True,
+        )
+    # And nothing was actually sent.
+    mock_client.inboxes.messages.send.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat path (un-migrated callsites)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_email_without_tags_is_unchanged(service, mock_client):
+    """A caller that omits action/kind should see no behavioral diff."""
+    await service.send_email(
+        to="kevin@example.com",
+        subject="Plain subject",
+        text="plain body",
+        html="<p>plain</p>",
+        force_send=True,
+    )
+
+    call = mock_client.inboxes.messages.send.await_args
+    assert call.kwargs["subject"] == "Plain subject"
+    assert call.kwargs["text"] == "plain body"
+    assert call.kwargs["html"] == "<p>plain</p>"
+
+
+@pytest.mark.asyncio
+async def test_send_email_partial_tag_does_not_apply(service, mock_client):
+    """Passing only one of action/kind is treated as un-tagged."""
+    await service.send_email(
+        to="kevin@example.com",
+        subject="Half-tagged",
+        text="body",
+        action=ActionTag.FYI,  # kind missing
+        force_send=True,
+    )
+    call = mock_client.inboxes.messages.send.await_args
+    assert call.kwargs["subject"] == "Half-tagged"
+    assert call.kwargs["text"] == "body"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency at the wrapper layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_email_does_not_double_prefix_when_caller_pretagged(service, mock_client):
+    """If the caller pre-tags the subject, the wrapper must not double-tag."""
+    await service.send_email(
+        to="kevin@example.com",
+        subject="[FYI/DIGEST] Daily YouTube Digest: Monday",
+        text="body",
+        action=ActionTag.FYI,
+        kind=KindTag.DIGEST,
+        source="youtube_daily_digest cron",
+        force_send=True,
+    )
+    call = mock_client.inboxes.messages.send.await_args
+    assert call.kwargs["subject"] == "[FYI/DIGEST] Daily YouTube Digest: Monday"

--- a/tests/unit/test_email_tags.py
+++ b/tests/unit/test_email_tags.py
@@ -1,0 +1,189 @@
+"""Unit tests for the bounded outbound email tag vocabulary."""
+
+from __future__ import annotations
+
+import pytest
+
+from universal_agent.services.email_tags import (
+    SUBJECT_TAG_RE,
+    ActionTag,
+    KindTag,
+    format_body_header,
+    format_tagged_subject,
+)
+
+# ---------------------------------------------------------------------------
+# Subject prefixing
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTaggedSubject:
+    def test_happy_path_prefixes_tag(self):
+        out = format_tagged_subject(ActionTag.FYI, KindTag.DIGEST, "Daily YouTube Digest: Monday")
+        assert out == "[FYI/DIGEST] Daily YouTube Digest: Monday"
+
+    def test_accepts_string_inputs(self):
+        out = format_tagged_subject("FYI", "DIGEST", "hi")
+        assert out == "[FYI/DIGEST] hi"
+
+    def test_string_inputs_case_insensitive(self):
+        out = format_tagged_subject("fyi", "digest", "hi")
+        assert out == "[FYI/DIGEST] hi"
+
+    def test_idempotent_does_not_double_tag(self):
+        once = format_tagged_subject(ActionTag.ACTION, KindTag.INCIDENT, "CI failed on PR #364")
+        twice = format_tagged_subject(ActionTag.ACTION, KindTag.INCIDENT, once)
+        thrice = format_tagged_subject(ActionTag.FYI, KindTag.DIGEST, twice)
+        assert once == twice == thrice  # first tag wins, no compounding
+
+    def test_idempotent_when_existing_tag_is_different(self):
+        # Even if a caller tries to "re-tag" with different values, the
+        # original tag is preserved — the first tagger wins.
+        already = "[FYI/DIGEST] Daily summary"
+        out = format_tagged_subject(ActionTag.ACTION, KindTag.INCIDENT, already)
+        assert out == already
+
+    def test_empty_subject(self):
+        out = format_tagged_subject(ActionTag.FYI, KindTag.CRON, "")
+        assert out == "[FYI/CRON]"
+
+    def test_none_subject_normalized(self):
+        out = format_tagged_subject(ActionTag.FYI, KindTag.CRON, None)  # type: ignore[arg-type]
+        assert out == "[FYI/CRON]"
+
+    def test_very_long_subject(self):
+        long = "X" * 500
+        out = format_tagged_subject(ActionTag.QUESTION, KindTag.PROACTIVE, long)
+        assert out.startswith("[QUESTION/PROACTIVE] ")
+        assert out.endswith("X" * 500)
+
+    def test_bad_action_string_raises(self):
+        with pytest.raises(ValueError):
+            format_tagged_subject("URGENT", KindTag.DIGEST, "x")
+
+    def test_bad_kind_string_raises(self):
+        with pytest.raises(ValueError):
+            format_tagged_subject(ActionTag.FYI, "GOSSIP", "x")
+
+    def test_non_string_action_type_raises(self):
+        with pytest.raises(TypeError):
+            format_tagged_subject(42, KindTag.DIGEST, "x")  # type: ignore[arg-type]
+
+    def test_non_string_kind_type_raises(self):
+        with pytest.raises(TypeError):
+            format_tagged_subject(ActionTag.FYI, 42, "x")  # type: ignore[arg-type]
+
+    def test_regex_recognizes_all_combinations(self):
+        for a in ActionTag:
+            for k in KindTag:
+                out = format_tagged_subject(a, k, "subject")
+                assert SUBJECT_TAG_RE.match(out), f"failed to recognize: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Body banner
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBodyHeader:
+    def test_returns_html_text_tuple(self):
+        html, text = format_body_header(
+            ActionTag.ACTION,
+            KindTag.INCIDENT,
+            source="ci-failure-watcher",
+            related=["PR #364"],
+            include_timestamp=False,
+        )
+        assert isinstance(html, str) and isinstance(text, str)
+
+    def test_text_banner_contains_required_lines(self):
+        _, text = format_body_header(
+            ActionTag.ACTION,
+            KindTag.INCIDENT,
+            source="ci-failure-watcher",
+            related=["PR #364"],
+            include_timestamp=False,
+        )
+        assert "Tags: ACTION/INCIDENT" in text
+        assert "Source: ci-failure-watcher" in text
+        assert "Related: PR #364" in text
+        assert text.rstrip().endswith("---")
+
+    def test_html_banner_contains_required_fields(self):
+        html, _ = format_body_header(
+            ActionTag.FYI,
+            KindTag.DIGEST,
+            source="youtube_daily_digest cron",
+            related=["day=monday"],
+            include_timestamp=False,
+        )
+        assert "FYI/DIGEST" in html
+        assert "youtube_daily_digest cron" in html
+        assert "day=monday" in html
+        # Should be self-contained (no script tags etc.)
+        assert "<script" not in html
+
+    def test_related_can_be_list_or_string(self):
+        _, text_list = format_body_header(
+            ActionTag.FYI, KindTag.DIGEST, "src", related=["a", "b"], include_timestamp=False,
+        )
+        _, text_str = format_body_header(
+            ActionTag.FYI, KindTag.DIGEST, "src", related="a, b", include_timestamp=False,
+        )
+        assert "Related: a, b" in text_list
+        assert "Related: a, b" in text_str
+
+    def test_related_omitted_when_empty(self):
+        _, text = format_body_header(
+            ActionTag.FYI, KindTag.DIGEST, "src", related=None, include_timestamp=False,
+        )
+        assert "Related:" not in text
+
+    def test_source_omitted_when_empty(self):
+        _, text = format_body_header(
+            ActionTag.FYI, KindTag.DIGEST, "", include_timestamp=False,
+        )
+        assert "Source:" not in text
+
+    def test_timestamp_included_by_default(self):
+        _, text = format_body_header(ActionTag.FYI, KindTag.CRON, "src")
+        assert "Time:" in text
+
+    def test_html_escapes_special_chars(self):
+        html, _ = format_body_header(
+            ActionTag.FYI,
+            KindTag.DIGEST,
+            source="src<script>",
+            related=["a & b"],
+            include_timestamp=False,
+        )
+        assert "<script>" not in html  # raw not present
+        assert "&lt;script&gt;" in html
+        assert "&amp;" in html
+
+    def test_bad_enum_raises(self):
+        with pytest.raises(ValueError):
+            format_body_header("BOGUS", KindTag.DIGEST, "src")
+        with pytest.raises(ValueError):
+            format_body_header(ActionTag.FYI, "BOGUS", "src")
+
+
+# ---------------------------------------------------------------------------
+# Enum invariants — keep the vocab small and explicit.
+# ---------------------------------------------------------------------------
+
+
+def test_action_tag_has_exactly_four_values():
+    assert {a.value for a in ActionTag} == {"FYI", "ACTION", "DECISION", "QUESTION"}
+
+
+def test_kind_tag_has_exactly_seven_values():
+    assert {k.value for k in KindTag} == {
+        "DIGEST",
+        "TUTORIAL",
+        "PROACTIVE",
+        "INCIDENT",
+        "CRON",
+        "SYSTEM",
+        "DEPLOY",
+    }


### PR DESCRIPTION
## Summary

Adds a bounded 2-dimension tag scheme to outbound UA email so the operator can eyeball-triage their inbox without opening each message. Subjects become `[ACTION/KIND] <existing subject>` and a body banner is injected at the top of both the HTML and plaintext bodies.

Sibling PR #391 (digest delivery reminders with TTL) ships the same evening — these are independent, compose cleanly: the reminder fires on send, the tag decorates the subject.

## The 2-Dimension Vocab (closed enums)

| Dimension | Values | Meaning |
|---|---|---|
| `ActionTag` (4) | `FYI`, `ACTION`, `DECISION`, `QUESTION` | What response, if any, is required |
| `KindTag` (7) | `DIGEST`, `TUTORIAL`, `PROACTIVE`, `INCIDENT`, `CRON`, `SYSTEM`, `DEPLOY` | What kind of content the email contains |

4 × 7 = 28 combos. No improvising free-form tags — new sources pick the closest existing KIND or add ONE entry to the enum.

## Subject Format

```
[<ACTION>/<KIND>] <existing subject>
```

Examples (after migration):
- `[FYI/DIGEST] Daily YouTube Digest: Monday`
- `[DECISION/PROACTIVE] Codie proposes consolidating import ordering across 3 services`
- `[ACTION/INCIDENT] CI failed on PR #364`
- `[FYI/CRON] Nightly wiki generation complete (0 new cards)`
- `[FYI/DEPLOY] Production deploy succeeded — sha=6f2e321f`
- `[ACTION/DEPLOY] Production deploy FAILED — see workflow run 26052...`
- `[QUESTION/PROACTIVE] Which import-ordering convention should I follow?`

## Body Banner (HTML + plaintext)

When tags are set, the wrapper injects a banner at the top of the body:

```
Tags: ACTION/INCIDENT
Source: proactive_health_notifier
Related: finding_id=watchdog.heartbeat.idle
Time: 2026-05-19T15:42:00-05:00
---
```

Time is Houston-local for operator readability. `Related:` is optional context (PR numbers, ticket IDs, file paths, artifact IDs).

## Migrated Callsites (v1)

| File | Tag | Source |
|---|---|---|
| `scripts/youtube_daily_digest.py` | `FYI/DIGEST` | `youtube_daily_digest cron` |
| `services/intelligence_reporter.py::send_daily_digest` | `FYI/DIGEST` | `intelligence_reporter.send_daily_digest` |
| `services/intelligence_reporter.py::send_weekly_preference_report` | `FYI/DIGEST` | `intelligence_reporter.send_weekly_preference_report` |
| `services/intelligence_reporter.py::send_review_email` | `DECISION/PROACTIVE` | `intelligence_reporter.send_review_email` |
| `services/proactive_health_notifier.py` (live alerts) | `ACTION/INCIDENT` | `proactive_health_notifier` |
| `services/proactive_health_notifier.py` (test endpoint) | `FYI/INCIDENT` | `proactive_health_notifier (manual test)` |

Less-frequent callsites (`hooks.py`, `cli_io.py`, `dependency_upgrade.py`, etc.) remain un-tagged for now and continue to work unchanged — migration is purely additive and mechanical.

## Backward Compatibility

`AgentMailService.send_email()` callsites that don't pass `action`+`kind` continue working uncategorized:

- Tagging is gated on `action is not None AND kind is not None`.
- Partial tags are ignored (treated as un-tagged).
- Invalid enum strings raise `ValueError` at the call (typos cannot ship a bad email).
- **Idempotent**: a subject already starting with `[X/Y]` is left alone — catches accidental re-sends and replies.

## Recommended Gmail Filters

Six ready-to-paste rules so the inbox segments visually. Paste each into Gmail Settings → Filters → Create new:

```
Filter 1
  Search:  subject:[FYI/DIGEST] OR subject:[ACTION/DIGEST]
  Action:  Apply label: UA/Digest (color: blue)
           Skip inbox: NO

Filter 2
  Search:  subject:[FYI/INCIDENT] OR subject:[ACTION/INCIDENT]
  Action:  Apply label: UA/Incident (color: red)
           Skip inbox: NO   (incidents must stay in inbox)

Filter 3
  Search:  subject:[DECISION/PROACTIVE] OR subject:[QUESTION/PROACTIVE] OR subject:[ACTION/PROACTIVE]
  Action:  Apply label: UA/Proactive (color: orange)
           Skip inbox: NO

Filter 4
  Search:  subject:[ACTION/DEPLOY] OR subject:[FYI/DEPLOY]
  Action:  Apply label: UA/Deploy (color: purple)
           Skip inbox: NO

Filter 5
  Search:  subject:[FYI/CRON] OR subject:[ACTION/CRON]
  Action:  Apply label: UA/Cron (color: gray)
           Skip inbox: NO

Filter 6
  Search:  subject:[FYI/SYSTEM] OR subject:[ACTION/SYSTEM] OR subject:[FYI/TUTORIAL]
  Action:  Apply label: UA/System (color: green)
           Skip inbox: NO
```

## Test plan

- [x] 30 new unit + integration tests (12 helper unit, 6 enum invariant, 12 wrapper integration) — all pass.
- [x] Existing `tests/unit/test_agentmail_service.py` + `test_agentmail_send_policy.py` — 133/133 pass.
- [x] `ruff check` clean on all touched files.
- [x] Dry-run of `format_tagged_subject` + `format_body_header` confirms produced output: `SUBJECT: [FYI/DIGEST] Daily YouTube Digest: Monday` with expected plaintext + HTML banner.
- [ ] Post-merge: first live `youtube_daily_digest` cron tick produces a `[FYI/DIGEST]`-prefixed email; verify in inbox.
- [ ] Post-merge: first `proactive_health_notifier` finding produces a `[ACTION/INCIDENT]`-prefixed email.

## Docs

- `docs/03_Operations/82_Email_Architecture_And_AgentMail_Source_Of_Truth_2026-03-06.md` — new "Outbound Subject Tagging" section with vocab, format, migrated callsites, wrapper API, Gmail filter recipes. Last-updated stamp bumped to 2026-05-19.
- `docs/Documentation_Status.md` — entry 82 updated to mention the new outbound tag system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)