### PR TITLE
feat(watchdog): P1a — universal CSI source liveness invariant

### DIFF
--- a/memory/HEARTBEAT.md
+++ b/memory/HEARTBEAT.md
@@ -81,6 +81,7 @@ This file controls proactive heartbeat behavior. Keep items concrete and actiona
     5. **Do not** invoke the invariant probes directly from the heartbeat shell — call the endpoint. Probes can mutate over time as pipeline owners register new ones; the endpoint is the stable contract.
     6. If the endpoint returns 5xx, log a `warn` finding with `metric_key='proactive_health_endpoint_down'` and `runbook_command='journalctl -u universal-agent-gateway --since "10 min ago" --no-pager'`. Do not block the rest of the heartbeat on this.
     7. Canonical reference: [`docs/03_Operations/132_Proactive_Health_Watchdog.md`](../docs/03_Operations/132_Proactive_Health_Watchdog.md). Authoring a new invariant: same doc, "Authoring runbook" section.
+    8. **Triage `proactive_health:*` Task Hub rows.** Since 2026-05-20 (P0c) the heartbeat pre-flight automatically parks a `needs_review` row in Task Hub for every critical finding (`task_id = proactive_health:<finding_id>`, `source_kind = proactive_health`). When you encounter one in your sweep: read `metadata.runbook_command` and `metadata.recommendation`, investigate the underlying pipeline, and either (a) mark `status=completed` with a comment summarizing the fix, or (b) mark `status=blocked` with the operator-blocker reason. Do NOT mass-clear `proactive_health:*` rows without investigation — they represent real production pipeline failures the watchdog detected.
 <!-- scope:all -->
 - [ ] Mission Control build kickoff
   - Confirm first concrete milestone and produce a short execution checklist.

--- a/src/universal_agent/heartbeat_service.py
+++ b/src/universal_agent/heartbeat_service.py
@@ -2532,12 +2532,66 @@ class HeartbeatService:
                         except Exception:  # noqa: BLE001
                             pass
 
+                # P0c (2026-05-20): emit a Task Hub `needs_review` row for
+                # every critical finding so unresolved findings persist past
+                # this heartbeat. Independent channel from the email path —
+                # losing one shouldn't lose both. Dedup: if a row with the
+                # same finding_id is already in an active status (open,
+                # needs_review, in_progress), upsert silently leaves it.
+                def _emit_finding_to_task_hub(finding: dict[str, Any]) -> None:
+                    finding_id = str(finding.get("finding_id") or finding.get("metric_key") or "unknown")
+                    task_id = f"proactive_health:{finding_id}"
+                    try:
+                        from universal_agent.durable.db import (
+                            connect_runtime_db,
+                            get_activity_db_path,
+                        )
+                        conn = connect_runtime_db(get_activity_db_path())
+                        try:
+                            existing = task_hub.get_item(conn, task_id)
+                            if existing and str(existing.get("status") or "").lower() in {
+                                "open", "needs_review", "in_progress",
+                            }:
+                                # Already parked — leave it alone, don't churn updated_at
+                                return
+                            task_hub.upsert_item(
+                                conn,
+                                {
+                                    "task_id": task_id,
+                                    "source_kind": "proactive_health",
+                                    "title": f"[CRITICAL] {finding.get('title') or finding_id}",
+                                    "status": "needs_review",
+                                    "metadata": {
+                                        "finding_id": finding_id,
+                                        "metric_key": finding.get("metric_key"),
+                                        "severity": finding.get("severity"),
+                                        "recommendation": finding.get("recommendation"),
+                                        "runbook_command": finding.get("runbook_command"),
+                                        "category": finding.get("category"),
+                                        "observed_value": finding.get("observed_value"),
+                                    },
+                                },
+                            )
+                            conn.commit()
+                        finally:
+                            try:
+                                conn.close()
+                            except Exception:  # noqa: BLE001
+                                pass
+                    except Exception:  # noqa: BLE001
+                        logger.warning(
+                            "proactive_health: failed to park task_hub row for %s",
+                            finding_id,
+                            exc_info=True,
+                        )
+
                 await run_pre_flight_check(
                     workspace_dir=Path(str(session.workspace_dir)),
                     payload_builder=_build_payload,
                     agentmail_service=getattr(_gs, "_agentmail_service", None),
                     notifications_list=getattr(_gs, "_notifications", None),
                     add_notification_fn=getattr(_gs, "_add_notification", None),
+                    task_hub_emit_fn=_emit_finding_to_task_hub,
                 )
             except Exception:  # noqa: BLE001
                 logger.warning(

--- a/src/universal_agent/services/invariants/__init__.py
+++ b/src/universal_agent/services/invariants/__init__.py
@@ -15,6 +15,7 @@ Authoring a new invariant:
 from __future__ import annotations
 
 from universal_agent.services.invariants import (  # noqa: F401
+    csi_source_liveness,
     proactive_pipeline_invariants,
     youtube_invariants,
 )

--- a/src/universal_agent/services/invariants/csi_source_liveness.py
+++ b/src/universal_agent/services/invariants/csi_source_liveness.py
@@ -1,0 +1,182 @@
+"""Universal CSI source liveness invariant.
+
+One probe that watches every CSI adapter (youtube_channel_rss,
+youtube_playlist, reddit_discovery, threads_owned, threads_trends_seeded,
+threads_trends_broad, hackernews, csi_analytics) by checking
+`max(occurred_at)` per source in csi.db's `events` table against a
+per-source expected-max-silence threshold.
+
+Why one invariant instead of six: the framework emits at most one finding
+per invariant. Splitting into six would create six emails per dead CSI
+day (spam) and six separate Task Hub rows to triage. A single finding
+that lists every stale source gives the operator the full picture in one
+alert, with the per-source breakdown surfaced in `observed_value`.
+
+Was added 2026-05-20 (P1a) after a holistic audit found three adapters
+silently dead for 40+ hours with zero watchdog coverage. Before this
+probe, only `youtube_channel_rss` had any liveness coverage; the other
+five adapters were invisible.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import logging
+from pathlib import Path
+import sqlite3
+from typing import Any, Dict, Optional
+
+from universal_agent.services.pipeline_invariants import invariant
+
+logger = logging.getLogger(__name__)
+
+
+# Per-source expected max silence in hours. Conservative defaults: leave
+# breathing room for low-cadence sources (youtube_playlist, threads_trends_*)
+# while still catching the 40h+ failure mode that prompted P1a. Tune via
+# follow-up PR once we have a few weeks of operational data — never silence
+# a source entirely.
+SOURCE_THRESHOLDS_HOURS: Dict[str, float] = {
+    "hackernews": 3.0,                   # very high frequency (every 30 min cron + adapter poll)
+    "csi_analytics": 12.0,               # downstream aggregator — depends on upstream cadence
+    "youtube_channel_rss": 12.0,         # 444-channel watchlist, hourly-ish per channel
+    "youtube_playlist": 48.0,            # playlists tick less often than channels
+    "reddit_discovery": 12.0,            # subreddit polling
+    "threads_owned": 12.0,               # owned-handle polling
+    "threads_trends_seeded": 24.0,       # broad seeded queries, lower cadence
+    "threads_trends_broad": 24.0,        # broadest sweep, lower cadence
+}
+
+
+def _per_source_last_seen(
+    csi_db_path: Path,
+) -> Dict[str, Optional[datetime]]:
+    """Return {source: max(occurred_at)} for every source listed in the
+    threshold table. Sources that never appear in `events` get None.
+
+    Bounded query: only look at the last 30 days. A source dead for 30+ days
+    is treated as never_seen (operator should investigate the watchlist
+    config or take it out of monitoring instead of letting it pile up alerts).
+    """
+    results: Dict[str, Optional[datetime]] = {s: None for s in SOURCE_THRESHOLDS_HOURS}
+    conn = sqlite3.connect(str(csi_db_path))
+    try:
+        cursor = conn.execute(
+            "SELECT source, MAX(occurred_at) FROM events "
+            "WHERE occurred_at >= datetime('now', '-30 days') "
+            "GROUP BY source"
+        )
+        for source, last_seen_iso in cursor.fetchall():
+            if source not in results:
+                continue
+            if last_seen_iso is None:
+                continue
+            try:
+                # tolerate Z suffix and naive timestamps
+                parsed = datetime.fromisoformat(str(last_seen_iso).replace("Z", "+00:00"))
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                results[source] = parsed
+            except (ValueError, AttributeError):
+                continue
+    finally:
+        conn.close()
+    return results
+
+
+@invariant(
+    id="csi_source_liveness",
+    title="CSI adapters are producing events on schedule",
+    description=(
+        "Watches max(occurred_at) per CSI source against a per-source "
+        "expected-max-silence threshold. Fires when one or more adapters "
+        "have gone quieter than their configured threshold. Replaces the "
+        "previous coverage gap where only youtube_channel_rss was watched."
+    ),
+    severity="critical",
+    runbook_command=(
+        "sqlite3 /var/lib/universal-agent/csi/csi.db "
+        "\"SELECT source, COUNT(*), MAX(occurred_at) FROM events "
+        "WHERE occurred_at >= datetime('now','-7 days') GROUP BY source ORDER BY MAX(occurred_at);\"; "
+        "sudo journalctl -u csi-ingester --since '6 hours ago' --no-pager | grep -iE 'error|fail'"
+    ),
+    metadata={
+        "pipeline": "csi_ingester_adapters",
+        "tables": ["events"],
+        "db": "csi.db",
+        "sources_monitored": list(SOURCE_THRESHOLDS_HOURS.keys()),
+        "design_note": (
+            "P1a (2026-05-20): one invariant covering six adapters in one "
+            "finding. Listing per-source thresholds + last_seen in "
+            "observed_value lets the operator triage all stale sources from "
+            "a single alert. Splitting per-source would spam the email/Task "
+            "Hub channels."
+        ),
+    },
+)
+def csi_source_liveness(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    csi_db_path = ctx.get("csi_db_path")
+    if csi_db_path is None:
+        return None
+    path = Path(str(csi_db_path))
+    if not path.exists():
+        return None
+    try:
+        last_seen = _per_source_last_seen(path)
+    except sqlite3.OperationalError as exc:
+        # No events table yet (early dev / fresh DB) — silent.
+        logger.debug("csi_source_liveness: events table unavailable (%s)", exc)
+        return None
+    except sqlite3.Error as exc:
+        logger.warning("csi_source_liveness: query failed: %s", exc, exc_info=True)
+        return None
+
+    now = datetime.now(timezone.utc)
+    stale_sources: list[dict[str, Any]] = []
+    for source, threshold_h in SOURCE_THRESHOLDS_HOURS.items():
+        ts = last_seen.get(source)
+        if ts is None:
+            stale_sources.append(
+                {
+                    "source": source,
+                    "threshold_hours": threshold_h,
+                    "silence_hours": None,
+                    "state": "never_seen",
+                    "last_event_utc": None,
+                }
+            )
+            continue
+        silence = (now - ts).total_seconds() / 3600.0
+        if silence > threshold_h:
+            stale_sources.append(
+                {
+                    "source": source,
+                    "threshold_hours": threshold_h,
+                    "silence_hours": round(silence, 1),
+                    "state": "stale",
+                    "last_event_utc": ts.isoformat(),
+                }
+            )
+
+    if not stale_sources:
+        return None
+
+    source_names = sorted(s["source"] for s in stale_sources)
+    return {
+        "observed_value": {
+            "stale_sources": stale_sources,
+            "stale_count": len(stale_sources),
+            "monitored_count": len(SOURCE_THRESHOLDS_HOURS),
+            "evaluated_at_utc": now.isoformat(),
+        },
+        "threshold_text": (
+            "every monitored CSI source produces an event within its "
+            "per-source threshold (see metadata.sources_monitored)"
+        ),
+        "message": (
+            f"{len(stale_sources)} CSI adapter(s) past their expected-silence "
+            f"threshold: {', '.join(source_names)}. The csi-ingester service "
+            f"is up but these adapters are not landing events. Investigate "
+            f"the adapter loop, polling errors, or upstream rate limits."
+        ),
+    }

--- a/src/universal_agent/services/invariants/proactive_pipeline_invariants.py
+++ b/src/universal_agent/services/invariants/proactive_pipeline_invariants.py
@@ -157,16 +157,18 @@ def morning_briefing_freshness(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "pipeline": "proactive_artifact_digest",
         "cron_expr": "35 8 * * *",
         "tables": ["proactive_artifact_emails"],
-        "db": "runtime_state.db",
+        "db": "activity_state.db",
         "design_note": (
-            "Probe corrected 2026-05-20 (WS3): was reading from activity_conn "
-            "(activity_events.db) which never had the proactive_artifact_emails "
-            "table — silently no-op'd since PR #376. Now uses runtime_conn."
+            "Probe corrected 2026-05-20 (P0b): writers use _activity_connect() "
+            "→ activity_state.db. PR #376 wrote to runtime_conn (runtime_state.db), "
+            "PR #392 then opened a separate runtime_conn — still wrong DB. "
+            "P0b: invariants use activity_conn which already points at "
+            "activity_state.db (same DB as task_hub_items). No parallel plumbing."
         ),
     },
 )
 def proactive_artifact_digest_delivery(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    conn = ctx.get("runtime_conn")
+    conn = ctx.get("activity_conn")
     if conn is None:
         return None
     # Only probe after the 8:35 AM tick so a fresh morning doesn't false-fire.
@@ -455,11 +457,11 @@ def nightly_wiki_persistent_silence(ctx: Dict[str, Any]) -> Optional[Dict[str, A
         "cron_exprs": ["5 7 * * *", "5 12 * * *", "5 16 * * *"],
         "tz": "America/Chicago",
         "tables": ["proactive_intelligence_reports"],
-        "db": "runtime_state.db",
+        "db": "activity_state.db",
     },
 )
 def proactive_reports_daily_trio(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    conn = ctx.get("runtime_conn")
+    conn = ctx.get("activity_conn")
     if conn is None:
         return None
     now = _now_houston()
@@ -593,12 +595,12 @@ def claude_code_intel_packet_freshness(ctx: Dict[str, Any]) -> Optional[Dict[str
         "cron_expr": "5 10,15 * * *",
         "tz": "America/Chicago",
         "tables": ["proactive_artifacts"],
-        "db": "runtime_state.db",
+        "db": "activity_state.db",
         "artifact_type": "csi_demo_triage_run",
     },
 )
 def csi_demo_triage_rank_artifact(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    conn = ctx.get("runtime_conn")
+    conn = ctx.get("activity_conn")
     if conn is None:
         return None
     now = _now_houston()
@@ -684,11 +686,11 @@ def csi_demo_triage_rank_artifact(ctx: Dict[str, Any]) -> Optional[Dict[str, Any
         "cron_expr": "0 21 * * *",
         "tz": "America/Chicago",
         "tables": ["proactive_artifact_emails"],
-        "db": "runtime_state.db",
+        "db": "activity_state.db",
     },
 )
 def paper_to_podcast_email_delivery(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-    conn = ctx.get("runtime_conn")
+    conn = ctx.get("activity_conn")
     if conn is None:
         return None
     now = _now_houston()

--- a/src/universal_agent/services/proactive_health.py
+++ b/src/universal_agent/services/proactive_health.py
@@ -229,45 +229,26 @@ def build_proactive_health_payload(
     except Exception:  # noqa: BLE001
         artifacts_dir = None
 
-    # Open a dedicated runtime_state.db connection for invariants that query
-    # proactive_artifacts / proactive_intelligence_reports / proactive_artifact_emails.
-    # These tables live in runtime_state.db, NOT activity_events.db — earlier
-    # invariants in PR #376 silently no-op'd because they queried the wrong DB.
-    # If caller provided runtime_conn, use it (legacy + test path). Otherwise
-    # open one locally and close before returning.
-    runtime_conn_opened_locally = False
-    if runtime_conn is None:
-        try:
-            from universal_agent.durable.db import (
-                connect_runtime_db,
-                get_runtime_db_path,
-            )
-            runtime_conn = connect_runtime_db(get_runtime_db_path())
-            runtime_conn.row_factory = sqlite3.Row
-            runtime_conn_opened_locally = True
-        except Exception:  # noqa: BLE001 — best-effort
-            logger.warning(
-                "proactive_health: failed to open runtime_state.db; "
-                "proactive_* invariants will stay quiet",
-                exc_info=True,
-            )
-            runtime_conn = None
-
-    try:
-        invariant_findings = pipeline_invariants.run_invariants(
-            {
-                "csi_db_path": csi_db_path,
-                "runtime_conn": runtime_conn,
-                "activity_conn": activity_conn,
-                "artifacts_dir": artifacts_dir,
-            }
-        )
-    finally:
-        if runtime_conn_opened_locally and runtime_conn is not None:
-            try:
-                runtime_conn.close()
-            except Exception:  # noqa: BLE001
-                pass
+    # P0b note (2026-05-20): the previous code opened a separate
+    # runtime_state.db connection here for invariants that query
+    # proactive_artifacts / proactive_artifact_emails / proactive_intelligence_reports.
+    # That was wrong twice: PR #376 used activity_events.db (no proactive
+    # tables), PR #392 used runtime_state.db (also no proactive tables).
+    # The actual writers (`_activity_connect()` in gateway_server.py) write
+    # those tables into activity_state.db, which is exactly what
+    # `activity_conn` points at in both the heartbeat and gateway endpoint
+    # paths. Invariants now use `activity_conn` directly — one DB, no
+    # parallel plumbing. The `runtime_conn` parameter is kept for backwards
+    # compatibility with callers that pass it explicitly, but the aggregator
+    # no longer opens one itself.
+    invariant_findings = pipeline_invariants.run_invariants(
+        {
+            "csi_db_path": csi_db_path,
+            "runtime_conn": runtime_conn,
+            "activity_conn": activity_conn,
+            "artifacts_dir": artifacts_dir,
+        }
+    )
 
     overall = _derive_overall_status(
         invariant_findings,

--- a/src/universal_agent/services/proactive_health_notifier.py
+++ b/src/universal_agent/services/proactive_health_notifier.py
@@ -250,6 +250,27 @@ async def _notify_critical(
     return True
 
 
+def _emit_to_task_hub(
+    findings: list[dict[str, Any]],
+    task_hub_emit_fn: Optional[Callable[[dict[str, Any]], None]],
+) -> None:
+    """Best-effort: park a Task Hub row for each critical finding so it persists
+    past one heartbeat. Independent of email — losing the email channel must
+    not lose the persistent backlog. Never raises."""
+    if task_hub_emit_fn is None:
+        return
+    for f in findings:
+        try:
+            task_hub_emit_fn(f)
+        except Exception:  # noqa: BLE001 — never crash the heartbeat
+            fp = str(f.get("finding_id") or f.get("metric_key") or "unknown")
+            logger.warning(
+                "proactive_health: task_hub_emit_fn failed for %s",
+                fp,
+                exc_info=True,
+            )
+
+
 async def run_pre_flight_check(
     *,
     workspace_dir: Path,
@@ -257,6 +278,7 @@ async def run_pre_flight_check(
     agentmail_service: Optional[_AgentMailLike],
     notifications_list: Optional[list[dict[str, Any]]],
     add_notification_fn: Optional[Callable[..., dict[str, Any]]],
+    task_hub_emit_fn: Optional[Callable[[dict[str, Any]], None]] = None,
 ) -> dict[str, Any]:
     """Run the proactive watchdog as a pre-flight before any agent invocation.
 
@@ -311,6 +333,10 @@ async def run_pre_flight_check(
                     fp,
                     consecutive,
                 )
+            # Task Hub channel is independent of email. Even when email is
+            # blocked, park a `needs_review` row for each critical so the
+            # finding survives past this heartbeat.
+            _emit_to_task_hub(criticals, task_hub_emit_fn)
             return payload
 
     cooldown = _cooldown_seconds()
@@ -318,7 +344,11 @@ async def run_pre_flight_check(
     notifications = notifications_list if notifications_list is not None else []
 
     sent_count = 0
-    for finding in _critical_invariants(payload):
+    criticals_this_tick = _critical_invariants(payload)
+    # Park Task Hub rows up front so the persistent backlog reflects every
+    # critical, independent of whether email succeeds or hits cooldown.
+    _emit_to_task_hub(criticals_this_tick, task_hub_emit_fn)
+    for finding in criticals_this_tick:
         sent = await _notify_critical(
             finding=finding,
             payload_generated_at=generated_at,

--- a/tests/unit/test_csi_source_liveness.py
+++ b/tests/unit/test_csi_source_liveness.py
@@ -1,0 +1,213 @@
+"""Tests for the universal CSI source liveness invariant.
+
+Background: prior to P1a, only `youtube_channel_rss` had invariant coverage
+(via the two YouTube-specific invariants in PR #367). Five other CSI
+adapters — youtube_playlist, reddit_discovery, threads_owned,
+threads_trends_seeded, threads_trends_broad — were entirely invisible to
+the watchdog. Live data on 2026-05-20 showed three of them dead (40h+ no
+events) with zero alerts. P1a adds one invariant that covers all six
+adapters by checking max(occurred_at) per source vs. an expected-cadence
+threshold.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from universal_agent.services import pipeline_invariants as pi
+from universal_agent.services.pipeline_invariants import (
+    clear_registry_for_tests,
+    run_invariants,
+)
+
+UTC = timezone.utc
+
+EVENTS_SCHEMA = """
+CREATE TABLE events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id TEXT UNIQUE NOT NULL,
+    dedupe_key TEXT NOT NULL DEFAULT '',
+    source TEXT NOT NULL,
+    event_type TEXT NOT NULL DEFAULT 'item',
+    occurred_at TEXT NOT NULL,
+    received_at TEXT NOT NULL DEFAULT '',
+    emitted_at TEXT,
+    subject_json TEXT NOT NULL DEFAULT '{}',
+    routing_json TEXT NOT NULL DEFAULT '{}',
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    delivered INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT (datetime('now'))
+);
+"""
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    """Each test loads only csi_source_liveness so other invariants don't
+    cross-contaminate findings counts."""
+    clear_registry_for_tests()
+    from universal_agent.services.invariants import csi_source_liveness
+    importlib.reload(csi_source_liveness)
+    yield
+    clear_registry_for_tests()
+
+
+def _seed_events(db_path: Path, rows: list[tuple[str, str]]) -> None:
+    """Seed (source, occurred_at_iso) tuples into a fresh csi.db."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(EVENTS_SCHEMA)
+        for i, (source, occurred_at) in enumerate(rows):
+            conn.execute(
+                "INSERT INTO events (event_id, dedupe_key, source, occurred_at, received_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (f"e{i}", f"d{i}", source, occurred_at, occurred_at),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _hours_ago(h: float) -> str:
+    return (datetime.now(UTC) - timedelta(hours=h)).isoformat()
+
+
+def test_registers_on_import() -> None:
+    ids = {inv.id for inv in pi.get_registered_invariants()}
+    assert "csi_source_liveness" in ids
+
+
+def test_all_sources_fresh_emits_nothing(tmp_path: Path) -> None:
+    """Every monitored source has an event within its threshold → no finding."""
+    from universal_agent.services.invariants.csi_source_liveness import (
+        SOURCE_THRESHOLDS_HOURS,
+    )
+    db = tmp_path / "csi.db"
+    # Seed every monitored source with a recent event so nothing trips
+    # either the stale OR never_seen branches.
+    _seed_events(
+        db,
+        [(source, _hours_ago(0.5)) for source in SOURCE_THRESHOLDS_HOURS],
+    )
+    findings = run_invariants({"csi_db_path": db})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert matches == []
+
+
+def test_one_stale_source_emits_one_finding(tmp_path: Path) -> None:
+    """Single source past its threshold → one finding listing that source."""
+    from universal_agent.services.invariants.csi_source_liveness import (
+        SOURCE_THRESHOLDS_HOURS,
+    )
+    db = tmp_path / "csi.db"
+    rows = [(s, _hours_ago(0.5)) for s in SOURCE_THRESHOLDS_HOURS if s != "youtube_channel_rss"]
+    rows.append(("youtube_channel_rss", _hours_ago(48)))  # WAY past 12h threshold
+    _seed_events(db, rows)
+    findings = run_invariants({"csi_db_path": db})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale = obs.get("stale_sources") or []
+    assert any(s.get("source") == "youtube_channel_rss" for s in stale)
+    # Healthy source should NOT appear in stale list
+    assert not any(s.get("source") == "hackernews" for s in stale)
+
+
+def test_multiple_stale_sources_listed_in_one_finding(tmp_path: Path) -> None:
+    """Three of N sources dead → ONE finding listing them (operator gets
+    full picture per alert, not three separate emails). Other monitored
+    sources are also seeded fresh so we can assert just on the stale set."""
+    from universal_agent.services.invariants.csi_source_liveness import (
+        SOURCE_THRESHOLDS_HOURS,
+    )
+    db = tmp_path / "csi.db"
+    stale_sources_expected = {
+        "youtube_channel_rss",
+        "reddit_discovery",
+        "threads_trends_broad",
+    }
+    rows: list[tuple[str, str]] = []
+    for source in SOURCE_THRESHOLDS_HOURS:
+        if source in stale_sources_expected:
+            # well past every threshold
+            rows.append((source, _hours_ago(200)))
+        else:
+            rows.append((source, _hours_ago(0.5)))
+    _seed_events(db, rows)
+    findings = run_invariants({"csi_db_path": db})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale_actual = {s["source"] for s in obs.get("stale_sources") or []}
+    assert stale_actual == stale_sources_expected
+
+
+def test_completely_missing_source_emits_finding(tmp_path: Path) -> None:
+    """A monitored source with ZERO events in the recent window should also
+    fire (never_seen state, distinct from stale). Seed all other sources
+    fresh so we isolate just the never_seen case."""
+    from universal_agent.services.invariants.csi_source_liveness import (
+        SOURCE_THRESHOLDS_HOURS,
+    )
+    db = tmp_path / "csi.db"
+    # All sources fresh EXCEPT youtube_playlist (never seeded)
+    rows = [
+        (source, _hours_ago(0.5))
+        for source in SOURCE_THRESHOLDS_HOURS
+        if source != "youtube_playlist"
+    ]
+    _seed_events(db, rows)
+    findings = run_invariants({"csi_db_path": db})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale_list = obs.get("stale_sources") or []
+    yt_playlist = [s for s in stale_list if s["source"] == "youtube_playlist"]
+    assert len(yt_playlist) == 1
+    assert yt_playlist[0]["state"] == "never_seen"
+
+
+def test_missing_csi_db_path_is_silent(tmp_path: Path) -> None:
+    findings = run_invariants({"csi_db_path": None})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert matches == []
+
+
+def test_nonexistent_csi_db_path_is_silent(tmp_path: Path) -> None:
+    """Path provided but the file doesn't exist (dev box without CSI) →
+    silent. Watchdog never crashes on a missing upstream."""
+    findings = run_invariants({"csi_db_path": tmp_path / "does_not_exist.db"})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert matches == []
+
+
+def test_db_without_events_table_is_silent(tmp_path: Path) -> None:
+    """DB file exists but no events table (early dev / migration state) →
+    silent. Don't crash the heartbeat over a schema drift."""
+    db = tmp_path / "csi.db"
+    sqlite3.connect(str(db)).close()  # creates empty DB
+    findings = run_invariants({"csi_db_path": db})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert matches == []
+
+
+def test_finding_has_actionable_runbook(tmp_path: Path) -> None:
+    """Operator should be able to investigate from the finding alone."""
+    db = tmp_path / "csi.db"
+    _seed_events(db, [("youtube_channel_rss", _hours_ago(48))])
+    findings = run_invariants({"csi_db_path": db})
+    matches = [f for f in findings if f.metric_key == "csi_source_liveness"]
+    assert len(matches) == 1
+    f = matches[0]
+    # runbook_command should mention csi-ingester or events query
+    assert f.runbook_command and (
+        "csi-ingester" in (f.runbook_command or "")
+        or "events" in (f.runbook_command or "")
+    )
+    # recommendation should name at least one stale source
+    assert "youtube_channel_rss" in (f.recommendation or "")

--- a/tests/unit/test_proactive_health_notifier.py
+++ b/tests/unit/test_proactive_health_notifier.py
@@ -544,3 +544,102 @@ async def test_send_test_critical_email_returns_unsent_when_no_agentmail(monkeyp
     result = await send_test_critical_email(agentmail_service=None)
     assert result["sent"] is False
     assert "agentmail_service=None" in result["reason"]
+
+
+# ─── P0c: task_hub emission so critical findings persist past one tick ────────
+# Background: PR #389 added per-finding email + 6h dedup. Email is necessary
+# but not sufficient — emails get archived/ignored. Findings should also park
+# a `needs_review` row in Task Hub so Simone has a persistent backlog of
+# unresolved criticals. This closes the loop the original HEARTBEAT.md
+# directive failed to close (Simone wasn't auto-emitting Task Hub rows for
+# findings even though she had access to them).
+
+@pytest.mark.asyncio
+async def test_critical_finding_emits_task_hub_row(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn
+):
+    """When task_hub_emit_fn is provided, the notifier passes each critical
+    finding to it. Lets the caller wire actual Task Hub upsert without the
+    notifier importing gateway_server / task_hub modules directly."""
+    emitted: list[dict] = []
+
+    def _emit(finding: dict) -> None:
+        emitted.append(finding)
+
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        task_hub_emit_fn=_emit,
+    )
+    assert len(emitted) == 1
+    assert emitted[0]["metric_key"] == "youtube_enrichment_coverage"
+    assert emitted[0]["severity"] == "critical"
+
+
+@pytest.mark.asyncio
+async def test_task_hub_emit_fn_failure_does_not_crash(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn
+):
+    """The notifier must never crash the heartbeat. If task_hub_emit_fn raises,
+    it logs and continues. Email still gets sent."""
+    def _emit_boom(finding: dict) -> None:
+        raise RuntimeError("simulated task_hub DB locked")
+
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        task_hub_emit_fn=_emit_boom,
+    )
+    # Email still sent despite the emit failure.
+    fake_agentmail.send_email.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_task_hub_emit_fn_is_backwards_compatible(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn
+):
+    """Existing callers that don't pass task_hub_emit_fn keep working (the
+    parameter is optional). Email still sent, sidecar still written."""
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        # task_hub_emit_fn omitted entirely
+    )
+    fake_agentmail.send_email.assert_awaited_once()
+    assert (tmp_path / "work_products" / "proactive_health_latest.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_task_hub_emit_runs_even_when_email_skipped(
+    tmp_path, notifications_list, add_notification_fn, caplog
+):
+    """If email plumbing is broken (no agentmail_service) but task_hub_emit_fn
+    is wired, the Task Hub row should still be created. Email and task hub
+    are independent escalation channels — losing one shouldn't lose both."""
+    import logging
+    caplog.set_level(logging.WARNING)
+    emitted: list[dict] = []
+
+    def _emit(finding: dict) -> None:
+        emitted.append(finding)
+
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_critical_payload,
+        agentmail_service=None,  # no email path
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        task_hub_emit_fn=_emit,
+    )
+    # Email path skipped (logged) but task_hub_emit_fn still fired
+    assert len(emitted) == 1
+    assert any("SKIPPED" in r.getMessage() for r in caplog.records)

--- a/tests/unit/test_proactive_health_payload.py
+++ b/tests/unit/test_proactive_health_payload.py
@@ -341,3 +341,133 @@ def test_missing_cron_persistence_path_is_silent(
     )
     assert payload["crons"] == []
     assert payload["overall_status"] == "ok"
+
+
+# ─── P0b: invariants read proactive_* tables from activity_conn ──────────────
+# Background: PR #392 wired the aggregator to open runtime_state.db and pass
+# it as `runtime_conn` to invariants. But the WRITERS (`_activity_connect()`
+# in gateway_server.py) write the proactive_artifacts / proactive_artifact_emails
+# / proactive_intelligence_reports tables into activity_state.db. As a result
+# 4 invariants (proactive_artifact_digest_delivery, proactive_reports_daily_trio,
+# csi_demo_triage_rank_artifact, paper_to_podcast_email_delivery) were silently
+# no-op'ing because they queried an empty DB. Fix: invariants use activity_conn
+# (already in context for task_hub_items queries — same DB has the proactive
+# tables too), aggregator stops opening the dead runtime_state.db connection.
+
+def test_proactive_artifact_digest_invariant_reads_from_activity_conn(
+    tmp_path: Path,
+) -> None:
+    """When the activity_conn DB has proactive_artifact_emails with a fresh
+    delivery, the proactive_artifact_digest_delivery invariant should NOT fire
+    (a healthy state). Before P0b, the invariant read from runtime_conn which
+    was empty, so this test would have passed for the wrong reason — the
+    invariant silently no-op'd whether the email was sent or not.
+
+    The post-fix behavior: invariant queries activity_conn and finds the
+    fresh row, so it stays quiet. A *missing* row (separate test below) is
+    what should fire it. Either way, we prove it's reading the right DB."""
+    from datetime import datetime, timezone, timedelta
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    # task_hub_items so the activity_conn path doesn't blow up
+    conn.executescript(TASK_HUB_SCHEMA)
+    # proactive_artifact_emails — same DB, different table (real prod layout)
+    conn.executescript(
+        """
+        CREATE TABLE proactive_artifact_emails (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            artifact_id TEXT NOT NULL,
+            message_id TEXT NOT NULL DEFAULT '',
+            thread_id TEXT NOT NULL DEFAULT '',
+            subject TEXT NOT NULL DEFAULT '',
+            recipient TEXT NOT NULL DEFAULT '',
+            sent_at TEXT NOT NULL,
+            delivery_state TEXT NOT NULL DEFAULT 'emailed',
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+        """
+    )
+    fresh = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    conn.execute(
+        "INSERT INTO proactive_artifact_emails (artifact_id, subject, recipient, sent_at) "
+        "VALUES ('a1', 'Proactive Digest 2026-05-20', 'kevinjdragan@gmail.com', ?)",
+        (fresh,),
+    )
+    conn.commit()
+
+    payload = build_proactive_health_payload(
+        activity_conn=conn,
+        cron_jobs=[],
+        csi_db_path=None,
+    )
+    digest_findings = [
+        f for f in payload["invariants"]
+        if f.get("metric_key") == "proactive_artifact_digest_delivery"
+    ]
+    # Fresh row → invariant should not fire. The key proof is that the
+    # aggregator + invariant path saw our seeded row.
+    assert digest_findings == [], (
+        f"Invariant fired despite fresh email row: {digest_findings}"
+    )
+
+
+def test_proactive_artifact_digest_invariant_fires_when_emails_stale(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The bug-reproduction case: aggregator should DETECT that no digest
+    email has been sent in 26h+. Before P0b, the invariant queried the empty
+    runtime_state.db and silently passed — it could never fire on real data."""
+    from datetime import datetime, timezone, timedelta
+    # Pin the clock to a moment WELL past the 9 AM probe window so the
+    # invariant's hour-gate doesn't filter the test out.
+    from universal_agent.services.invariants import proactive_pipeline_invariants as ppi
+    fixed_now = datetime(2026, 5, 20, 18, 0, tzinfo=timezone.utc)  # 1 PM Houston
+    monkeypatch.setattr(ppi, "_now_houston", lambda: fixed_now.astimezone(ppi.HOUSTON_TZ) if hasattr(ppi, "HOUSTON_TZ") else fixed_now)
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(TASK_HUB_SCHEMA)
+    conn.executescript(
+        """
+        CREATE TABLE proactive_artifact_emails (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            artifact_id TEXT NOT NULL,
+            message_id TEXT NOT NULL DEFAULT '',
+            thread_id TEXT NOT NULL DEFAULT '',
+            subject TEXT NOT NULL DEFAULT '',
+            recipient TEXT NOT NULL DEFAULT '',
+            sent_at TEXT NOT NULL,
+            delivery_state TEXT NOT NULL DEFAULT 'emailed',
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+        """
+    )
+    stale = (datetime.now(timezone.utc) - timedelta(hours=30)).isoformat()
+    conn.execute(
+        "INSERT INTO proactive_artifact_emails (artifact_id, subject, recipient, sent_at) "
+        "VALUES ('a1', 'Old Digest', 'kevinjdragan@gmail.com', ?)",
+        (stale,),
+    )
+    conn.commit()
+
+    # Need the invariant registered. The conftest pattern from the existing
+    # YouTube test resets the registry — re-import to pick up proactive_*.
+    import importlib
+    from universal_agent.services.invariants import proactive_pipeline_invariants
+    importlib.reload(proactive_pipeline_invariants)
+
+    payload = build_proactive_health_payload(
+        activity_conn=conn,
+        cron_jobs=[],
+        csi_db_path=None,
+    )
+    digest_findings = [
+        f for f in payload["invariants"]
+        if f.get("metric_key") == "proactive_artifact_digest_delivery"
+    ]
+    # Proof of fix: the invariant FOUND the stale row and flagged it. Before
+    # P0b, this list would be empty because the invariant read from an empty
+    # runtime_state.db connection.
+    assert len(digest_findings) >= 1, (
+        f"Expected stale-digest finding but got: {payload['invariants']}"
+    )

--- a/tests/unit/test_proactive_pipeline_invariants.py
+++ b/tests/unit/test_proactive_pipeline_invariants.py
@@ -169,7 +169,7 @@ def test_morning_briefing_silent_without_artifacts_dir(monkeypatch) -> None:
 
 def test_digest_recent_emits_nothing(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 10, 0, tzinfo=HOUSTON))
-    conn = _seeded_activity_conn()
+    conn = _seeded_proactive_artifacts_conn()
     now_utc = datetime.now(UTC)
     conn.execute(
         "INSERT INTO proactive_artifact_emails (artifact_id, recipient, sent_at) "
@@ -177,13 +177,13 @@ def test_digest_recent_emits_nothing(monkeypatch) -> None:
         ((now_utc - timedelta(hours=1)).isoformat(),),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "proactive_artifact_digest_delivery") == []
 
 
 def test_digest_old_emits_warn(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 10, 0, tzinfo=HOUSTON))
-    conn = _seeded_activity_conn()
+    conn = _seeded_proactive_artifacts_conn()
     old = datetime.now(UTC) - timedelta(hours=40)
     conn.execute(
         "INSERT INTO proactive_artifact_emails (artifact_id, recipient, sent_at) "
@@ -191,7 +191,7 @@ def test_digest_old_emits_warn(monkeypatch) -> None:
         (old.isoformat(),),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     matches = _only(findings, "proactive_artifact_digest_delivery")
     assert len(matches) == 1
     assert matches[0].severity == "warn"
@@ -199,14 +199,14 @@ def test_digest_old_emits_warn(monkeypatch) -> None:
 
 def test_digest_empty_table_stays_quiet(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 10, 0, tzinfo=HOUSTON))
-    conn = _seeded_activity_conn()
-    findings = run_invariants({"runtime_conn": conn})
+    conn = _seeded_proactive_artifacts_conn()
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "proactive_artifact_digest_delivery") == []
 
 
 def test_digest_silent_before_9am(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 8, 0, tzinfo=HOUSTON))
-    conn = _seeded_activity_conn()
+    conn = _seeded_proactive_artifacts_conn()
     old = datetime.now(UTC) - timedelta(hours=40)
     conn.execute(
         "INSERT INTO proactive_artifact_emails (artifact_id, recipient, sent_at) "
@@ -214,7 +214,7 @@ def test_digest_silent_before_9am(monkeypatch) -> None:
         (old.isoformat(),),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "proactive_artifact_digest_delivery") == []
 
 
@@ -277,7 +277,7 @@ def test_hn_silent_in_early_6am_window(tmp_path: Path, monkeypatch) -> None:
 
 def test_csi_convergence_fresh_emits_nothing(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 14, 0, tzinfo=HOUSTON))
-    conn = _seeded_activity_conn()
+    conn = _seeded_proactive_artifacts_conn()
     conn.execute(
         "INSERT INTO proactive_convergence_events (event_id, primary_topic, detected_at) "
         "VALUES ('e1', 'MCP', ?)",
@@ -290,7 +290,7 @@ def test_csi_convergence_fresh_emits_nothing(monkeypatch) -> None:
 
 def test_csi_convergence_stale_emits_warn(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 14, 0, tzinfo=HOUSTON))
-    conn = _seeded_activity_conn()
+    conn = _seeded_proactive_artifacts_conn()
     conn.execute(
         "INSERT INTO proactive_convergence_events (event_id, primary_topic, detected_at) "
         "VALUES ('e1', 'MCP', ?)",
@@ -305,7 +305,7 @@ def test_csi_convergence_stale_emits_warn(monkeypatch) -> None:
 
 def test_csi_convergence_empty_table_stays_quiet(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 14, 0, tzinfo=HOUSTON))
-    conn = _seeded_activity_conn()
+    conn = _seeded_proactive_artifacts_conn()
     findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "csi_convergence_sync_freshness") == []
 
@@ -381,12 +381,26 @@ def test_nightly_wiki_silent_without_artifacts_dir(monkeypatch) -> None:
 # earlier 5.
 
 
-def _seeded_runtime_conn() -> sqlite3.Connection:
-    """In-memory runtime_state.db with the proactive tables this PR queries."""
+def _seeded_proactive_artifacts_conn() -> sqlite3.Connection:
+    """In-memory activity DB seeded with proactive_intelligence_reports +
+    proactive_artifacts + proactive_artifact_emails + proactive_convergence_events.
+    Used by the WS3 invariants AND the csi_convergence invariant (P0b: all
+    invariants now use the same activity_conn key)."""
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
     conn.executescript(
         """
+        CREATE TABLE proactive_convergence_events (
+            event_id TEXT PRIMARY KEY,
+            primary_topic TEXT NOT NULL,
+            video_ids_json TEXT NOT NULL DEFAULT '[]',
+            channel_names_json TEXT NOT NULL DEFAULT '[]',
+            brief_task_id TEXT NOT NULL DEFAULT '',
+            artifact_id TEXT NOT NULL DEFAULT '',
+            feedback_score INTEGER,
+            detected_at TEXT NOT NULL,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
         CREATE TABLE proactive_intelligence_reports (
             report_id TEXT PRIMARY KEY,
             period TEXT NOT NULL,
@@ -442,7 +456,7 @@ def _seeded_runtime_conn() -> sqlite3.Connection:
 
 def test_proactive_reports_daily_trio_all_present_quiet(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 18, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
+    conn = _seeded_proactive_artifacts_conn()
     today = "2026-05-19"
     for period in ["morning", "midday", "afternoon"]:
         conn.execute(
@@ -451,13 +465,13 @@ def test_proactive_reports_daily_trio_all_present_quiet(monkeypatch) -> None:
             (f"r_{period}", period, f"{today}T12:00:00", f"{today}T12:00:00"),
         )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "proactive_reports_daily_trio") == []
 
 
 def test_proactive_reports_daily_trio_only_one_fires_warn(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 18, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
+    conn = _seeded_proactive_artifacts_conn()
     today = "2026-05-19"
     conn.execute(
         "INSERT INTO proactive_intelligence_reports "
@@ -465,7 +479,7 @@ def test_proactive_reports_daily_trio_only_one_fires_warn(monkeypatch) -> None:
         (f"{today}T07:05:00", f"{today}T07:05:00"),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     matches = _only(findings, "proactive_reports_daily_trio")
     assert len(matches) == 1
     obs = matches[0].observed_value
@@ -477,7 +491,7 @@ def test_proactive_reports_daily_trio_only_one_fires_warn(monkeypatch) -> None:
 def test_proactive_reports_daily_trio_two_of_three_stays_quiet(monkeypatch) -> None:
     """Tolerate 1 missed slot as routine API blip."""
     _set_now(monkeypatch, datetime(2026, 5, 19, 18, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
+    conn = _seeded_proactive_artifacts_conn()
     today = "2026-05-19"
     for period in ["morning", "midday"]:
         conn.execute(
@@ -486,14 +500,14 @@ def test_proactive_reports_daily_trio_two_of_three_stays_quiet(monkeypatch) -> N
             (f"r_{period}", period, f"{today}T12:00:00", f"{today}T12:00:00"),
         )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "proactive_reports_daily_trio") == []
 
 
 def test_proactive_reports_daily_trio_silent_before_5pm(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 14, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
-    findings = run_invariants({"runtime_conn": conn})
+    conn = _seeded_proactive_artifacts_conn()
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "proactive_reports_daily_trio") == []
 
 
@@ -545,7 +559,7 @@ def test_claude_code_intel_silent_during_dormancy(tmp_path: Path, monkeypatch) -
 
 def test_csi_demo_triage_rank_recent_quiet(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 16, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
+    conn = _seeded_proactive_artifacts_conn()
     recent_iso = (datetime.now(UTC) - timedelta(hours=2)).isoformat()
     conn.execute(
         "INSERT INTO proactive_artifacts (artifact_id, artifact_type, source_kind, "
@@ -554,13 +568,13 @@ def test_csi_demo_triage_rank_recent_quiet(monkeypatch) -> None:
         (recent_iso, recent_iso),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "csi_demo_triage_rank_artifact") == []
 
 
 def test_csi_demo_triage_rank_stale_fires_critical(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 16, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
+    conn = _seeded_proactive_artifacts_conn()
     old_iso = (datetime.now(UTC) - timedelta(hours=12)).isoformat()
     conn.execute(
         "INSERT INTO proactive_artifacts (artifact_id, artifact_type, source_kind, "
@@ -569,7 +583,7 @@ def test_csi_demo_triage_rank_stale_fires_critical(monkeypatch) -> None:
         (old_iso, old_iso),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     matches = _only(findings, "csi_demo_triage_rank_artifact")
     assert len(matches) == 1
     assert matches[0].severity == "critical"
@@ -578,8 +592,8 @@ def test_csi_demo_triage_rank_stale_fires_critical(monkeypatch) -> None:
 def test_csi_demo_triage_rank_empty_table_stays_quiet(monkeypatch) -> None:
     """No rows of this artifact_type yet — feature not active, stay quiet."""
     _set_now(monkeypatch, datetime(2026, 5, 19, 16, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
-    findings = run_invariants({"runtime_conn": conn})
+    conn = _seeded_proactive_artifacts_conn()
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "csi_demo_triage_rank_artifact") == []
 
 
@@ -588,7 +602,7 @@ def test_csi_demo_triage_rank_empty_table_stays_quiet(monkeypatch) -> None:
 
 def test_paper_to_podcast_recent_email_quiet(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 8, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
+    conn = _seeded_proactive_artifacts_conn()
     recent_iso = (datetime.now(UTC) - timedelta(hours=10)).isoformat()
     conn.execute(
         "INSERT INTO proactive_artifact_emails (artifact_id, recipient, subject, sent_at) "
@@ -596,13 +610,13 @@ def test_paper_to_podcast_recent_email_quiet(monkeypatch) -> None:
         (recent_iso,),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "paper_to_podcast_email_delivery") == []
 
 
 def test_paper_to_podcast_old_email_fires_critical(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 8, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
+    conn = _seeded_proactive_artifacts_conn()
     old_iso = (datetime.now(UTC) - timedelta(hours=48)).isoformat()
     conn.execute(
         "INSERT INTO proactive_artifact_emails (artifact_id, recipient, subject, sent_at) "
@@ -610,7 +624,7 @@ def test_paper_to_podcast_old_email_fires_critical(monkeypatch) -> None:
         (old_iso,),
     )
     conn.commit()
-    findings = run_invariants({"runtime_conn": conn})
+    findings = run_invariants({"activity_conn": conn})
     matches = _only(findings, "paper_to_podcast_email_delivery")
     assert len(matches) == 1
     assert matches[0].severity == "critical"
@@ -618,8 +632,8 @@ def test_paper_to_podcast_old_email_fires_critical(monkeypatch) -> None:
 
 def test_paper_to_podcast_empty_table_stays_quiet(monkeypatch) -> None:
     _set_now(monkeypatch, datetime(2026, 5, 19, 8, 0, tzinfo=HOUSTON))
-    conn = _seeded_runtime_conn()
-    findings = run_invariants({"runtime_conn": conn})
+    conn = _seeded_proactive_artifacts_conn()
+    findings = run_invariants({"activity_conn": conn})
     assert _only(findings, "paper_to_podcast_email_delivery") == []
 
 


### PR DESCRIPTION
## Summary

Before this PR, only `youtube_channel_rss` had liveness coverage. The other 5 CSI adapters plus `csi_analytics` and `hackernews` were entirely invisible. The 2026-05-20 holistic audit found three adapters dead for 40+ hours with zero watchdog alerts.

P1a adds one invariant (`csi_source_liveness`) that watches all 8 monitored sources via `max(occurred_at)` in `csi.db`'s events table against a per-source threshold. Multi-source failure emits ONE finding with a per-source breakdown in `observed_value` — operator gets the full picture per alert, not 8 separate emails.

States emitted: `stale` (last event past threshold) and `never_seen` (zero events in 30d).

## Thresholds shipped

| Source | Threshold | Rationale |
|---|---|---|
| hackernews | 3h | Very high freq |
| csi_analytics | 12h | Downstream aggregator |
| youtube_channel_rss | 12h | 444-channel watchlist |
| youtube_playlist | 48h | Playlists tick less often |
| reddit_discovery | 12h | Subreddit polling |
| threads_owned | 12h | Owned-handle polling |
| threads_trends_seeded | 24h | Lower cadence |
| threads_trends_broad | 24h | Broadest sweep |

These are intentionally generous to start — tune in a follow-up after a few weeks of operational data.

## Why one invariant covering all 8 (not 8 separate invariants)

The framework emits at most one finding per invariant. Splitting per-source would generate up to 8 separate emails + 8 Task Hub rows on a bad day (spam). The single-finding design lets the operator triage all stale sources from one alert.

## Test plan

- [x] TDD: 9 tests covering fresh state, single stale, multi-stale, never_seen, missing db_path, nonexistent file, missing events table, runbook content
- [x] RED'd before implementation; GREEN after
- [x] 89 watchdog tests pass (80 prior + 9 new)
- [ ] After deploy: confirm sidecar shows new `csi_source_liveness` finding with stale entries for the three currently-dead adapters (youtube_channel_rss, threads_trends_broad, reddit_discovery)

## Stack position

Stacks on PRs #395 (P0a), #396 (P0b), #397 (P0c). With this PR landed, the watchdog framework is fully restored: populated cron list, correct DB, persistent Task Hub backlog, and coverage extended from 1 CSI adapter to 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)