### PR TITLE
fix(youtube-digest): drop orphan ---, Houston-friendly banner time

### DIFF
--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -780,12 +780,15 @@ def _assemble_map_reduce_digest(
     """
     retellings_md = "\n\n---\n\n".join(r.retell_markdown for r in map_results)
     decisions_block = _build_decisions_json_block(map_results)
+    # No `---` between retellings and the JSON block: the JSON block is
+    # stripped from the human-facing email by `_strip_digest_decision_blocks`,
+    # which would leave the separator orphaned and render as a double `---`
+    # next to the wrapper's separator before the tutorial-dispatch section.
     return (
         f"{reduce_output.rstrip()}\n\n"
         f"---\n\n"
         f"## Per-Video Retellings\n\n"
         f"{retellings_md}\n\n"
-        f"---\n\n"
         f"{decisions_block}\n"
     )
 

--- a/src/universal_agent/services/email_tags.py
+++ b/src/universal_agent/services/email_tags.py
@@ -168,14 +168,23 @@ def format_tagged_subject(
 
 
 def _houston_now_iso() -> str:
-    """Return the current time in America/Chicago as an ISO-ish string."""
+    """Return the current time as an operator-friendly Houston-local string.
+
+    Format: ``5:05 PM Wed May 20 CDT`` (or ``CST`` outside DST).  This
+    matches the operator memory entry that mandates Houston-time display
+    rather than raw UTC or ISO offset format.  The helper retains its
+    historical name (``..._iso``) for backwards compatibility — the
+    suffix is misleading, but renaming would touch unrelated callers.
+    """
     if ZoneInfo is None:  # pragma: no cover
-        return datetime.now().isoformat(timespec="seconds")
-    return (
-        datetime.now(ZoneInfo("America/Chicago"))
-        .replace(microsecond=0)
-        .isoformat()
-    )
+        return datetime.now().strftime("%-I:%M %p %a %b %-d")
+    local = datetime.now(ZoneInfo("America/Chicago"))
+    # %-I drops the leading zero on the hour (POSIX).  Some non-POSIX
+    # platforms reject the GNU extensions; fall back to manual stripping.
+    try:
+        return local.strftime("%-I:%M %p %a %b %-d %Z")
+    except ValueError:  # pragma: no cover
+        return local.strftime("%I:%M %p %a %b %d %Z").lstrip("0")
 
 
 def _related_to_str(related: Optional[Iterable[str]]) -> str:
@@ -203,7 +212,7 @@ def format_body_header(
         Tags: ACTION/KIND
         Source: <source>
         Related: <related-1>, <related-2>      (omitted if no related items)
-        Time: 2026-05-19T15:42:00-05:00         (omitted if include_timestamp=False)
+        Time: 3:42 PM Mon May 19 CDT             (omitted if include_timestamp=False)
         ---
 
     Args:


### PR DESCRIPTION
## Summary

Two cosmetic issues surfaced by the WEDNESDAY dry-run smoke against PR #407:

1. **Double `---` separator** in the email body — the assembler emitted `---` BEFORE the \`youtube_digest_decisions\` JSON block. When the JSON block is stripped from the human-facing email by \`_strip_digest_decision_blocks\`, the separator becomes orphaned and renders alongside the wrapper's own \`---\` before the tutorial-dispatch section. Visible in \`tail\` of \`2026-05-20_WEDNESDAY_Digest.md\`.

2. **Banner Time format** still showed ISO offset (\`2026-05-20T17:05:16-05:00\`) instead of the Houston-friendly format mandated by the saved operator memory (\`5:05 PM Wed May 20 CDT\`).

## Fix

- \`_assemble_map_reduce_digest\` no longer emits \`---\` before the JSON block. The block is the file terminator, and removing the prior separator collapses the post-strip double-rule.
- \`_houston_now_iso\` now formats with \`%-I:%M %p %a %b %-d %Z\` (with a non-POSIX fallback). Docstring example updated.

## Verification

- 71/71 tests pass (digest + email-tags + agentmail-send-tagged suites)
- Will re-smoke against another unused day playlist after merge+deploy

## Coordination

Sits on top of #407 (deterministic JSON fix). Final cosmetic cleanup in the digest-reliability batch. Auto-merge eligible.