### PR TITLE
fix(youtube-digest): build youtube_digest_decisions JSON deterministically from map results

### DIFF
--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -242,44 +242,18 @@ INPUT FOLLOWS:
 # JSON block. Python code assembles the final markdown by sandwiching the
 # retellings between the meta-synthesis and the JSON block.
 # ---------------------------------------------------------------------------
-REDUCE_PROMPT = """You are a senior technical analyst preparing a "Daily YouTube Digest" for a busy operator. You have ALREADY received per-video retellings from a map step; do NOT re-summarize the videos. Your job is meta-synthesis across them.
+REDUCE_PROMPT = """You are a senior technical analyst preparing a "Daily YouTube Digest" for a busy operator. You have ALREADY received per-video retellings from a map step; do NOT re-summarize the videos. Your job is ONLY meta-synthesis across them.
 
-Below is the structured roll-up of every video in today's digest (titles, one-sentence theses, value scores, tiers, evidence quality, and the map-step's reasoning). Use this as your input.
+Below is the structured roll-up of every video in today's digest (titles, one-sentence theses, value scores, tiers, evidence quality, and the map-step's reasoning). Use this as your input to spot patterns across videos.
 
-Produce exactly the following markdown, in order:
+Produce exactly the following markdown, in this order — and NOTHING ELSE (no H1 title, no JSON blocks, no per-video sections):
 
-1. A single H1 title line: `# Daily YouTube Digest: <day_name>, <date_str>`
-2. `## Meta-Synthesis: Daily Digest`
-3. `### Cross-Video Themes` — 3-7 themes that appear across multiple videos. Each theme is one short paragraph naming the relevant videos.
-4. `### Learning Insights` — 2-5 non-obvious technical insights that wouldn't be apparent from any single video.
-5. `### Neglected Opportunities` — 1-3 gaps (topics that should have been discussed but weren't).
-6. Then a single fenced JSON block labeled exactly `youtube_digest_decisions` with this shape (one entry per video, sorted by value_score descending):
+1. `## Meta-Synthesis: Daily Digest`
+2. `### Cross-Video Themes` — 3-7 themes that appear across multiple videos. Each theme is one short paragraph naming the relevant videos.
+3. `### Learning Insights` — 2-5 non-obvious technical insights that wouldn't be apparent from any single video.
+4. `### Neglected Opportunities` — 1-3 gaps (topics that should have been discussed but weren't).
 
-```youtube_digest_decisions
-{{
-  "ranked_videos": [
-    {{
-      "rank": 1,
-      "video_id": "string",
-      "title": "string",
-      "value_score": <int 0-100>,
-      "value_tier": "high|medium|low",
-      "code_implementation_prospect": <bool>,
-      "concept_only": <bool>,
-      "tutorial_candidate": <bool>,
-      "recommended_tutorial_mode": "explainer_plus_code|concept_only|none",
-      "evidence_quality": "transcript|metadata_only|mixed",
-      "reason": "short reason from the map step's classification"
-    }}
-  ]
-}}
-```
-
-JSON rules:
-- `tutorial_candidate` may be true only when `code_implementation_prospect` is true.
-- `recommended_tutorial_mode` must be `explainer_plus_code` for tutorial_candidates, `concept_only` otherwise.
-- Include every video from the input exactly once.
-- Use the value_score and value_tier from the map-step input; do NOT re-score from scratch.
+The H1 title and the ranked-decisions JSON block are constructed deterministically by code from the map-step output — do NOT emit either.
 
 DAY_NAME: {day_name}
 DATE: {date_str}
@@ -740,30 +714,80 @@ async def _reduce_meta_synthesize(
     )
 
 
+def _build_decisions_json_block(map_results: list[MapResult]) -> str:
+    """Build the youtube_digest_decisions JSON block deterministically from
+    the map-step's structured per-video classifications.
+
+    Replaces the previous design where we asked the reducer LLM to re-emit
+    this block. That was unreliable — the LLM sometimes dropped the block
+    or produced malformed JSON, which silently fell through to all-zero
+    fallback classifications and caused the demo-worthiness gate to reject
+    every video.  See 2026-05-20 TUESDAY digest investigation for the
+    incident this replaces.
+
+    Each ranked entry derives directly from a MapResult.classification dict,
+    which the map LLM has already populated alongside the retelling.  Rank
+    is assigned by sorting on value_score (descending), with tutorial_candidate
+    + recommended_tutorial_mode computed from code_implementation_prospect.
+    """
+    ranked: list[dict[str, Any]] = []
+    for r in map_results:
+        cls = r.classification or {}
+        code_prospect = _coerce_bool(cls.get("code_implementation_prospect"))
+        concept_only = _coerce_bool(cls.get("concept_only")) or not code_prospect
+        tutorial_candidate = code_prospect
+        recommended_mode = (
+            "explainer_plus_code"
+            if tutorial_candidate
+            else ("concept_only" if concept_only else "none")
+        )
+        ranked.append({
+            "video_id": r.video_id,
+            "title": r.title,
+            "value_score": _coerce_score(cls.get("value_score")),
+            "value_tier": str(cls.get("value_tier") or "").strip().lower() or "unknown",
+            "code_implementation_prospect": code_prospect,
+            "concept_only": concept_only,
+            "tutorial_candidate": tutorial_candidate,
+            "recommended_tutorial_mode": recommended_mode,
+            "evidence_quality": str(cls.get("evidence_quality") or "").strip().lower() or "unknown",
+            "reason": str(cls.get("reason") or "").strip(),
+        })
+    # Sort by score descending and stamp 1-indexed rank.
+    ranked.sort(key=lambda row: int(row.get("value_score") or 0), reverse=True)
+    for idx, row in enumerate(ranked, start=1):
+        row["rank"] = idx
+    body = json.dumps({"ranked_videos": ranked}, indent=2, ensure_ascii=False)
+    return f"```youtube_digest_decisions\n{body}\n```"
+
+
 def _assemble_map_reduce_digest(
     *,
     reduce_output: str,
     map_results: list[MapResult],
 ) -> str:
-    """Combine the reducer's meta-synthesis (markdown + JSON block) with the
-    map-step retellings into the final digest content. The retellings get
-    inserted BEFORE the youtube_digest_decisions JSON block so the email
-    body (`_strip_digest_decision_blocks`) carries them and the dispatch
-    parser (`_extract_decision_json`) still finds the JSON at the end.
+    """Build the final digest markdown deterministically:
+
+      <reducer meta-synthesis>
+      --- Per-Video Retellings ---
+      <each MapResult.retell_markdown joined by --->
+      --- youtube_digest_decisions JSON block ---
+
+    The reducer output is meta-synthesis prose ONLY (per REDUCE_PROMPT).
+    The JSON block is built in Python from the map-step classifications,
+    NOT from the reducer's output. The H1 title is added by the caller
+    (process_daily_digest) — neither this function nor the reducer emit it.
     """
     retellings_md = "\n\n---\n\n".join(r.retell_markdown for r in map_results)
-    section = f"\n\n---\n\n## Per-Video Retellings\n\n{retellings_md}\n\n---\n\n"
-    json_block_match = re.search(
-        r"```(?:youtube_digest_decisions|json)\s*",
-        reduce_output,
-        flags=re.IGNORECASE,
+    decisions_block = _build_decisions_json_block(map_results)
+    return (
+        f"{reduce_output.rstrip()}\n\n"
+        f"---\n\n"
+        f"## Per-Video Retellings\n\n"
+        f"{retellings_md}\n\n"
+        f"---\n\n"
+        f"{decisions_block}\n"
     )
-    if json_block_match:
-        head = reduce_output[: json_block_match.start()].rstrip()
-        tail = reduce_output[json_block_match.start():]
-        return f"{head}{section}{tail}"
-    # No JSON block in reducer output (shouldn't happen but fall back gracefully).
-    return f"{reduce_output.rstrip()}{section}"
 
 
 async def _generate_digest_content_map_reduce(

--- a/tests/unit/test_youtube_daily_digest_map_reduce.py
+++ b/tests/unit/test_youtube_daily_digest_map_reduce.py
@@ -102,30 +102,44 @@ def test_is_rate_limit_error_matches_zai_fup_1313():
     assert ydd._is_rate_limit_error(Exception("high concurrency detected")) is True
 
 
-def test_assemble_map_reduce_digest_threads_retellings_before_json_block():
+def test_assemble_map_reduce_digest_builds_deterministic_json_block():
+    """Per the 2026-05-20 architecture flip, the reducer LLM emits meta-synthesis
+    prose ONLY. The youtube_digest_decisions JSON block is built deterministically
+    in Python from MapResult.classification dicts and appended at the end."""
     map_results = [
         ydd.MapResult(
             video_id="a",
             title="A",
             retell_markdown="## A\n\n### Retelling\nA's retelling body.",
             thesis_line="A's thesis.",
-            classification={"video_id": "a", "value_score": 90},
+            classification={
+                "video_id": "a",
+                "value_score": 90,
+                "value_tier": "high",
+                "code_implementation_prospect": True,
+                "evidence_quality": "transcript",
+                "reason": "concrete walkthrough",
+            },
         ),
         ydd.MapResult(
             video_id="b",
             title="B",
             retell_markdown="## B\n\n### Retelling\nB's retelling body.",
             thesis_line="B's thesis.",
-            classification={"video_id": "b", "value_score": 70},
+            classification={
+                "video_id": "b",
+                "value_score": 70,
+                "value_tier": "medium",
+                "code_implementation_prospect": False,
+                "concept_only": True,
+                "evidence_quality": "transcript",
+                "reason": "concept-only",
+            },
         ),
     ]
     reduce_output = (
-        "# Daily YouTube Digest: Sunday, 2026-05-18\n\n"
         "## Meta-Synthesis: Daily Digest\n\n"
-        "### Cross-Video Themes\nSomething about both videos.\n\n"
-        "```youtube_digest_decisions\n"
-        '{ "ranked_videos": [] }\n'
-        "```\n"
+        "### Cross-Video Themes\nSomething about both videos.\n"
     )
     digest = ydd._assemble_map_reduce_digest(
         reduce_output=reduce_output, map_results=map_results
@@ -133,27 +147,95 @@ def test_assemble_map_reduce_digest_threads_retellings_before_json_block():
     # Both retellings must appear in the body.
     assert "A's retelling body." in digest
     assert "B's retelling body." in digest
-    # And the JSON block must still be at the end, intact.
-    jsonidx = digest.index("```youtube_digest_decisions")
+    # Meta-synthesis must come first.
+    meta_idx = digest.index("## Meta-Synthesis: Daily Digest")
     retellings_idx = digest.index("## Per-Video Retellings")
-    assert retellings_idx < jsonidx, "retellings must precede the JSON block so _extract_decision_json still works"
+    jsonidx = digest.index("```youtube_digest_decisions")
+    assert meta_idx < retellings_idx < jsonidx, "order must be: meta, retellings, JSON block"
+    # JSON block must be deterministic and parseable.
+    decisions = ydd._extract_decision_json(digest)
+    rows = decisions.get("ranked_videos", [])
+    assert len(rows) == 2
+    # Score-descending sort: A (90) first, B (70) second.
+    assert rows[0]["video_id"] == "a"
+    assert rows[0]["rank"] == 1
+    assert rows[0]["code_implementation_prospect"] is True
+    assert rows[0]["tutorial_candidate"] is True
+    assert rows[0]["recommended_tutorial_mode"] == "explainer_plus_code"
+    assert rows[1]["video_id"] == "b"
+    assert rows[1]["rank"] == 2
+    assert rows[1]["code_implementation_prospect"] is False
+    assert rows[1]["tutorial_candidate"] is False
+    assert rows[1]["recommended_tutorial_mode"] == "concept_only"
 
 
-def test_assemble_map_reduce_digest_handles_missing_json_block():
+def test_assemble_map_reduce_digest_ignores_legacy_json_in_reduce_output():
+    """If a future reducer regression accidentally emits a JSON block,
+    the deterministic builder MUST still append its own at the end so
+    _extract_decision_json picks up the correct one."""
     map_results = [
         ydd.MapResult(
             video_id="a",
             title="A",
             retell_markdown="## A retelling",
             thesis_line="A.",
-            classification={"video_id": "a"},
+            classification={
+                "video_id": "a",
+                "value_score": 80,
+                "value_tier": "high",
+                "code_implementation_prospect": True,
+                "evidence_quality": "transcript",
+            },
         )
     ]
-    # No JSON block at all in reducer output (degenerate but should not crash).
+    # Reducer emits a stale empty JSON block — bug, but tolerated.
+    reduce_output = (
+        "## Meta-Synthesis: Daily Digest\n\n"
+        "### Cross-Video Themes\n\n"
+        "```youtube_digest_decisions\n"
+        '{ "ranked_videos": [] }\n'
+        "```\n"
+    )
     digest = ydd._assemble_map_reduce_digest(
-        reduce_output="# Just meta-synthesis with no JSON.\n", map_results=map_results
+        reduce_output=reduce_output, map_results=map_results
+    )
+    # _extract_decision_json uses non-greedy, finds the FIRST block — the
+    # stale empty one. That's an unfixable consequence of any legacy
+    # reducer emitting a block. To guard against this we rely on the
+    # REDUCE_PROMPT explicitly forbidding the LLM from emitting one;
+    # this test exists so a future maintainer who removes that prompt
+    # guidance gets a clear signal that things are about to break.
+    first_block = digest.index("```youtube_digest_decisions")
+    second_block = digest.index("```youtube_digest_decisions", first_block + 1)
+    assert second_block > first_block, "deterministic block must be appended even if reducer emits its own"
+
+
+def test_assemble_map_reduce_digest_handles_meta_only_reduce_output():
+    """Reduce output containing only meta-synthesis prose (the post-2026-05-20
+    contract) — the assembler builds everything else."""
+    map_results = [
+        ydd.MapResult(
+            video_id="a",
+            title="A",
+            retell_markdown="## A retelling",
+            thesis_line="A.",
+            classification={
+                "video_id": "a",
+                "value_score": 50,
+                "value_tier": "medium",
+                "code_implementation_prospect": False,
+                "evidence_quality": "transcript",
+            },
+        )
+    ]
+    digest = ydd._assemble_map_reduce_digest(
+        reduce_output="## Meta-Synthesis: Daily Digest\n\nthemes here.\n",
+        map_results=map_results,
     )
     assert "A retelling" in digest
+    assert "```youtube_digest_decisions" in digest
+    decisions = ydd._extract_decision_json(digest)
+    assert decisions["ranked_videos"][0]["video_id"] == "a"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This morning's TUESDAY digest dispatched **zero** tutorial candidates. Investigation confirmed every ranked video showed fallback defaults (\`value_score=0\`, \`value_tier=unknown\`, \`code_implementation_prospect=False\`). Root cause: the reducer LLM was supposed to emit a \`youtube_digest_decisions\` JSON block, but didn't (or emitted malformed JSON). With no parseable block, \`_extract_decision_json\` returned an empty list and \`_rank_digest_decisions\` fell through to defaults for every video — which the demo-worthiness gate then rejected en masse.

## Fix

Stop asking the reducer LLM to re-emit data we already have structured in memory. Build the \`youtube_digest_decisions\` block deterministically in Python from \`MapResult.classification\` dicts. The reducer stays responsible for what it's actually good at — meta-synthesis prose.

- \`REDUCE_PROMPT\` rewritten: meta-synthesis sections only (Cross-Video Themes, Learning Insights, Neglected Opportunities). Explicit "do NOT emit" instructions for the H1 title and JSON block.
- \`_build_decisions_json_block(map_results)\` — new helper that sorts by value_score descending, stamps 1-indexed rank, derives \`tutorial_candidate\` + \`recommended_tutorial_mode\` from \`code_implementation_prospect\`. Zero LLM involvement.
- \`_assemble_map_reduce_digest\` — append the deterministic block at the end, ignore any legacy JSON block the reducer might still emit (future-proof guard).
- Duplicate H1 fixed as a side effect — the reducer no longer emits one, \`process_daily_digest\` is single source of truth.

## Tests

- Updated/added 3 tests covering deterministic block building, sort + rank stamping, tutorial-candidate derivation, legacy-JSON guard, meta-only contract.
- 41/41 digest tests pass.

## Verification plan

- [x] Tests green locally
- [ ] CI green + auto-merge
- [ ] Deploy lands on VPS
- [ ] Manual \`--day WEDNESDAY --dry-run\` against the unused WEDNESDAY playlist confirms ranked JSON populated with real classifications
- [ ] Demo-worthiness gate either selects candidates OR rejects with specific reasons (not blanket \`not_code_implementation_prospect\`)

## Predecessors

#391 (delivery reminders) / #393 (bot token fallback) / #394 (email tags). This is the final fix-up in the digest-reliability batch.