### PR TITLE
feat(watchdog): P1b — universal cron staleness invariant

### DIFF
--- a/src/universal_agent/services/invariants/__init__.py
+++ b/src/universal_agent/services/invariants/__init__.py
@@ -15,6 +15,7 @@ Authoring a new invariant:
 from __future__ import annotations
 
 from universal_agent.services.invariants import (  # noqa: F401
+    cron_staleness,
     csi_source_liveness,
     proactive_pipeline_invariants,
     youtube_invariants,

--- a/src/universal_agent/services/invariants/cron_staleness.py
+++ b/src/universal_agent/services/invariants/cron_staleness.py
@@ -1,0 +1,231 @@
+"""Universal cron last-run staleness invariant.
+
+After P0a (PR #395) the watchdog sidecar's `crons[]` is populated with
+every persisted cron job (job_id, enabled, cron_expr, last_run_at,
+last_outcome, next_run_at). P1b adds the matching Layer-2 invariant:
+walk every enabled cron, derive its expected interval from the cron_expr,
+and fire when last_run is >2× past that interval.
+
+Three failure modes flagged:
+1. `stale` — last_run > 2× expected interval old.
+2. `last_outcome_error` — recent run, but the last outcome wasn't success.
+3. `never_run` — last_run is None AND next_run was in the past
+   (registered but never fired). Brand-new crons with future next_run
+   stay quiet.
+
+One invariant, one finding listing every stale cron. Splitting per-cron
+would emit up to 22 alerts on a bad day.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from typing import Any, Dict, Optional
+
+try:
+    from croniter import croniter
+except ImportError:  # croniter is in pyproject deps; this is a paranoia branch
+    croniter = None  # type: ignore[assignment]
+
+from universal_agent.services.pipeline_invariants import invariant
+
+logger = logging.getLogger(__name__)
+
+
+# Multiplier on the cron's expected interval. last_run > MULTIPLIER × interval
+# old is flagged. 2.0 gives one cycle of grace so a cron that simply ran a
+# little late doesn't trip the alarm.
+STALENESS_MULTIPLIER = 2.0
+
+# Floor: any cron whose interval is less than this gets this as its threshold
+# instead. Prevents `*/1 * * * *` crons from firing on 2-min lag.
+MIN_STALENESS_SECONDS = 300.0  # 5 min
+
+
+def _parse_timestamp(value: Any) -> Optional[datetime]:
+    """Accept epoch float, epoch int, or ISO string; return aware UTC datetime."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
+    s = str(value).strip()
+    if not s:
+        return None
+    try:
+        parsed = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except (ValueError, AttributeError):
+        return None
+
+
+def _expected_interval_seconds(cron_expr: str, ref_dt: datetime) -> Optional[float]:
+    """Compute the gap between the next two scheduled fires after `ref_dt`.
+
+    This is the cron's expected cadence as advertised by its expression.
+    Returns None if the expression is unparseable.
+    """
+    if croniter is None:
+        return None
+    try:
+        c = croniter(cron_expr, ref_dt)
+        first = c.get_next(datetime)
+        second = c.get_next(datetime)
+        # Ensure aware datetimes for subtraction.
+        if first.tzinfo is None:
+            first = first.replace(tzinfo=timezone.utc)
+        if second.tzinfo is None:
+            second = second.replace(tzinfo=timezone.utc)
+        return (second - first).total_seconds()
+    except Exception:  # noqa: BLE001 — croniter raises a variety of types
+        return None
+
+
+def _evaluate_cron(cron: Dict[str, Any], now: datetime) -> Optional[Dict[str, Any]]:
+    """Return a {job_id, reason, ...} dict if the cron is in trouble; None if OK.
+
+    Caller filters disabled crons before calling.
+    """
+    job_id = str(cron.get("job_id") or "?")
+    cron_expr = str(cron.get("cron_expr") or "").strip()
+    if not cron_expr:
+        return None
+
+    last_run = _parse_timestamp(cron.get("last_run_at"))
+    next_run = _parse_timestamp(cron.get("next_run_at"))
+    last_outcome = str(cron.get("last_outcome") or "").strip().lower()
+
+    interval = _expected_interval_seconds(cron_expr, last_run or now)
+    if interval is None:
+        # Unparseable cron_expr — skip silently, don't crash.
+        logger.debug("cron_staleness: cannot parse cron_expr for %s: %r", job_id, cron_expr)
+        return None
+    threshold_seconds = max(MIN_STALENESS_SECONDS, interval * STALENESS_MULTIPLIER)
+
+    # Case 1: never run
+    if last_run is None:
+        if next_run is not None and next_run < now:
+            return {
+                "job_id": job_id,
+                "reason": "never_run",
+                "cron_expr": cron_expr,
+                "expected_interval_seconds": round(interval, 1),
+                "last_run_at": None,
+                "next_run_at_utc": next_run.isoformat(),
+            }
+        return None
+
+    # Case 2: stale by timing
+    age_seconds = (now - last_run).total_seconds()
+    if age_seconds > threshold_seconds:
+        return {
+            "job_id": job_id,
+            "reason": "stale",
+            "cron_expr": cron_expr,
+            "expected_interval_seconds": round(interval, 1),
+            "threshold_seconds": round(threshold_seconds, 1),
+            "age_seconds": round(age_seconds, 1),
+            "last_run_at_utc": last_run.isoformat(),
+            "last_outcome": last_outcome or None,
+        }
+
+    # Case 3: ran on time but outcome was an error
+    if last_outcome and last_outcome not in {"success", "ok", "clean_exit_zero", "completed"}:
+        return {
+            "job_id": job_id,
+            "reason": "last_outcome_error",
+            "cron_expr": cron_expr,
+            "last_run_at_utc": last_run.isoformat(),
+            "last_outcome": last_outcome,
+        }
+
+    return None
+
+
+@invariant(
+    id="cron_staleness",
+    title="Every enabled cron is firing on schedule with successful outcomes",
+    description=(
+        "Walks `cron_jobs` from the watchdog context (sourced from "
+        "CronStore persistence file or in-memory CronService). For each "
+        "enabled cron: computes the expected interval from its cron_expr, "
+        "compares last_run_at against the threshold, and inspects "
+        "last_outcome. Emits one finding listing every cron in trouble."
+    ),
+    severity="warn",
+    runbook_command=(
+        "ls -la /opt/universal_agent/AGENT_RUN_WORKSPACES/cron_jobs.json; "
+        "tail -50 /opt/universal_agent/AGENT_RUN_WORKSPACES/cron_runs.jsonl | python3 -c \""
+        "import json,sys; [print(json.loads(l)) for l in sys.stdin]\""
+    ),
+    metadata={
+        "context_key": "cron_jobs",
+        "design_note": (
+            "P1b (2026-05-20): one invariant for all crons. The multiplier "
+            "of 2× the expected interval gives one cycle of grace. Floor "
+            "of 5 min keeps every-minute crons from tripping on transient "
+            "lag. Listing all stale crons in one finding avoids 22 alerts "
+            "on a bad day."
+        ),
+        "staleness_multiplier": STALENESS_MULTIPLIER,
+        "min_staleness_seconds": MIN_STALENESS_SECONDS,
+    },
+)
+def cron_staleness(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    cron_jobs = ctx.get("cron_jobs")
+    if not cron_jobs:
+        return None
+
+    now = datetime.now(timezone.utc)
+    stale_crons: list[Dict[str, Any]] = []
+
+    for raw in cron_jobs:
+        # Tolerate either dict-shaped rows (from CronStore.load_jobs after
+        # to_dict, or from the gateway endpoint's _summarize_cron_jobs) or
+        # objects exposing .to_dict.
+        if hasattr(raw, "to_dict"):
+            try:
+                cron = raw.to_dict()
+            except Exception:  # noqa: BLE001
+                continue
+        elif isinstance(raw, dict):
+            cron = raw
+        else:
+            continue
+
+        if not bool(cron.get("enabled", True)):
+            continue
+
+        try:
+            result = _evaluate_cron(cron, now)
+        except Exception as exc:  # noqa: BLE001 — defensive, never crash the runner
+            logger.debug("cron_staleness: evaluate failed for %r: %s", cron.get("job_id"), exc)
+            continue
+        if result is not None:
+            stale_crons.append(result)
+
+    if not stale_crons:
+        return None
+
+    job_ids = sorted(s["job_id"] for s in stale_crons)
+    return {
+        "observed_value": {
+            "stale_crons": stale_crons,
+            "stale_count": len(stale_crons),
+            "evaluated_at_utc": now.isoformat(),
+        },
+        "threshold_text": (
+            f"every enabled cron's last_run within {STALENESS_MULTIPLIER}× its "
+            "expected interval AND last_outcome is success"
+        ),
+        "message": (
+            f"{len(stale_crons)} cron job(s) in trouble: {', '.join(job_ids)}. "
+            f"Review last_outcome on each; check journalctl for the gateway "
+            f"service and cron_runs.jsonl for the per-job failure context."
+        ),
+    }

--- a/src/universal_agent/services/proactive_health.py
+++ b/src/universal_agent/services/proactive_health.py
@@ -241,12 +241,24 @@ def build_proactive_health_payload(
     # parallel plumbing. The `runtime_conn` parameter is kept for backwards
     # compatibility with callers that pass it explicitly, but the aggregator
     # no longer opens one itself.
+    # Pass materialized_cron_jobs (post-fallback to persistence file) so the
+    # cron_staleness invariant can walk every enabled cron. Coerce each row
+    # to a dict here once so the invariant doesn't have to re-handle
+    # to_dict() failure paths.
+    cron_jobs_for_invariants: list[Dict[str, Any]] = []
+    for job in materialized_cron_jobs or ():
+        try:
+            cron_jobs_for_invariants.append(job.to_dict() if hasattr(job, "to_dict") else dict(job))
+        except Exception:  # noqa: BLE001
+            continue
+
     invariant_findings = pipeline_invariants.run_invariants(
         {
             "csi_db_path": csi_db_path,
             "runtime_conn": runtime_conn,
             "activity_conn": activity_conn,
             "artifacts_dir": artifacts_dir,
+            "cron_jobs": cron_jobs_for_invariants,
         }
     )
 

--- a/tests/unit/test_cron_staleness.py
+++ b/tests/unit/test_cron_staleness.py
@@ -1,0 +1,217 @@
+"""Tests for the universal cron staleness invariant.
+
+Background: P0a (PR #395) populated `crons[]` in the sidecar — Layer 1 of
+the watchdog can now SEE every production cron's last_run_at. P1b adds
+Layer 2's matching invariant: one probe that walks every enabled cron,
+computes expected interval from cron_expr, and fires when last_run is
+>2× past its expected gap. One invariant covers all 22 production crons
+in one sweep instead of 22 individual probes.
+
+Failure modes detected:
+1. Cron stopped firing (last_run > 2× expected interval).
+2. Cron is firing but consistently erroring (last_outcome != success).
+3. Cron has never run AND its first scheduled time is in the past.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib
+import time
+
+import pytest
+
+from universal_agent.services import pipeline_invariants as pi
+from universal_agent.services.pipeline_invariants import (
+    clear_registry_for_tests,
+    run_invariants,
+)
+
+UTC = timezone.utc
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    clear_registry_for_tests()
+    from universal_agent.services.invariants import cron_staleness
+    importlib.reload(cron_staleness)
+    yield
+    clear_registry_for_tests()
+
+
+def _cron_dict(
+    job_id: str,
+    *,
+    cron_expr: str,
+    enabled: bool = True,
+    last_run_at: float | None = None,
+    last_outcome: str | None = "success",
+    next_run_at: float | None = None,
+) -> dict:
+    """Mimic the shape gateway_server passes (epoch seconds for *_at fields)."""
+    return {
+        "job_id": job_id,
+        "enabled": enabled,
+        "cron_expr": cron_expr,
+        "last_run_at": last_run_at,
+        "last_outcome": last_outcome,
+        "next_run_at": next_run_at,
+    }
+
+
+def _now_epoch() -> float:
+    return time.time()
+
+
+def test_registers_on_import() -> None:
+    ids = {inv.id for inv in pi.get_registered_invariants()}
+    assert "cron_staleness" in ids
+
+
+def test_all_fresh_crons_emit_nothing() -> None:
+    """Every cron ran within 2× its expected interval → no finding."""
+    crons = [
+        # Hourly cron, ran 30 min ago
+        _cron_dict("hourly_job", cron_expr="0 * * * *", last_run_at=_now_epoch() - 1800),
+        # Every-minute cron, ran 30 sec ago
+        _cron_dict("minute_job", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        # Daily cron, ran 6h ago (within 2-day = 48h threshold)
+        _cron_dict("daily_job", cron_expr="0 6 * * *", last_run_at=_now_epoch() - 21600),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_one_stale_cron_fires() -> None:
+    """A cron that ran 5h ago when expected hourly → fires."""
+    crons = [
+        _cron_dict("good_job", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        _cron_dict(
+            "stuck_job", cron_expr="0 * * * *",
+            last_run_at=_now_epoch() - 18000,  # 5h ago, hourly cron, way past 2h threshold
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale_jobs = {s["job_id"] for s in obs.get("stale_crons") or []}
+    assert "stuck_job" in stale_jobs
+    assert "good_job" not in stale_jobs
+
+
+def test_multiple_stale_crons_in_one_finding() -> None:
+    """Three stale crons → ONE finding listing all three (not three separate)."""
+    crons = [
+        _cron_dict("good", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        _cron_dict("stale_a", cron_expr="0 * * * *", last_run_at=_now_epoch() - 18000),
+        _cron_dict("stale_b", cron_expr="*/15 * * * *", last_run_at=_now_epoch() - 7200),  # 2h, 15min cron
+        _cron_dict("stale_c", cron_expr="0 6 * * *", last_run_at=_now_epoch() - 432000),  # 5 days, daily
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale_jobs = {s["job_id"] for s in obs.get("stale_crons") or []}
+    assert stale_jobs == {"stale_a", "stale_b", "stale_c"}
+
+
+def test_disabled_crons_ignored() -> None:
+    """A disabled cron with stale last_run is NOT a finding (operator opted
+    out of running it)."""
+    crons = [
+        _cron_dict(
+            "disabled", cron_expr="0 * * * *", enabled=False,
+            last_run_at=_now_epoch() - 432000,  # 5 days old, would otherwise be stale
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_error_outcome_fires_even_with_recent_last_run() -> None:
+    """A cron firing on schedule but its last outcome was an error → fires.
+    Don't make the operator wait for stale-timing — surface the error now."""
+    crons = [
+        _cron_dict(
+            "erroring", cron_expr="*/5 * * * *",
+            last_run_at=_now_epoch() - 60,  # ran 1 min ago, would be fresh
+            last_outcome="error",
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale = obs.get("stale_crons") or []
+    assert any(s["job_id"] == "erroring" and s.get("reason") == "last_outcome_error" for s in stale)
+
+
+def test_never_run_with_past_next_run_fires() -> None:
+    """A cron that has never run AND its first scheduled time was in the
+    past (cron was registered hours ago but hasn't fired) → fires."""
+    crons = [
+        _cron_dict(
+            "never_fired", cron_expr="0 * * * *",
+            last_run_at=None,
+            next_run_at=_now_epoch() - 7200,  # next_run was 2h ago, never fired
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+
+
+def test_never_run_with_future_next_run_stays_quiet() -> None:
+    """A freshly-added cron whose first scheduled time is still in the
+    future → silent (not yet expected to have run)."""
+    crons = [
+        _cron_dict(
+            "new_cron", cron_expr="0 6 * * *",
+            last_run_at=None,
+            next_run_at=_now_epoch() + 3600,  # next_run in 1h
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_empty_cron_list_silent() -> None:
+    findings = run_invariants({"cron_jobs": []})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_missing_cron_jobs_key_silent() -> None:
+    findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_malformed_cron_expr_does_not_crash() -> None:
+    """If croniter can't parse the cron_expr, skip that row gracefully —
+    never crash the watchdog over one bad row."""
+    crons = [
+        _cron_dict("good", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        _cron_dict("garbage", cron_expr="this is not a cron", last_run_at=_now_epoch() - 100000),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    # No probe-error (the invariant should swallow per-row parse failures).
+    probe_errors = [f for f in findings if "probe_error" in (f.metric_key or "")]
+    assert probe_errors == []
+
+
+def test_iso_string_last_run_at_supported() -> None:
+    """Some cron rows arrive with ISO-string timestamps (e.g. from the
+    summarizer). The invariant should handle both epoch-float and ISO."""
+    one_hour_ago = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+    crons = [
+        _cron_dict("iso_cron", cron_expr="0 * * * *", last_run_at=one_hour_ago),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    # 5h since last run on an hourly cron → fires (5h > 2h threshold)
+    assert len(matches) == 1


### PR DESCRIPTION
## Summary

After P0a (PR #395) populated the sidecar with all 22 production crons, Layer 1 could SEE every cron — but no Layer-2 invariant was walking that list to detect crons that stopped firing or started erroring. P1b closes the loop.

`cron_staleness` walks every enabled cron in `ctx["cron_jobs"]`. For each row:
- Computes the expected interval from `cron_expr` via `croniter`
- Compares `last_run_at` against `max(2× interval, 5 min floor)`
- Inspects `last_outcome`

Three failure modes emitted in one finding:
1. **`stale`** — last_run > 2× expected interval (cron stopped firing)
2. **`last_outcome_error`** — recent run but outcome wasn't success
3. **`never_run`** — last_run is None AND next_run was in the past

One invariant for all 22 prod crons. Per-cron breakdown in `observed_value.stale_crons` so the operator can triage every issue from one alert.

## Why one invariant for 22 crons

Same design as P1a (#398): the framework emits one finding per invariant. Splitting per-cron would generate up to 22 alerts on a bad day. Single-finding design keeps the email + Task Hub channels usable.

## Test plan

- [x] TDD: 12 tests covering fresh state, single/multi stale, disabled-ignored, error-with-fresh-run, never_run with past/future next_run, empty list, missing context key, malformed cron_expr resilience, epoch-float vs ISO-string timestamps
- [x] RED'd before implementation; GREEN after
- [x] 101 watchdog tests pass (89 prior + 12 new)
- [ ] After deploy: verify sidecar's `invariants[]` includes `cron_staleness` finding (or absence) per heartbeat tick

## Stack position

Stacks on PRs #395 (P0a), #396 (P0b), #397 (P0c), #398 (P1a). With this PR landed, the watchdog framework is fully restored AND its Layer-2 coverage extended:

| Phase | What it fixes |
|---|---|
| P0a #395 | Layer 1 cron list populated |
| P0b #396 | Layer 2 invariants read correct DB |
| P0c #397 | Critical findings parked as Task Hub work |
| P1a #398 | 8 CSI sources covered (was 1) |
| P1b this PR | 22 crons covered by one invariant |

🤖 Generated with [Claude Code](https://claude.com/claude-code)