### PR TITLE
feat(watchdog): P5 — disk usage health invariant

### DIFF
--- a/src/universal_agent/services/invariants/__init__.py
+++ b/src/universal_agent/services/invariants/__init__.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 from universal_agent.services.invariants import (  # noqa: F401
     cron_staleness,
     csi_source_liveness,
+    disk_usage_health,
     proactive_pipeline_invariants,
     youtube_invariants,
     zai_inference_health,

--- a/src/universal_agent/services/invariants/disk_usage_health.py
+++ b/src/universal_agent/services/invariants/disk_usage_health.py
@@ -1,0 +1,143 @@
+"""Disk usage health invariant — P5 of the watchdog restoration.
+
+Simone's 2026-05-20 morning digest flagged disk at 70% with a "climbing"
+trend and recommended an invariant for proactive detection before
+disk-full becomes an outage. P5 adds one.
+
+Same lightweight pattern as P4 zai_inference_health: pure-syscall probe
+(`shutil.disk_usage()`), no DB, no AI inference, no HTTP. Cost per
+heartbeat: ~1ms across the monitored mounts.
+
+Monitored mounts (overridable via UA_DISK_HEALTH_MOUNTS env var, comma-
+separated):
+- `/` — root filesystem (general disk pressure)
+- `/opt` — where AGENT_RUN_WORKSPACES lives (per-heartbeat archives are
+  the most common growth source)
+- `/var/lib` — where csi.db + activity_state.db + runtime_state.db live
+  (DB growth is the second most common growth source)
+
+Severity (strict per operator pattern set in P4):
+- WARN: any mount above 75%
+- CRITICAL: any mount above 90%
+- Worst-of across mounts drives severity_override
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from universal_agent.services.pipeline_invariants import invariant
+
+logger = logging.getLogger(__name__)
+
+
+WARN_THRESHOLD_PCT = float(os.getenv("UA_DISK_HEALTH_WARN_PCT", "75"))
+CRITICAL_THRESHOLD_PCT = float(os.getenv("UA_DISK_HEALTH_CRITICAL_PCT", "90"))
+
+
+def _default_mounts() -> list[str]:
+    raw = (os.getenv("UA_DISK_HEALTH_MOUNTS") or "").strip()
+    if raw:
+        return [p.strip() for p in raw.split(",") if p.strip()]
+    return ["/", "/opt", "/var/lib"]
+
+
+def _gb(num_bytes: int) -> float:
+    return round(num_bytes / (1024 ** 3), 2)
+
+
+def _measure_mount(path: str) -> Optional[Dict[str, Any]]:
+    try:
+        usage = shutil.disk_usage(path)
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        # Dev box without this mount, or transient — skip silently per
+        # watchdog fail-open contract.
+        logger.debug("disk_usage_health: skip %s (%s)", path, exc)
+        return None
+    if usage.total <= 0:
+        return None
+    used_pct = round((usage.used / usage.total) * 100, 1)
+    return {
+        "mount": path,
+        "total_gb": _gb(usage.total),
+        "used_gb": _gb(usage.used),
+        "free_gb": _gb(usage.free),
+        "used_pct": used_pct,
+    }
+
+
+@invariant(
+    id="disk_usage_health",
+    title="Disk usage across monitored mounts within safe range",
+    description=(
+        "Watches the disk-usage percentage on root, /opt (AGENT_RUN_WORKSPACES "
+        "lives here), and /var/lib (canonical DB locations). Fires when any "
+        "mount is above the warn threshold (75%) and critical above 90%. "
+        "Added 2026-05-20 (P5) after Simone's morning digest flagged 70% "
+        "and climbing — proactive coverage before disk-full becomes outage."
+    ),
+    severity="warn",
+    runbook_command=(
+        "df -h; echo '--- workspaces older than 14 days ---'; "
+        "find /opt/universal_agent/AGENT_RUN_WORKSPACES -maxdepth 1 -type d -mtime +14 "
+        "-printf '%T@ %s %p\\n' 2>/dev/null | sort -n | head -20; "
+        "echo '--- largest DB files ---'; "
+        "ls -laSh /opt/universal_agent/*.db /opt/universal_agent/AGENT_RUN_WORKSPACES/*.db "
+        "/var/lib/universal-agent/csi/*.db 2>/dev/null | head -10"
+    ),
+    metadata={
+        "design_note": (
+            "P5 (2026-05-20): one probe covering multiple mounts in one "
+            "finding. Pure shutil.disk_usage call — no DB, no HTTP, "
+            "no AI inference. Severity_override lifts to critical above "
+            "90% on any mount."
+        ),
+        "thresholds": {
+            "warn_pct": WARN_THRESHOLD_PCT,
+            "critical_pct": CRITICAL_THRESHOLD_PCT,
+        },
+    },
+)
+def disk_usage_health(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    mounts = _default_mounts()
+    pressured: list[Dict[str, Any]] = []
+    healthy: list[Dict[str, Any]] = []
+    worst_pct = 0.0
+
+    for path in mounts:
+        m = _measure_mount(path)
+        if m is None:
+            continue
+        if m["used_pct"] > WARN_THRESHOLD_PCT:
+            pressured.append(m)
+            worst_pct = max(worst_pct, m["used_pct"])
+        else:
+            healthy.append(m)
+
+    if not pressured:
+        return None
+
+    severity = "critical" if worst_pct > CRITICAL_THRESHOLD_PCT else "warn"
+
+    mount_names = sorted(m["mount"] for m in pressured)
+    return {
+        "observed_value": {
+            "pressured_mounts": pressured,
+            "healthy_mounts": healthy,
+            "worst_used_pct": worst_pct,
+        },
+        "threshold_text": (
+            f"every monitored mount used_pct ≤ {WARN_THRESHOLD_PCT}% "
+            f"(critical above {CRITICAL_THRESHOLD_PCT}%)"
+        ),
+        "message": (
+            f"Disk pressure on {len(pressured)} mount(s): {', '.join(mount_names)}. "
+            f"Worst {worst_pct}%. Cleanup target: AGENT_RUN_WORKSPACES dirs "
+            "older than 14 days (Simone 2026-05-20 digest recommendation)."
+        ),
+        "severity_override": severity,
+    }

--- a/tests/unit/test_disk_usage_health.py
+++ b/tests/unit/test_disk_usage_health.py
@@ -1,0 +1,181 @@
+"""Tests for the disk_usage_health invariant.
+
+Background: Simone's 2026-05-20 morning digest flagged disk at 70% with a
+"climbing" trend and recommended an invariant for proactive detection. P5
+adds one. Same lightweight pattern as the P4 zai_inference_health probe:
+no DB, no AI inference, single fast syscall + small pure-logic block.
+
+Thresholds (operator-strict per pattern set in P4):
+- WARN: any monitored mount above 75%
+- CRITICAL: any monitored mount above 90%
+- Severity is the worst-of across monitored mounts
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest.mock import patch
+from collections import namedtuple
+
+import pytest
+
+from universal_agent.services import pipeline_invariants as pi
+from universal_agent.services.pipeline_invariants import (
+    clear_registry_for_tests,
+    run_invariants,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    clear_registry_for_tests()
+    from universal_agent.services.invariants import disk_usage_health
+    importlib.reload(disk_usage_health)
+    yield
+    clear_registry_for_tests()
+
+
+DiskUsage = namedtuple("DiskUsage", ["total", "used", "free"])
+
+
+def _gb(n: float) -> int:
+    return int(n * 1024 * 1024 * 1024)
+
+
+def _mock_disk_usage(mounts: dict[str, DiskUsage]):
+    """Patch shutil.disk_usage to return controlled values per path."""
+    def _impl(path):
+        path_str = str(path)
+        # Walk up looking for a known mount
+        for mount, usage in mounts.items():
+            if path_str.startswith(mount):
+                return usage
+        return mounts.get("/", DiskUsage(_gb(100), _gb(10), _gb(90)))
+    return patch(
+        "universal_agent.services.invariants.disk_usage_health.shutil.disk_usage",
+        side_effect=_impl,
+    )
+
+
+def test_registers_on_import():
+    ids = {inv.id for inv in pi.get_registered_invariants()}
+    assert "disk_usage_health" in ids
+
+
+def test_all_mounts_healthy_emits_nothing():
+    """Every mount well below the warn threshold (75%) → no finding."""
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(200), _gb(40), _gb(160)),       # 20%
+        "/opt": DiskUsage(_gb(100), _gb(30), _gb(70)),     # 30%
+        "/var/lib": DiskUsage(_gb(100), _gb(50), _gb(50)), # 50%
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert matches == []
+
+
+def test_seventy_five_percent_does_not_fire():
+    """At the exact threshold (75%) we don't fire — the gate is strictly above."""
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(100), _gb(75), _gb(25)),  # exactly 75%
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert matches == []
+
+
+def test_above_seventy_five_percent_fires_warn():
+    """Disk above 75% → warn. Simone's 70%-and-climbing case crossing the gate."""
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(100), _gb(80), _gb(20)),  # 80%
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert len(matches) == 1
+    assert matches[0].severity == "warn"
+    obs = matches[0].observed_value or {}
+    pressured = obs.get("pressured_mounts") or []
+    assert any(m.get("mount") == "/" and m.get("used_pct") >= 75 for m in pressured)
+
+
+def test_above_ninety_percent_fires_critical():
+    """Disk above 90% is catastrophic-class — critical severity."""
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(100), _gb(92), _gb(8)),  # 92%
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert len(matches) == 1
+    assert matches[0].severity == "critical"
+
+
+def test_worst_mount_drives_severity():
+    """If /opt is fine but / is critical, finding is critical. Worst-of."""
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(100), _gb(95), _gb(5)),     # 95% critical
+        "/opt": DiskUsage(_gb(100), _gb(30), _gb(70)), # 30% healthy
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert len(matches) == 1
+    assert matches[0].severity == "critical"
+
+
+def test_multiple_pressured_mounts_listed_in_one_finding():
+    """Both root and /opt above 75% → ONE finding listing both."""
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(100), _gb(82), _gb(18)),    # 82%
+        "/opt": DiskUsage(_gb(100), _gb(78), _gb(22)), # 78%
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    pressured = {m["mount"] for m in obs.get("pressured_mounts") or []}
+    # At least the two pressured mounts present (others may be there if monitored too)
+    assert "/" in pressured
+    assert "/opt" in pressured
+
+
+def test_disk_usage_oserror_silent():
+    """If a mount path doesn't exist on the host (dev box without /var/lib),
+    skip that mount gracefully — don't crash the watchdog."""
+    def _raise(path):
+        raise FileNotFoundError(path)
+    with patch(
+        "universal_agent.services.invariants.disk_usage_health.shutil.disk_usage",
+        side_effect=_raise,
+    ):
+        findings = run_invariants({})
+    # Probe handled the error; either no finding, or a finding with empty
+    # pressured_mounts. Critically: no probe_error finding was emitted.
+    probe_errors = [f for f in findings if "probe_error" in (f.metric_key or "")]
+    assert probe_errors == []
+
+
+def test_finding_includes_runbook_command():
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(100), _gb(85), _gb(15)),
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert len(matches) == 1
+    runbook = matches[0].runbook_command or ""
+    # Useful runbook mentions df + AGENT_RUN_WORKSPACES (most likely cleanup target)
+    assert "df" in runbook or "AGENT_RUN_WORKSPACES" in runbook
+
+
+def test_observed_value_includes_gb_used_and_free():
+    """Operator should be able to size the problem from the finding alone."""
+    with _mock_disk_usage({
+        "/": DiskUsage(_gb(200), _gb(160), _gb(40)),  # 80%
+    }):
+        findings = run_invariants({})
+    matches = [f for f in findings if f.metric_key == "disk_usage_health"]
+    assert len(matches) == 1
+    obs = matches[0].observed_value or {}
+    pressured = obs.get("pressured_mounts") or []
+    root = next((m for m in pressured if m["mount"] == "/"), None)
+    assert root is not None
+    assert root.get("used_gb") and root.get("free_gb") and root.get("total_gb")


### PR DESCRIPTION
## Summary

Simone's 2026-05-20 morning digest flagged disk at 70% with a "climbing" trend and recommended "Add a disk-awareness invariant to the watchdog for ongoing protection." P5 adds one.

## Changes

New invariant `disk_usage_health`:
- Monitors `/`, `/opt`, `/var/lib` (overridable via `UA_DISK_HEALTH_MOUNTS`)
- WARN above 75% used, CRITICAL above 90%
- One finding lists every pressured mount in `observed_value.pressured_mounts`
- `severity_override` picks worst-of across mounts
- Cost: ~1ms per heartbeat. Pure `shutil.disk_usage` syscall — no DB, no HTTP, no AI inference.

Runbook command closes the loop to Simone's "purge workspaces >14 days" recommendation.

## Test plan

- [x] 10 tests covering registration, all-healthy silence, exact-75%-no-fire, 80%-fires-warn, 92%-fires-critical, worst-mount-drives-severity, multi-mount listing, OSError silence, runbook content, observed-value shape
- [x] 135 watchdog tests pass total (125 prior + 10 new)
- [ ] After deploy: verify finding fires when prod disk crosses 75% (currently 70% per Simone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)