### PR TITLE
feat(watchdog): P6 — wire watchdog state into morning briefing

### DIFF
--- a/src/universal_agent/scripts/briefings_agent.py
+++ b/src/universal_agent/scripts/briefings_agent.py
@@ -29,6 +29,9 @@ from universal_agent.services.hackernews_snapshot_service import (
     DEFAULT_TOPICS,
     _load_watchlist,
 )
+from universal_agent.services.watchdog_briefing_context import (
+    build_briefing_block as build_watchdog_briefing_block,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +132,21 @@ def _get_triage_block_or_empty() -> str:
         return ""
 
 
+def _get_watchdog_block_or_empty() -> str:
+    """Return the watchdog briefing block, or "" on kill switch / no findings.
+
+    Kill switch: `UA_BRIEFING_WATCHDOG_BLOCK_ENABLED=0` disables. Any helper
+    failure is swallowed — the briefing must never break because the
+    watchdog query did. P6 (2026-05-20): closes the integration gap where
+    Simone's morning digest had zero awareness of active watchdog findings.
+    """
+    try:
+        return build_watchdog_briefing_block()
+    except Exception as exc:  # noqa: BLE001 — never let watchdog break the briefing
+        logger.warning("Watchdog briefing block helper crashed: %s", exc)
+        return ""
+
+
 def _build_objective(
     *,
     telemetry_json: str,
@@ -137,6 +155,7 @@ def _build_objective(
     artifacts_dir: str,
     today: str,
     triage_block: str = "",
+    watchdog_block: str = "",
 ) -> str:
     """Assemble the briefing prompt from the context sources.
 
@@ -154,6 +173,23 @@ def _build_objective(
             "\n- Surface the demo-triage queue depth at the top of the briefing if non-empty. "
             "The operator approval drawer is the only path from a tier-3 candidate to Cody — "
             "if pending count is growing, call it out as an action item for Kevin."
+        )
+
+    # P6 (2026-05-20): watchdog block. The watchdog parks proactive_health:*
+    # Task Hub rows for every critical finding and escalates persistent warns
+    # after 3 ticks. Without surfacing this in the briefing the operator can
+    # have hours-old critical alerts that never reach the morning report.
+    watchdog_section = ""
+    watchdog_instructions = ""
+    if watchdog_block:
+        watchdog_section = f"\n\n{watchdog_block}\n"
+        watchdog_instructions = (
+            "\n- **Lead the briefing with a Watchdog Status section.** Critical findings ARE the "
+            "operator's top priority for the day — surface every CRITICAL row from the watchdog "
+            "block prominently with its runbook command. Warn-tier findings get a brief mention. "
+            "The Task Hub backlog (`proactive_health:*` rows) is the actionable list of unresolved "
+            "issues — quote the task_ids so the operator can triage from the dashboard. If the "
+            "watchdog reports `overall: ok` and the backlog is empty, say so in one line and move on."
         )
 
     hn_section = ""
@@ -187,13 +223,13 @@ Here is the external Nightly Wiki Proactive Generation output (if any):
 ```markdown
 {wiki_content}
 ```
-{triage_section}{hn_section}
+{watchdog_section}{triage_section}{hn_section}
 Instructions:
 - Summarize tasks completed, attempted, and failed.
 - Include links/paths to any artifacts produced.
 - MUST explicitly include a "Latest Proactive Knowledge Base Additions" section referencing the Nightly Wiki external paths and files if any are provided.
 - Highlight any items requiring user decisions.
-- If there are data quality warnings, mention them.{triage_instructions}{hn_instructions}
+- If there are data quality warnings, mention them.{watchdog_instructions}{triage_instructions}{hn_instructions}
 
 Write a concise markdown report to '{artifacts_dir}/autonomous-briefings/{today}/DAILY_BRIEFING.md'.
 Make sure to provide a short completion message suitable for a dashboard notification.
@@ -256,6 +292,15 @@ async def main():
     else:
         logger.info("Triage briefing block omitted (kill switch / nothing pending)")
 
+    # P6 (2026-05-20): watchdog block. Surfaces current proactive_health
+    # findings + task_hub backlog so the briefing reflects what the watchdog
+    # has been detecting all morning.
+    watchdog_block = _get_watchdog_block_or_empty()
+    if watchdog_block:
+        logger.info("Watchdog briefing block included (~%d chars)", len(watchdog_block))
+    else:
+        logger.info("Watchdog briefing block omitted (kill switch / healthy state / no findings)")
+
     objective = _build_objective(
         telemetry_json=telemetry_json,
         wiki_content=wiki_content,
@@ -263,6 +308,7 @@ async def main():
         artifacts_dir=artifacts_dir,
         today=today,
         triage_block=triage_block,
+        watchdog_block=watchdog_block,
     )
 
     logger.info("Dispatching mission to vp.general.primary...")

--- a/src/universal_agent/services/watchdog_briefing_context.py
+++ b/src/universal_agent/services/watchdog_briefing_context.py
@@ -1,0 +1,176 @@
+"""Watchdog briefing context block.
+
+P6 (2026-05-20): wire the proactive_health watchdog state into the
+morning briefing so Simone's digest surfaces what the watchdog has
+been detecting. Before this, briefings_agent.py had no awareness of
+watchdog findings — operator got a daily digest that missed
+critical-tier system issues the watchdog had been flagging for hours.
+
+Two data sources combined:
+1. GET /api/v1/ops/proactive_health — current Layer-1+Layer-2 state
+   (best-effort: skipped if no UA_OPS_TOKEN, endpoint unreachable, etc.)
+2. task_hub_items WHERE source_kind = 'proactive_health' — persistent
+   backlog of unresolved findings parked by P0c + P3.
+
+Kill switch: `UA_BRIEFING_WATCHDOG_BLOCK_ENABLED=0` returns "".
+Default ON. Any helper exception is swallowed — the briefing must
+never break because the watchdog query did.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Severity labels for renderer; ordered worst-first so the block leads
+# with the most actionable rows.
+_SEVERITY_ORDER = ("critical", "warn", "info")
+
+
+def _enabled() -> bool:
+    return (os.getenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED") or "1") != "0"
+
+
+def _fetch_current_findings() -> dict[str, Any] | None:
+    """Hit the proactive_health endpoint. Returns None on any failure —
+    we proceed with task_hub-only rendering rather than block the briefing."""
+    token = (os.getenv("UA_OPS_TOKEN") or "").strip()
+    if not token:
+        return None
+    port = (os.getenv("UA_GATEWAY_PORT") or "8002").strip()
+    url = f"http://127.0.0.1:{port}/api/v1/ops/proactive_health"
+    try:
+        resp = httpx.get(
+            url,
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=5.0,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # noqa: BLE001 — never break the briefing
+        logger.debug("watchdog briefing: endpoint fetch failed: %s", exc)
+        return None
+
+
+def _fetch_taskhub_backlog() -> list[dict[str, Any]]:
+    """Query open proactive_health:* rows from the activity DB. The watchdog
+    parks one row per critical finding (P0c) and persistent warns after 3
+    consecutive heartbeats (P3). This list IS the operator's actionable
+    backlog. Returns [] on any failure."""
+    db_path = os.getenv("UA_ACTIVITY_DB_PATH") or "/opt/universal_agent/AGENT_RUN_WORKSPACES/activity_state.db"
+    rows: list[dict[str, Any]] = []
+    try:
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.execute(
+                "SELECT task_id, status, title, updated_at FROM task_hub_items "
+                "WHERE source_kind = 'proactive_health' "
+                "AND status IN ('open', 'needs_review', 'in_progress') "
+                "ORDER BY updated_at DESC LIMIT 20"
+            )
+            for r in cursor.fetchall():
+                rows.append({
+                    "task_id": r["task_id"],
+                    "status": r["status"],
+                    "title": r["title"],
+                    "updated_at": r["updated_at"],
+                })
+        finally:
+            conn.close()
+    except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+        logger.debug("watchdog briefing: task_hub query failed: %s", exc)
+    return rows
+
+
+def _render_findings(findings: list[dict[str, Any]]) -> str:
+    """Render the current-heartbeat findings list in severity order."""
+    if not findings:
+        return ""
+    by_sev: dict[str, list[dict[str, Any]]] = {s: [] for s in _SEVERITY_ORDER}
+    for f in findings:
+        sev = str(f.get("severity") or "info").lower()
+        by_sev.setdefault(sev, []).append(f)
+
+    lines: list[str] = []
+    for sev in _SEVERITY_ORDER:
+        items = by_sev.get(sev) or []
+        if not items:
+            continue
+        for f in items:
+            metric = f.get("metric_key") or f.get("finding_id") or "?"
+            recommendation = (f.get("recommendation") or "").strip()
+            runbook = (f.get("runbook_command") or "").strip()
+            line = f"- **[{sev.upper()}] `{metric}`** — {recommendation}"
+            lines.append(line)
+            if runbook:
+                # Truncate long runbooks; full text is in the task hub row metadata.
+                truncated = runbook if len(runbook) <= 200 else runbook[:200] + "..."
+                lines.append(f"  - Runbook: `{truncated}`")
+    return "\n".join(lines)
+
+
+def _render_backlog(rows: list[dict[str, Any]]) -> str:
+    if not rows:
+        return ""
+    lines = []
+    for r in rows:
+        lines.append(
+            f"- `{r['task_id']}` (status={r['status']}, updated {r['updated_at']}) — {r['title']}"
+        )
+    return "\n".join(lines)
+
+
+def build_briefing_block() -> str:
+    """Return the watchdog block as markdown, or "" on kill switch /
+    nothing to report. Never raises."""
+    if not _enabled():
+        logger.info("watchdog briefing block disabled via UA_BRIEFING_WATCHDOG_BLOCK_ENABLED=0")
+        return ""
+
+    try:
+        payload = _fetch_current_findings()
+        backlog = _fetch_taskhub_backlog()
+    except Exception as exc:  # noqa: BLE001 — defensive belt-and-suspenders
+        logger.warning("watchdog briefing: top-level failure: %s", exc, exc_info=True)
+        return ""
+
+    overall_status = (payload or {}).get("overall_status") or "unknown"
+    findings = (payload or {}).get("invariants") or []
+    stale_count = ((payload or {}).get("stale_tasks") or {}).get("count") or 0
+    parked_count = ((payload or {}).get("parked_tasks") or {}).get("count") or 0
+
+    findings_md = _render_findings(findings)
+    backlog_md = _render_backlog(backlog)
+
+    # If absolutely nothing to report (healthy state + empty backlog),
+    # return "" so the briefing isn't padded with noise.
+    if not findings_md and not backlog_md and overall_status in ("ok", "unknown"):
+        return ""
+
+    block: list[str] = []
+    block.append(f"## Watchdog Status — overall: {overall_status}")
+    block.append("")
+    block.append(
+        f"_Layer 1: {stale_count} stale in-progress task(s), {parked_count} parked. "
+        "Source: `/api/v1/ops/proactive_health` + Task Hub `proactive_health:*` rows._"
+    )
+
+    if findings_md:
+        block.append("")
+        block.append("### Active alerts (current heartbeat)")
+        block.append(findings_md)
+
+    if backlog_md:
+        block.append("")
+        block.append("### Open Task Hub backlog (unresolved watchdog findings)")
+        block.append(backlog_md)
+
+    return "\n".join(block)

--- a/tests/unit/test_watchdog_briefing_context.py
+++ b/tests/unit/test_watchdog_briefing_context.py
@@ -1,0 +1,207 @@
+"""Tests for the watchdog briefing context block.
+
+Background: 2026-05-20 Simone's morning digest missed every active
+watchdog finding (csi_source_liveness critical, youtube_enrichment_coverage
+critical, etc.) because briefings_agent.py had zero watchdog awareness.
+P6 adds the missing wire-in so morning briefings surface what the
+watchdog has been detecting.
+
+Same lightweight pattern as the HN block + triage block: a kill-switch-
+gated helper that returns either a markdown block or "" on failure.
+Never raises — the briefing must not break because the watchdog query did.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from universal_agent.services.watchdog_briefing_context import (
+    build_briefing_block,
+)
+
+
+def _ok_payload() -> dict:
+    return {
+        "overall_status": "ok",
+        "generated_at_utc": "2026-05-20T20:00:00+00:00",
+        "crons": [],
+        "stale_tasks": {"count": 0, "samples": []},
+        "parked_tasks": {"count": 0, "samples": []},
+        "invariants": [],
+    }
+
+
+def _critical_payload() -> dict:
+    return {
+        "overall_status": "critical",
+        "generated_at_utc": "2026-05-20T20:00:00+00:00",
+        "crons": [],
+        "stale_tasks": {"count": 0, "samples": []},
+        "parked_tasks": {"count": 2, "samples": []},
+        "invariants": [
+            {
+                "finding_id": "invariant:csi_source_liveness",
+                "severity": "critical",
+                "metric_key": "csi_source_liveness",
+                "title": "CSI adapters producing events on schedule",
+                "recommendation": "3 CSI adapters past expected silence threshold: reddit_discovery, threads_owned, threads_trends_broad.",
+                "runbook_command": "sqlite3 /var/lib/.../csi.db ...",
+                "observed_value": {"stale_count": 3},
+            },
+            {
+                "finding_id": "invariant:disk_usage_health",
+                "severity": "warn",
+                "metric_key": "disk_usage_health",
+                "title": "Disk usage across monitored mounts within safe range",
+                "recommendation": "Disk pressure on / at 80%. Cleanup target: AGENT_RUN_WORKSPACES older than 14 days.",
+                "runbook_command": "df -h; find /opt/...",
+                "observed_value": {"worst_used_pct": 80},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def memory_taskhub(tmp_path, monkeypatch):
+    """In-memory task_hub with proactive_health:* rows so the block sees them."""
+    db_path = tmp_path / "activity_state.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE task_hub_items (
+            task_id TEXT PRIMARY KEY,
+            source_kind TEXT NOT NULL,
+            title TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'open',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+    """)
+    conn.execute("""
+        INSERT INTO task_hub_items (task_id, source_kind, title, status, created_at, updated_at)
+        VALUES (?, 'proactive_health', '[CRITICAL] CSI adapters dead', 'needs_review',
+                '2026-05-20T19:00:00+00:00', '2026-05-20T19:00:00+00:00')
+    """, ("proactive_health:invariant:csi_source_liveness",))
+    conn.execute("""
+        INSERT INTO task_hub_items (task_id, source_kind, title, status, created_at, updated_at)
+        VALUES (?, 'proactive_health', '[CRITICAL] YouTube enrichment lag', 'needs_review',
+                '2026-05-20T18:30:00+00:00', '2026-05-20T18:30:00+00:00')
+    """, ("proactive_health:invariant:youtube_enrichment_coverage",))
+    conn.commit()
+    conn.close()
+    monkeypatch.setenv("UA_ACTIVITY_DB_PATH", str(db_path))
+    yield db_path
+
+
+def _mock_proactive_health_response(payload: dict):
+    """Patch httpx to return a fake /api/v1/ops/proactive_health response."""
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json = MagicMock(return_value=payload)
+    return patch(
+        "universal_agent.services.watchdog_briefing_context.httpx.get",
+        return_value=mock_response,
+    )
+
+
+def test_kill_switch_returns_empty(monkeypatch, memory_taskhub):
+    monkeypatch.setenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED", "0")
+    block = build_briefing_block()
+    assert block == ""
+
+
+def test_healthy_state_returns_empty_or_brief(monkeypatch, memory_taskhub):
+    """When overall_status is ok and no parked rows, the block stays empty —
+    don't pollute the briefing with healthy noise."""
+    monkeypatch.setenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED", "1")
+    monkeypatch.setenv("UA_OPS_TOKEN", "test-token")
+    monkeypatch.setenv("UA_GATEWAY_PORT", "8002")
+
+    # Clear the seeded rows so the task_hub is empty
+    conn = sqlite3.connect(str(memory_taskhub))
+    conn.execute("DELETE FROM task_hub_items")
+    conn.commit()
+    conn.close()
+
+    with _mock_proactive_health_response(_ok_payload()):
+        block = build_briefing_block()
+    assert block == ""
+
+
+def test_critical_findings_render_in_block(monkeypatch, memory_taskhub):
+    """A critical finding must appear in the block with its title +
+    recommendation so Simone surfaces it in the briefing."""
+    monkeypatch.setenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED", "1")
+    monkeypatch.setenv("UA_OPS_TOKEN", "test-token")
+    monkeypatch.setenv("UA_GATEWAY_PORT", "8002")
+
+    with _mock_proactive_health_response(_critical_payload()):
+        block = build_briefing_block()
+
+    assert block != ""
+    assert "Watchdog" in block
+    assert "csi_source_liveness" in block
+    assert "critical" in block.lower()
+    # The recommendation should be visible to Simone
+    assert "CSI adapters past expected silence" in block
+
+
+def test_parked_taskhub_rows_appear_in_block(monkeypatch, memory_taskhub):
+    """proactive_health:* Task Hub rows are persistent state — include them
+    in the block as a backlog section."""
+    monkeypatch.setenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED", "1")
+    monkeypatch.setenv("UA_OPS_TOKEN", "test-token")
+    monkeypatch.setenv("UA_GATEWAY_PORT", "8002")
+
+    with _mock_proactive_health_response(_ok_payload()):
+        block = build_briefing_block()
+
+    # task_hub rows are present even when current findings are quiet
+    assert block != ""
+    assert "proactive_health:invariant:csi_source_liveness" in block
+    assert "proactive_health:invariant:youtube_enrichment_coverage" in block
+
+
+def test_endpoint_unreachable_block_still_uses_taskhub(monkeypatch, memory_taskhub):
+    """If the endpoint times out / fails, we still have task_hub persistent
+    state — don't return empty just because one source failed."""
+    monkeypatch.setenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED", "1")
+    monkeypatch.setenv("UA_OPS_TOKEN", "test-token")
+    monkeypatch.setenv("UA_GATEWAY_PORT", "8002")
+
+    with patch(
+        "universal_agent.services.watchdog_briefing_context.httpx.get",
+        side_effect=Exception("connection refused"),
+    ):
+        block = build_briefing_block()
+
+    # Endpoint failed but task_hub rows ARE there from the fixture
+    assert block != ""
+    assert "proactive_health" in block
+
+
+def test_no_ops_token_block_still_uses_taskhub(monkeypatch, memory_taskhub):
+    """If UA_OPS_TOKEN isn't set, skip the endpoint call but still surface
+    the task_hub backlog. Avoid total silence."""
+    monkeypatch.setenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED", "1")
+    monkeypatch.delenv("UA_OPS_TOKEN", raising=False)
+
+    block = build_briefing_block()
+
+    assert "proactive_health:invariant:csi_source_liveness" in block
+
+
+def test_block_never_raises_on_bad_db(monkeypatch, tmp_path):
+    """If the activity DB doesn't exist (dev box), helper returns "" not raise."""
+    monkeypatch.setenv("UA_BRIEFING_WATCHDOG_BLOCK_ENABLED", "1")
+    monkeypatch.setenv("UA_ACTIVITY_DB_PATH", str(tmp_path / "does_not_exist.db"))
+    monkeypatch.delenv("UA_OPS_TOKEN", raising=False)
+
+    # Should NOT raise
+    block = build_briefing_block()
+    assert isinstance(block, str)


### PR DESCRIPTION
## Summary

Simone's 2026-05-20 morning digest missed every active watchdog finding (`csi_source_liveness` critical, `youtube_enrichment_coverage` critical, `csi_convergence_sync_freshness` warn). The watchdog was detecting issues, parking Task Hub rows via P0c, escalating warns via P3 — but none of that reached the briefing process.

P6 closes the integration gap. `briefings_agent.py` now prepends a **"Watchdog Status"** block to the LLM prompt, with explicit instructions for Simone to **lead the briefing with it**.

## Data sources combined

1. `GET /api/v1/ops/proactive_health` — current Layer-1 + Layer-2 state
2. `task_hub_items WHERE source_kind='proactive_health'` — persistent backlog of unresolved findings (parked by P0c critical + P3 warn-escalation)

Combining both means the briefing surfaces:
- New criticals detected this heartbeat (with runbook commands)
- Persistent backlog of findings the operator hasn't triaged yet

## Failure modes handled

| Failure | Behavior |
|---|---|
| `UA_OPS_TOKEN` missing | Skip endpoint, use task_hub only |
| Endpoint unreachable | Skip endpoint, use task_hub only |
| Activity DB missing (dev box) | Skip task_hub, use endpoint only |
| Both fail | Return "" so briefing isn't padded with empty section |
| Healthy state + empty backlog | Return "" (no noise) |
| Any exception | Caught + logged + return "" (briefing never breaks) |

**Kill switch**: `UA_BRIEFING_WATCHDOG_BLOCK_ENABLED=0` disables the block.

## Test plan

- [x] 7 tests covering kill switch, healthy state, critical findings, task_hub backlog, endpoint failure, missing token, bad DB
- [x] 132 watchdog tests pass total
- [ ] After deploy: tomorrow's morning briefing should LEAD with a Watchdog Status section showing the actionable findings + backlog

## Sequence

Stacks on the merged P0-P4 work. Independent of P5 (#405 disk usage invariant). With P5 + P6 landed, tomorrow's Simone digest gets:
- Watchdog Status section at the top (P6)
- Disk-usage finding in that section when crossed (P5)
- Plus the existing telemetry/wiki/HN/triage blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)