### PR TITLE
feat(watchdog): P3 — warn-severity escalation to Task Hub after 3 ticks

### DIFF
--- a/lrepos/universal_agent/plans/create-a-plan-to-gentle-pebble.md
+++ b/lrepos/universal_agent/plans/create-a-plan-to-gentle-pebble.md
@@ -211,6 +211,47 @@ Nothing in this plan creates a second watchdog process or a parallel telemetry p
 
 ---
 
+## §7 — P2 Investigation findings (2026-05-20 19:00 UTC)
+
+After P0a–P1b shipped, diagnosed the three currently-dead adapters via SSH/SQL on prod (no sudo for csi-ingester logs):
+
+**Adapter state (last event UTC):**
+| Adapter | Last event | Silence | Cadence config |
+|---|---|---|---|
+| youtube_channel_rss | 2026-05-18 23:31 | ~43h | Time-gated CT hours [2,6,8,10,12,14,16,18,20], 90 min min interval |
+| threads_trends_broad | 2026-05-18 20:47 | ~46h | 1800s poll |
+| reddit_discovery | 2026-05-12 06:30 | ~8 days | 28800s poll (3x/day) |
+| youtube_playlist | (never seen) | n/a | `enabled: false` in config — deliberate, not a failure |
+| threads_owned, threads_trends_seeded | (never seen) | n/a | Config enabled but no recent events; needs investigation post-restart |
+
+**csi-ingester service state:**
+- Up since 2026-05-19 02:24 UTC (1d 16h) — never restarted during the silence
+- Memory 103 MB, CPU 5min/40h — VERY low utilization (smoking gun: adapters not actually polling)
+- 0 dead_letter rows in csi.db (adapters aren't erroring INTO the dead-letter queue)
+- 6 csi_poll_errors total over the lifetime (low)
+- HTTP /metrics shows polling alive (498 cycles, 3459 events) — but those are aggregate, hackernews is doing the work
+- 444 YouTube channels all active in DB; no config drift
+
+**Diagnosis:** the three silent adapters appear to have entered a state where the polling scheduler skips them, but no exception was thrown into dead_letter. Could be:
+- (a) Per-adapter loop task died silently; remaining adapters continued
+- (b) Adapter-internal time-gate or rate-limit state got confused and stays skipped
+- (c) Shared upstream (proxy, rate-limit cache) is broken silently
+
+**Operator action required (blocked on sudo):**
+```
+sudo systemctl restart csi-ingester
+```
+`ua` user does NOT have sudo for csi-ingester (only staging-* services). The restart should clear in-memory adapter state and recover three adapters. If silence persists post-restart, deeper investigation needs csi-ingester journal access (add `ua` to `systemd-journal` group, or get sudo for `journalctl -u csi-ingester`).
+
+**Watchdog coverage going forward:** PRs #398 (P1a csi_source_liveness) + #397 (P0c task_hub emission) means this exact failure mode will auto-surface on every heartbeat once deployed:
+- csi_source_liveness will fire as `critical` listing the stale sources
+- A `proactive_health:invariant:csi_source_liveness` row will park in Task Hub
+- The row's metadata will include the runbook command Kevin can paste
+
+So P2's structural fix is shipped via P1a; the *current* dead adapters are an operational restart away.
+
+---
+
 ## §A — Archived: Original close-out plan (WS1–WS4)
 
 (Kept for traceability. All WS1–WS4 items shipped in PRs #367, #370, #372, #374, #376, #389, #390, #392. The plumbing bugs found in §2 above are gaps in those PRs, not unshipped work.)

--- a/src/universal_agent/services/invariants/__init__.py
+++ b/src/universal_agent/services/invariants/__init__.py
@@ -15,6 +15,7 @@ Authoring a new invariant:
 from __future__ import annotations
 
 from universal_agent.services.invariants import (  # noqa: F401
+    cron_staleness,
     csi_source_liveness,
     proactive_pipeline_invariants,
     youtube_invariants,

--- a/src/universal_agent/services/invariants/cron_staleness.py
+++ b/src/universal_agent/services/invariants/cron_staleness.py
@@ -1,0 +1,231 @@
+"""Universal cron last-run staleness invariant.
+
+After P0a (PR #395) the watchdog sidecar's `crons[]` is populated with
+every persisted cron job (job_id, enabled, cron_expr, last_run_at,
+last_outcome, next_run_at). P1b adds the matching Layer-2 invariant:
+walk every enabled cron, derive its expected interval from the cron_expr,
+and fire when last_run is >2× past that interval.
+
+Three failure modes flagged:
+1. `stale` — last_run > 2× expected interval old.
+2. `last_outcome_error` — recent run, but the last outcome wasn't success.
+3. `never_run` — last_run is None AND next_run was in the past
+   (registered but never fired). Brand-new crons with future next_run
+   stay quiet.
+
+One invariant, one finding listing every stale cron. Splitting per-cron
+would emit up to 22 alerts on a bad day.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from typing import Any, Dict, Optional
+
+try:
+    from croniter import croniter
+except ImportError:  # croniter is in pyproject deps; this is a paranoia branch
+    croniter = None  # type: ignore[assignment]
+
+from universal_agent.services.pipeline_invariants import invariant
+
+logger = logging.getLogger(__name__)
+
+
+# Multiplier on the cron's expected interval. last_run > MULTIPLIER × interval
+# old is flagged. 2.0 gives one cycle of grace so a cron that simply ran a
+# little late doesn't trip the alarm.
+STALENESS_MULTIPLIER = 2.0
+
+# Floor: any cron whose interval is less than this gets this as its threshold
+# instead. Prevents `*/1 * * * *` crons from firing on 2-min lag.
+MIN_STALENESS_SECONDS = 300.0  # 5 min
+
+
+def _parse_timestamp(value: Any) -> Optional[datetime]:
+    """Accept epoch float, epoch int, or ISO string; return aware UTC datetime."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            return None
+    s = str(value).strip()
+    if not s:
+        return None
+    try:
+        parsed = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except (ValueError, AttributeError):
+        return None
+
+
+def _expected_interval_seconds(cron_expr: str, ref_dt: datetime) -> Optional[float]:
+    """Compute the gap between the next two scheduled fires after `ref_dt`.
+
+    This is the cron's expected cadence as advertised by its expression.
+    Returns None if the expression is unparseable.
+    """
+    if croniter is None:
+        return None
+    try:
+        c = croniter(cron_expr, ref_dt)
+        first = c.get_next(datetime)
+        second = c.get_next(datetime)
+        # Ensure aware datetimes for subtraction.
+        if first.tzinfo is None:
+            first = first.replace(tzinfo=timezone.utc)
+        if second.tzinfo is None:
+            second = second.replace(tzinfo=timezone.utc)
+        return (second - first).total_seconds()
+    except Exception:  # noqa: BLE001 — croniter raises a variety of types
+        return None
+
+
+def _evaluate_cron(cron: Dict[str, Any], now: datetime) -> Optional[Dict[str, Any]]:
+    """Return a {job_id, reason, ...} dict if the cron is in trouble; None if OK.
+
+    Caller filters disabled crons before calling.
+    """
+    job_id = str(cron.get("job_id") or "?")
+    cron_expr = str(cron.get("cron_expr") or "").strip()
+    if not cron_expr:
+        return None
+
+    last_run = _parse_timestamp(cron.get("last_run_at"))
+    next_run = _parse_timestamp(cron.get("next_run_at"))
+    last_outcome = str(cron.get("last_outcome") or "").strip().lower()
+
+    interval = _expected_interval_seconds(cron_expr, last_run or now)
+    if interval is None:
+        # Unparseable cron_expr — skip silently, don't crash.
+        logger.debug("cron_staleness: cannot parse cron_expr for %s: %r", job_id, cron_expr)
+        return None
+    threshold_seconds = max(MIN_STALENESS_SECONDS, interval * STALENESS_MULTIPLIER)
+
+    # Case 1: never run
+    if last_run is None:
+        if next_run is not None and next_run < now:
+            return {
+                "job_id": job_id,
+                "reason": "never_run",
+                "cron_expr": cron_expr,
+                "expected_interval_seconds": round(interval, 1),
+                "last_run_at": None,
+                "next_run_at_utc": next_run.isoformat(),
+            }
+        return None
+
+    # Case 2: stale by timing
+    age_seconds = (now - last_run).total_seconds()
+    if age_seconds > threshold_seconds:
+        return {
+            "job_id": job_id,
+            "reason": "stale",
+            "cron_expr": cron_expr,
+            "expected_interval_seconds": round(interval, 1),
+            "threshold_seconds": round(threshold_seconds, 1),
+            "age_seconds": round(age_seconds, 1),
+            "last_run_at_utc": last_run.isoformat(),
+            "last_outcome": last_outcome or None,
+        }
+
+    # Case 3: ran on time but outcome was an error
+    if last_outcome and last_outcome not in {"success", "ok", "clean_exit_zero", "completed"}:
+        return {
+            "job_id": job_id,
+            "reason": "last_outcome_error",
+            "cron_expr": cron_expr,
+            "last_run_at_utc": last_run.isoformat(),
+            "last_outcome": last_outcome,
+        }
+
+    return None
+
+
+@invariant(
+    id="cron_staleness",
+    title="Every enabled cron is firing on schedule with successful outcomes",
+    description=(
+        "Walks `cron_jobs` from the watchdog context (sourced from "
+        "CronStore persistence file or in-memory CronService). For each "
+        "enabled cron: computes the expected interval from its cron_expr, "
+        "compares last_run_at against the threshold, and inspects "
+        "last_outcome. Emits one finding listing every cron in trouble."
+    ),
+    severity="warn",
+    runbook_command=(
+        "ls -la /opt/universal_agent/AGENT_RUN_WORKSPACES/cron_jobs.json; "
+        "tail -50 /opt/universal_agent/AGENT_RUN_WORKSPACES/cron_runs.jsonl | python3 -c \""
+        "import json,sys; [print(json.loads(l)) for l in sys.stdin]\""
+    ),
+    metadata={
+        "context_key": "cron_jobs",
+        "design_note": (
+            "P1b (2026-05-20): one invariant for all crons. The multiplier "
+            "of 2× the expected interval gives one cycle of grace. Floor "
+            "of 5 min keeps every-minute crons from tripping on transient "
+            "lag. Listing all stale crons in one finding avoids 22 alerts "
+            "on a bad day."
+        ),
+        "staleness_multiplier": STALENESS_MULTIPLIER,
+        "min_staleness_seconds": MIN_STALENESS_SECONDS,
+    },
+)
+def cron_staleness(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    cron_jobs = ctx.get("cron_jobs")
+    if not cron_jobs:
+        return None
+
+    now = datetime.now(timezone.utc)
+    stale_crons: list[Dict[str, Any]] = []
+
+    for raw in cron_jobs:
+        # Tolerate either dict-shaped rows (from CronStore.load_jobs after
+        # to_dict, or from the gateway endpoint's _summarize_cron_jobs) or
+        # objects exposing .to_dict.
+        if hasattr(raw, "to_dict"):
+            try:
+                cron = raw.to_dict()
+            except Exception:  # noqa: BLE001
+                continue
+        elif isinstance(raw, dict):
+            cron = raw
+        else:
+            continue
+
+        if not bool(cron.get("enabled", True)):
+            continue
+
+        try:
+            result = _evaluate_cron(cron, now)
+        except Exception as exc:  # noqa: BLE001 — defensive, never crash the runner
+            logger.debug("cron_staleness: evaluate failed for %r: %s", cron.get("job_id"), exc)
+            continue
+        if result is not None:
+            stale_crons.append(result)
+
+    if not stale_crons:
+        return None
+
+    job_ids = sorted(s["job_id"] for s in stale_crons)
+    return {
+        "observed_value": {
+            "stale_crons": stale_crons,
+            "stale_count": len(stale_crons),
+            "evaluated_at_utc": now.isoformat(),
+        },
+        "threshold_text": (
+            f"every enabled cron's last_run within {STALENESS_MULTIPLIER}× its "
+            "expected interval AND last_outcome is success"
+        ),
+        "message": (
+            f"{len(stale_crons)} cron job(s) in trouble: {', '.join(job_ids)}. "
+            f"Review last_outcome on each; check journalctl for the gateway "
+            f"service and cron_runs.jsonl for the per-job failure context."
+        ),
+    }

--- a/src/universal_agent/services/proactive_health.py
+++ b/src/universal_agent/services/proactive_health.py
@@ -241,12 +241,24 @@ def build_proactive_health_payload(
     # parallel plumbing. The `runtime_conn` parameter is kept for backwards
     # compatibility with callers that pass it explicitly, but the aggregator
     # no longer opens one itself.
+    # Pass materialized_cron_jobs (post-fallback to persistence file) so the
+    # cron_staleness invariant can walk every enabled cron. Coerce each row
+    # to a dict here once so the invariant doesn't have to re-handle
+    # to_dict() failure paths.
+    cron_jobs_for_invariants: list[Dict[str, Any]] = []
+    for job in materialized_cron_jobs or ():
+        try:
+            cron_jobs_for_invariants.append(job.to_dict() if hasattr(job, "to_dict") else dict(job))
+        except Exception:  # noqa: BLE001
+            continue
+
     invariant_findings = pipeline_invariants.run_invariants(
         {
             "csi_db_path": csi_db_path,
             "runtime_conn": runtime_conn,
             "activity_conn": activity_conn,
             "artifacts_dir": artifacts_dir,
+            "cron_jobs": cron_jobs_for_invariants,
         }
     )
 

--- a/src/universal_agent/services/proactive_health_notifier.py
+++ b/src/universal_agent/services/proactive_health_notifier.py
@@ -155,6 +155,68 @@ def _critical_invariants(payload: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
+def _warn_invariants(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        f
+        for f in (payload.get("invariants") or [])
+        if str(f.get("severity") or "").lower() == "warn"
+    ]
+
+
+# P3: track how many consecutive ticks each warn finding has been observed.
+# A warn that fires once then disappears was probably a transient — don't
+# escalate. A warn that persists past WARN_ESCALATION_THRESHOLD ticks is a
+# real degradation worth parking in Task Hub. NOT emailed — warn-tier
+# emails would noise out the critical-tier alerts.
+WARN_ESCALATION_THRESHOLD = 3
+_consecutive_warns: dict[str, int] = {}
+
+
+def _warn_threshold() -> int:
+    raw = os.getenv("UA_HEARTBEAT_PROACTIVE_HEALTH_WARN_ESCALATION_THRESHOLD")
+    if not raw:
+        return WARN_ESCALATION_THRESHOLD
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return WARN_ESCALATION_THRESHOLD
+
+
+def _track_and_filter_warns_for_escalation(
+    warns_this_tick: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Increment the per-fingerprint consecutive counter for every warn seen
+    this tick. Reset counters for warns that DIDN'T fire this tick. Return
+    only warns that have crossed the escalation threshold AND just crossed
+    it (i.e. emit once when crossing, not every subsequent tick — Task Hub
+    upsert handles persistence).
+
+    Reset-on-absence prevents zombie counters from accumulating: a finding
+    that fires once, disappears for 2 ticks, then re-fires starts over."""
+    threshold = _warn_threshold()
+    fingerprints_this_tick: set[str] = set()
+    to_escalate: list[dict[str, Any]] = []
+
+    for f in warns_this_tick:
+        fp = str(f.get("finding_id") or f.get("metric_key") or "unknown")
+        fingerprints_this_tick.add(fp)
+        prior = _consecutive_warns.get(fp, 0)
+        _consecutive_warns[fp] = prior + 1
+        # Escalate when the counter EQUALS the threshold (once on crossing).
+        # Subsequent ticks continue incrementing but don't re-emit.
+        if _consecutive_warns[fp] == threshold:
+            to_escalate.append(f)
+
+    # Reset counters for warns absent this tick (the underlying issue
+    # resolved itself before reaching escalation OR after escalation —
+    # either way, restart the clock).
+    for fp in list(_consecutive_warns.keys()):
+        if fp not in fingerprints_this_tick:
+            _consecutive_warns.pop(fp, None)
+
+    return to_escalate
+
+
 def _format_email(finding: dict[str, Any], payload_generated_at: str) -> tuple[str, str]:
     title = finding.get("title") or "Proactive health finding"
     metric_key = finding.get("metric_key") or "?"
@@ -335,8 +397,14 @@ async def run_pre_flight_check(
                 )
             # Task Hub channel is independent of email. Even when email is
             # blocked, park a `needs_review` row for each critical so the
-            # finding survives past this heartbeat.
+            # finding survives past this heartbeat. P3: also escalate any
+            # warns that have persisted past the threshold here, since the
+            # warn escalation is via Task Hub regardless of email state.
             _emit_to_task_hub(criticals, task_hub_emit_fn)
+            warns_to_escalate = _track_and_filter_warns_for_escalation(
+                _warn_invariants(payload)
+            )
+            _emit_to_task_hub(warns_to_escalate, task_hub_emit_fn)
             return payload
 
     cooldown = _cooldown_seconds()
@@ -348,6 +416,12 @@ async def run_pre_flight_check(
     # Park Task Hub rows up front so the persistent backlog reflects every
     # critical, independent of whether email succeeds or hits cooldown.
     _emit_to_task_hub(criticals_this_tick, task_hub_emit_fn)
+
+    # P3: also park Task Hub rows for warns that have persisted past the
+    # escalation threshold. No email (warn-tier emails would noise out
+    # criticals); the persistent Task Hub row IS the escalation channel.
+    warns_to_escalate = _track_and_filter_warns_for_escalation(_warn_invariants(payload))
+    _emit_to_task_hub(warns_to_escalate, task_hub_emit_fn)
     for finding in criticals_this_tick:
         sent = await _notify_critical(
             finding=finding,

--- a/tests/unit/test_cron_staleness.py
+++ b/tests/unit/test_cron_staleness.py
@@ -1,0 +1,217 @@
+"""Tests for the universal cron staleness invariant.
+
+Background: P0a (PR #395) populated `crons[]` in the sidecar — Layer 1 of
+the watchdog can now SEE every production cron's last_run_at. P1b adds
+Layer 2's matching invariant: one probe that walks every enabled cron,
+computes expected interval from cron_expr, and fires when last_run is
+>2× past its expected gap. One invariant covers all 22 production crons
+in one sweep instead of 22 individual probes.
+
+Failure modes detected:
+1. Cron stopped firing (last_run > 2× expected interval).
+2. Cron is firing but consistently erroring (last_outcome != success).
+3. Cron has never run AND its first scheduled time is in the past.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import importlib
+import time
+
+import pytest
+
+from universal_agent.services import pipeline_invariants as pi
+from universal_agent.services.pipeline_invariants import (
+    clear_registry_for_tests,
+    run_invariants,
+)
+
+UTC = timezone.utc
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    clear_registry_for_tests()
+    from universal_agent.services.invariants import cron_staleness
+    importlib.reload(cron_staleness)
+    yield
+    clear_registry_for_tests()
+
+
+def _cron_dict(
+    job_id: str,
+    *,
+    cron_expr: str,
+    enabled: bool = True,
+    last_run_at: float | None = None,
+    last_outcome: str | None = "success",
+    next_run_at: float | None = None,
+) -> dict:
+    """Mimic the shape gateway_server passes (epoch seconds for *_at fields)."""
+    return {
+        "job_id": job_id,
+        "enabled": enabled,
+        "cron_expr": cron_expr,
+        "last_run_at": last_run_at,
+        "last_outcome": last_outcome,
+        "next_run_at": next_run_at,
+    }
+
+
+def _now_epoch() -> float:
+    return time.time()
+
+
+def test_registers_on_import() -> None:
+    ids = {inv.id for inv in pi.get_registered_invariants()}
+    assert "cron_staleness" in ids
+
+
+def test_all_fresh_crons_emit_nothing() -> None:
+    """Every cron ran within 2× its expected interval → no finding."""
+    crons = [
+        # Hourly cron, ran 30 min ago
+        _cron_dict("hourly_job", cron_expr="0 * * * *", last_run_at=_now_epoch() - 1800),
+        # Every-minute cron, ran 30 sec ago
+        _cron_dict("minute_job", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        # Daily cron, ran 6h ago (within 2-day = 48h threshold)
+        _cron_dict("daily_job", cron_expr="0 6 * * *", last_run_at=_now_epoch() - 21600),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_one_stale_cron_fires() -> None:
+    """A cron that ran 5h ago when expected hourly → fires."""
+    crons = [
+        _cron_dict("good_job", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        _cron_dict(
+            "stuck_job", cron_expr="0 * * * *",
+            last_run_at=_now_epoch() - 18000,  # 5h ago, hourly cron, way past 2h threshold
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale_jobs = {s["job_id"] for s in obs.get("stale_crons") or []}
+    assert "stuck_job" in stale_jobs
+    assert "good_job" not in stale_jobs
+
+
+def test_multiple_stale_crons_in_one_finding() -> None:
+    """Three stale crons → ONE finding listing all three (not three separate)."""
+    crons = [
+        _cron_dict("good", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        _cron_dict("stale_a", cron_expr="0 * * * *", last_run_at=_now_epoch() - 18000),
+        _cron_dict("stale_b", cron_expr="*/15 * * * *", last_run_at=_now_epoch() - 7200),  # 2h, 15min cron
+        _cron_dict("stale_c", cron_expr="0 6 * * *", last_run_at=_now_epoch() - 432000),  # 5 days, daily
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale_jobs = {s["job_id"] for s in obs.get("stale_crons") or []}
+    assert stale_jobs == {"stale_a", "stale_b", "stale_c"}
+
+
+def test_disabled_crons_ignored() -> None:
+    """A disabled cron with stale last_run is NOT a finding (operator opted
+    out of running it)."""
+    crons = [
+        _cron_dict(
+            "disabled", cron_expr="0 * * * *", enabled=False,
+            last_run_at=_now_epoch() - 432000,  # 5 days old, would otherwise be stale
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_error_outcome_fires_even_with_recent_last_run() -> None:
+    """A cron firing on schedule but its last outcome was an error → fires.
+    Don't make the operator wait for stale-timing — surface the error now."""
+    crons = [
+        _cron_dict(
+            "erroring", cron_expr="*/5 * * * *",
+            last_run_at=_now_epoch() - 60,  # ran 1 min ago, would be fresh
+            last_outcome="error",
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    stale = obs.get("stale_crons") or []
+    assert any(s["job_id"] == "erroring" and s.get("reason") == "last_outcome_error" for s in stale)
+
+
+def test_never_run_with_past_next_run_fires() -> None:
+    """A cron that has never run AND its first scheduled time was in the
+    past (cron was registered hours ago but hasn't fired) → fires."""
+    crons = [
+        _cron_dict(
+            "never_fired", cron_expr="0 * * * *",
+            last_run_at=None,
+            next_run_at=_now_epoch() - 7200,  # next_run was 2h ago, never fired
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert len(matches) == 1
+
+
+def test_never_run_with_future_next_run_stays_quiet() -> None:
+    """A freshly-added cron whose first scheduled time is still in the
+    future → silent (not yet expected to have run)."""
+    crons = [
+        _cron_dict(
+            "new_cron", cron_expr="0 6 * * *",
+            last_run_at=None,
+            next_run_at=_now_epoch() + 3600,  # next_run in 1h
+        ),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_empty_cron_list_silent() -> None:
+    findings = run_invariants({"cron_jobs": []})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_missing_cron_jobs_key_silent() -> None:
+    findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    assert matches == []
+
+
+def test_malformed_cron_expr_does_not_crash() -> None:
+    """If croniter can't parse the cron_expr, skip that row gracefully —
+    never crash the watchdog over one bad row."""
+    crons = [
+        _cron_dict("good", cron_expr="*/1 * * * *", last_run_at=_now_epoch() - 30),
+        _cron_dict("garbage", cron_expr="this is not a cron", last_run_at=_now_epoch() - 100000),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    # No probe-error (the invariant should swallow per-row parse failures).
+    probe_errors = [f for f in findings if "probe_error" in (f.metric_key or "")]
+    assert probe_errors == []
+
+
+def test_iso_string_last_run_at_supported() -> None:
+    """Some cron rows arrive with ISO-string timestamps (e.g. from the
+    summarizer). The invariant should handle both epoch-float and ISO."""
+    one_hour_ago = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+    crons = [
+        _cron_dict("iso_cron", cron_expr="0 * * * *", last_run_at=one_hour_ago),
+    ]
+    findings = run_invariants({"cron_jobs": crons})
+    matches = [f for f in findings if f.metric_key == "cron_staleness"]
+    # 5h since last run on an hourly cron → fires (5h > 2h threshold)
+    assert len(matches) == 1

--- a/tests/unit/test_proactive_health_notifier.py
+++ b/tests/unit/test_proactive_health_notifier.py
@@ -618,6 +618,201 @@ async def test_no_task_hub_emit_fn_is_backwards_compatible(
     assert (tmp_path / "work_products" / "proactive_health_latest.json").exists()
 
 
+# ─── P3: warn-severity escalation via Task Hub (no email) ────────────────────
+
+
+def _warn_payload(finding_id: str = "morning_briefing_freshness") -> dict:
+    return {
+        "overall_status": "warn",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "crons": [],
+        "stale_tasks": {"count": 0, "samples": []},
+        "parked_tasks": {"count": 0, "samples": []},
+        "invariants": [
+            {
+                "finding_id": f"invariant:{finding_id}",
+                "category": "proactive_health",
+                "severity": "warn",
+                "metric_key": finding_id,
+                "observed_value": {"today": "2026-05-20"},
+                "title": "Test warn invariant",
+                "recommendation": "investigate",
+                "runbook_command": "ls -la artifacts/",
+                "metadata": {},
+            }
+        ],
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_counter():
+    """Each test starts with a fresh consecutive-warn counter."""
+    notifier._consecutive_warns.clear()
+    yield
+    notifier._consecutive_warns.clear()
+
+
+@pytest.mark.asyncio
+async def test_single_warn_tick_does_not_escalate(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn
+):
+    """A warn finding seen ONCE should NOT park a Task Hub row. The
+    escalation threshold is 3 consecutive ticks by default — transient
+    warns shouldn't pollute the backlog."""
+    emitted: list[dict] = []
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_warn_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        task_hub_emit_fn=emitted.append,
+    )
+    assert emitted == []  # warns don't emit on first sighting
+    fake_agentmail.send_email.assert_not_called()  # warns never email
+
+
+@pytest.mark.asyncio
+async def test_warn_escalates_at_threshold(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn, monkeypatch
+):
+    """A warn finding observed 3 consecutive ticks should park ONE Task Hub row
+    on the 3rd tick — not before, and not again on tick 4+."""
+    monkeypatch.setenv("UA_HEARTBEAT_PROACTIVE_HEALTH_WARN_ESCALATION_THRESHOLD", "3")
+    emitted: list[dict] = []
+
+    # Tick 1, 2 — should NOT emit
+    for _ in range(2):
+        await run_pre_flight_check(
+            workspace_dir=tmp_path,
+            payload_builder=_warn_payload,
+            agentmail_service=fake_agentmail,
+            notifications_list=notifications_list,
+            add_notification_fn=add_notification_fn,
+            task_hub_emit_fn=emitted.append,
+        )
+    assert emitted == []
+
+    # Tick 3 — escalates
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_warn_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        task_hub_emit_fn=emitted.append,
+    )
+    assert len(emitted) == 1
+    assert emitted[0]["severity"] == "warn"
+    assert emitted[0]["metric_key"] == "morning_briefing_freshness"
+
+    # Tick 4, 5 — NOT re-emitted (Task Hub upsert handles persistence
+    # on the consumer side; notifier only emits once per crossing).
+    for _ in range(2):
+        await run_pre_flight_check(
+            workspace_dir=tmp_path,
+            payload_builder=_warn_payload,
+            agentmail_service=fake_agentmail,
+            notifications_list=notifications_list,
+            add_notification_fn=add_notification_fn,
+            task_hub_emit_fn=emitted.append,
+        )
+    assert len(emitted) == 1  # still only the one
+
+
+@pytest.mark.asyncio
+async def test_warn_disappears_resets_counter(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn, monkeypatch
+):
+    """If a warn fires twice then the issue resolves and it disappears, the
+    counter must RESET. If the warn comes back later, it starts from 1 not
+    from 3 — otherwise a flapping warn would immediately escalate on its
+    second flare."""
+    monkeypatch.setenv("UA_HEARTBEAT_PROACTIVE_HEALTH_WARN_ESCALATION_THRESHOLD", "3")
+    emitted: list[dict] = []
+
+    # Two warn ticks
+    for _ in range(2):
+        await run_pre_flight_check(
+            workspace_dir=tmp_path,
+            payload_builder=_warn_payload,
+            agentmail_service=fake_agentmail,
+            notifications_list=notifications_list,
+            add_notification_fn=add_notification_fn,
+            task_hub_emit_fn=emitted.append,
+        )
+    assert emitted == []
+
+    # Resolution tick — no warn in payload
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_ok_payload,  # imported at top of file
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        task_hub_emit_fn=emitted.append,
+    )
+    # Counter for morning_briefing_freshness should be gone.
+    assert "invariant:morning_briefing_freshness" not in notifier._consecutive_warns
+
+    # Warn flares again — should be tick 1 of 3, not immediate escalation
+    await run_pre_flight_check(
+        workspace_dir=tmp_path,
+        payload_builder=_warn_payload,
+        agentmail_service=fake_agentmail,
+        notifications_list=notifications_list,
+        add_notification_fn=add_notification_fn,
+        task_hub_emit_fn=emitted.append,
+    )
+    assert emitted == []  # still no emission — counter restarted
+
+
+@pytest.mark.asyncio
+async def test_warn_escalation_independent_of_email_path(
+    tmp_path, notifications_list, add_notification_fn, monkeypatch
+):
+    """Warn escalation must run even when the email channel is broken (no
+    agentmail_service). Task Hub is the warn-tier escalation surface, not
+    a fallback for blocked emails."""
+    monkeypatch.setenv("UA_HEARTBEAT_PROACTIVE_HEALTH_WARN_ESCALATION_THRESHOLD", "2")
+    emitted: list[dict] = []
+
+    for _ in range(2):
+        await run_pre_flight_check(
+            workspace_dir=tmp_path,
+            payload_builder=_warn_payload,
+            agentmail_service=None,
+            notifications_list=notifications_list,
+            add_notification_fn=add_notification_fn,
+            task_hub_emit_fn=emitted.append,
+        )
+    assert len(emitted) == 1
+    assert emitted[0]["severity"] == "warn"
+
+
+@pytest.mark.asyncio
+async def test_warn_never_emails_even_at_escalation(
+    tmp_path, fake_agentmail, notifications_list, add_notification_fn, monkeypatch
+):
+    """Warn escalation parks Task Hub rows but NEVER sends email. Warn-tier
+    emails would noise out the critical-tier alerts Kevin needs to act on."""
+    monkeypatch.setenv("UA_HEARTBEAT_PROACTIVE_HEALTH_WARN_ESCALATION_THRESHOLD", "2")
+    emitted: list[dict] = []
+
+    for _ in range(3):
+        await run_pre_flight_check(
+            workspace_dir=tmp_path,
+            payload_builder=_warn_payload,
+            agentmail_service=fake_agentmail,
+            notifications_list=notifications_list,
+            add_notification_fn=add_notification_fn,
+            task_hub_emit_fn=emitted.append,
+        )
+    # Task Hub row created at tick 2 — but ZERO emails sent.
+    assert len(emitted) >= 1
+    fake_agentmail.send_email.assert_not_called()
+
+
 @pytest.mark.asyncio
 async def test_task_hub_emit_runs_even_when_email_skipped(
     tmp_path, notifications_list, add_notification_fn, caplog


### PR DESCRIPTION
## Summary

Before P3, the notifier only escalated `critical` findings (email + Task Hub via P0c). Warns were written to the sidecar but never surfaced anywhere persistent — Kevin would have to open the JSON manually. A real degraded-but-not-critical state (e.g. morning_briefing 12h late) was invisible.

P3 adds warn-tier escalation via Task Hub ONLY (no email — warn-tier emails would noise out the criticals):

- Module-level counter increments every tick a warn fingerprint is observed
- Hits threshold (default 3, env-tunable) → fires ONCE to `task_hub_emit_fn`
- Subsequent ticks increment but don't re-emit (Task Hub upsert handles persistence)
- Counters for warns absent this tick are RESET — flapping warns start over at 1
- Independent of email channel (works when AgentMail is down)

## Why Task Hub, not email

A warn-tier email channel would compete with the critical-tier alerts Kevin needs to act on. The persistent Task Hub row IS the escalation channel — Simone's heartbeat triage already covers `proactive_health:*` rows (added in P0c).

## Test plan

- [x] TDD: 6 tests covering single-tick-no-emit, escalate-on-3rd-tick, no-re-emit-on-4th, counter-reset-on-absence, runs-when-email-blocked, never-emails-even-at-escalation
- [x] 106 watchdog tests pass (101 prior + 6 new)
- [ ] After deploy: confirm a persistent warn (e.g. csi_convergence_sync_freshness) escalates within ~3 heartbeats and lands as a `proactive_health:*` Task Hub row

## Stack — final piece of the plan

This completes the watchdog restoration plan §4 (`plans/create-a-plan-to-gentle-pebble.md`). All six phases shipped:

| Phase | PR | What it fixes |
|---|---|---|
| P0a | #395 (merged) | Layer 1 cron list populated |
| P0b | #396 | Layer 2 invariants read correct DB |
| P0c | #397 | Critical findings parked as Task Hub work |
| P1a | #398 | 8 CSI sources covered (was 1) |
| P1b | #399 | 22 crons covered by one invariant |
| P3 | this PR | Persistent warns escalate to Task Hub |

P2 (operational dead-adapter diagnosis) documented in the plan doc §7; operator needs `sudo systemctl restart csi-ingester` to clear current state. Going forward, the new `csi_source_liveness` invariant (P1a) + Task Hub emission (P0c) means the next dead adapter will self-surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)