### PR TITLE
feat(youtube-digest): Tier A scoring rubric + multi-tier learning-loop roadmap notation

### DIFF
--- a/docs/03_Operations/99_Tutorial_Pipeline_Architecture_And_Operations.md
+++ b/docs/03_Operations/99_Tutorial_Pipeline_Architecture_And_Operations.md
@@ -3,7 +3,7 @@
 > **Canonical source-of-truth** for the YouTube Tutorial Pipeline. All other
 > tutorial-related documentation should reference this file.
 >
-> **Last updated:** 2026-05-19 — Added **delivery-reminder signals** (Telegram + dashboard tile) that fire when the digest email is accepted by AgentMail, both self-expiring after `UA_DIGEST_REMINDER_TTL_MINUTES` (default 90).  Earlier 2026-05-18: Daily Digest ships on a **map-reduce pipeline** (per-video retell on `glm-4.5-air` @ conc=3, meta-synthesis on `glm-5.1`), with the per-video prompt asking for a **50% length retelling** instead of a "concise summary". Tutorial dispatch now passes through a deterministic **demo-worthiness gate** (score ≥ 70, value_tier ≠ low/unknown, evidence_quality ≠ metadata_only). `required_secrets` preflight now includes `YOUTUBE_OAUTH_*`. Per-call retry / FUP-1313 telemetry surfaces in `MapResult` and the comparison harness. PRs #356, #357, #360, #361, #363.
+> **Last updated:** 2026-05-20 — **Tier A scoring rubric** added inline to `RETELL_PROMPT` with anchored buckets (90-100 / 75-89 / 60-74 / 40-59 / 20-39 / 0-19) + disqualifier caps (sales-pitch / view-count / metadata-only) + explicit "do not default to 95" guidance.  Addresses score saturation surfaced by the 2026-05-20 WEDNESDAY dry-run (12 of 29 videos got 95).  See § 1.1B for the full multi-tier roadmap (Tier A current, Tier B/C/D deferred). Earlier 2026-05-20: deterministic `youtube_digest_decisions` JSON block built from `MapResult` classifications in Python (PR #407) so reducer LLM failures can no longer drop tutorial dispatch to zero; orphan `---` removed + Houston-friendly banner time (PR #408).  2026-05-19: delivery-reminder signals (Telegram + dashboard tile) with `UA_DIGEST_REMINDER_TTL_MINUTES` (default 90).  2026-05-18: Daily Digest ships on a **map-reduce pipeline** (per-video retell on `glm-4.5-air` @ conc=3, meta-synthesis on `glm-5.1`), 50%-length retelling, deterministic **demo-worthiness gate** (score ≥ 70, value_tier ≠ low/unknown, evidence_quality ≠ metadata_only). `required_secrets` preflight includes `YOUTUBE_OAUTH_*`. PRs #356, #357, #360, #361, #363, #391, #393, #394, #407, #408.
 
 ## 1. Pipeline Overview
 
@@ -155,6 +155,92 @@ PYTHONPATH=src uv run python -m universal_agent.scripts.youtube_daily_digest --r
 > different state storage, and require independent operational management.
 > Failing to reset BOTH systems (e.g., during a proxy provider switch) will
 > result in stale state in one pipeline while the other is clean.
+
+### 1.1B Scoring Rubric — Tier A (current) and the deferred Tier B/C/D roadmap
+
+The map-step LLM (`glm-4.5-air`) assigns `value_score` (0-100), `value_tier`,
+and `code_implementation_prospect` to each ingested video. Those structured
+fields drive the deterministic **demo-worthiness gate** in
+`_select_tutorial_dispatch_candidates`, which decides what gets dispatched
+to the tutorial pipeline. The gate only works as a discriminator if scores
+actually spread across 0-100. The 2026-05-20 WEDNESDAY dry-run smoke
+exposed a saturation regression: 12 of 29 videos got `value_score=95`, so
+with `top_n=4` the tutorial dispatch became effectively arbitrary among
+ties.
+
+**Tier A — Inline anchored rubric (shipped 2026-05-20)**
+
+`RETELL_PROMPT` now contains an explicit SCORING RUBRIC section with:
+
+- **Anchored buckets** with named examples of what each range earns:
+  - `90-100` Concrete build tutorial with named files, commands, visible code
+  - `75-89` Strong technical explainer with named tools / mechanism explanations
+  - `60-74` Educational explainer at the conceptual level (no code shown)
+  - `40-59` Survey / overview / opinion / commentary
+  - `20-39` Sales / marketing / promotional content
+  - `0-19` Off-topic, clickbait, low-signal
+
+- **Disqualifier caps** that override bucket selection:
+  - Sales-pitch framing ("Make $X with...", "Anyone can start...") → CAP 50
+  - View-count / "going viral" focus → CAP 50
+  - Affiliate-link dominant CTA → CAP 50
+  - Transcript metadata-only → CAP 30 + `evidence_quality="metadata_only"`
+
+- **Tier–score agreement rule**:
+  - `high` requires `score >= 75`, `medium` `50 ≤ score < 75`, `low` `score < 50`
+
+- **Code implementation prospect tightened**: `True` only when an automated
+  build agent could realistically attempt to reproduce the result (named tools,
+  commands, config, file paths). Concept explainers default to `False`.
+
+- **Explicit "do not default to 95"** admonition.
+
+The rubric lives inline in `src/universal_agent/scripts/youtube_daily_digest.py`
+under the `RETELL_PROMPT` definition. Edits are PRs against that file.
+
+**Tier B — Extract `youtube_scoring_rubric.md` (deferred)**
+
+Move the SCORING RUBRIC section to its own markdown file in the repo and
+have `RETELL_PROMPT` include it via `.format()`. Benefit: single editable
+source-of-truth where each rubric tweak is a one-file PR.
+
+**Trigger condition**: 1-2 weeks of post-Tier-A score-distribution data
+from real cron runs. If Tier A alone fixes saturation, Tier B is purely a
+cleanup. If saturation persists, Tier B + Tier C together become the path.
+
+**Tier C — Labeled-outcomes store (deferred)**
+
+A new schema (or use the existing CSI activity DB) capturing per-video
+downstream outcomes:
+
+- Did Cody produce a runnable demo for this dispatched video?  Available
+  via `manifest.json` + `run_output.txt` already produced by
+  `cody-implements-from-brief`.
+- Operator marks on the dashboard tile: "worth my time" vs "skip these".
+- Recall signal: were any videos the gate REJECTED later found to be
+  high-value? (Would need a dashboard "shoulda-dispatched" surface.)
+
+**Trigger condition**: after Tier A measurement period. If saturation still
+biases dispatch toward arbitrary ties, we need outcome data to learn from.
+
+**Tier D — Rubric-tuner agent (deferred, depends on B + C)**
+
+A weekly Claude Code session that reads the labeled-outcomes store from
+Tier C, identifies miscalls (high score → useless demo; low score → great
+video), and proposes rubric edits to the file from Tier B as a PR for
+operator review. **This is where a Claude Code skill genuinely fits**: a
+meta-skill that tunes the rubric. The ranking itself stays a deterministic
+SDK call.
+
+**Tier D explicitly is NOT "a ranking skill that learns"** — ranking is
+synchronous and deterministic. The "learning" is an offline weekly loop
+that edits the prompt the next cron uses.
+
+**Why we don't promote a tier without measurement**: rubric churn without
+a baseline makes regressions hard to diagnose. The Tier A roadmap is also
+documented inline above `RETELL_PROMPT` in
+`src/universal_agent/scripts/youtube_daily_digest.py` so future maintainers
+encounter the plan before editing scoring guidance.
 
 ### 1.1 Dual-Pipeline Architecture
 

--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -186,13 +186,61 @@ Here are the videos:
 #
 # Output contract (strict):
 #   1. Markdown "## <title>" heading
-#   2. ### Retelling section (30-40% length retelling, NOT a summary)
+#   2. ### Retelling section (50% length retelling, NOT a summary)
 #   3. ### Actionable Insights section (bullets)
 #   4. ### Thesis (single short sentence — fed to the reducer for cross-video themes)
 #   5. ```per_video_classification JSON fenced block (parsed by code, stripped from email)
 #
 # The map LLM does NOT see other videos and is told NOT to draw cross-video themes —
 # that's the reducer's job.
+#
+# ===========================================================================
+# SCORING RUBRIC ROADMAP (recorded 2026-05-20 after the saturation regression)
+# ===========================================================================
+# The 2026-05-20 WEDNESDAY dry-run smoke surfaced score saturation: 12 of 29
+# videos got value_score=95 from the map LLM. With 8 candidates tied at 95
+# and top_n=4, tutorial dispatch becomes effectively arbitrary among ties.
+# The discriminator we built (demo-worthiness gate on value_score >= 70) only
+# works if scores actually spread across 0-100.
+#
+# Improvement plan (live tiers vs deferred tiers):
+#
+#   Tier A — TIGHTEN RUBRIC IN PROMPT (CURRENT STATE, shipped 2026-05-20)
+#     Inline anchored buckets + disqualifier caps + explicit "do not default
+#     to 95" guidance directly in this RETELL_PROMPT.  Lowest cost; works
+#     within the existing single-call map step.  See the SCORING RUBRIC
+#     section of the prompt below.
+#
+#   Tier B — EXTRACT RUBRIC TO ITS OWN FILE (deferred)
+#     Move the scoring section into `youtube_scoring_rubric.md` in the repo;
+#     RETELL_PROMPT includes it verbatim via .format().  Single editable
+#     source-of-truth for what scores mean; each rubric change becomes a
+#     reviewable PR.  Trigger condition: do Tier A first and measure score
+#     distribution across 1-2 weeks before committing to file extraction.
+#
+#   Tier C — LABELED OUTCOMES STORE (deferred)
+#     New schema capturing per-video downstream outcomes:
+#       - did Cody produce a runnable demo for this dispatched video?
+#         (already available in `manifest.json` + `run_output.txt`)
+#       - did the operator find the dispatched video worth watching?
+#         (would need a thumbs-up/down surface on the dashboard tile)
+#       - did any *rejected* video later turn out to be high-value?
+#     Wire `cody-work-evaluator` outcomes into this store.  Trigger: after
+#     1-2 weeks of Tier A data shows whether scoring is still saturating.
+#
+#   Tier D — RUBRIC-TUNER AGENT (deferred, depends on B + C)
+#     A weekly Claude Code session that reads the labeled outcomes store,
+#     identifies miscalls (high score → useless demo, low score → great
+#     video), and proposes rubric edits as a PR for operator review.  THIS
+#     is where a CC skill genuinely fits: a meta-skill that tunes the
+#     rubric.  NOT a "ranking skill that learns" — the ranking stays a
+#     deterministic SDK call; the learning loop is the offline tuner that
+#     edits this prompt.
+#
+# Don't promote a tier without measurement: rubric churn without a baseline
+# makes regressions hard to diagnose.  Doc 99 mirrors this roadmap for
+# operator visibility.
+# ===========================================================================
 # ---------------------------------------------------------------------------
 RETELL_PROMPT = """You are a technical knowledge synthesizer. You will be given the transcript and metadata for ONE YouTube video. Produce a "Compressed Retelling" that lets the reader skip watching the video while preserving its substance.
 
@@ -210,7 +258,7 @@ REQUIRED OUTPUT FORMAT (markdown — do not deviate):
 **Video ID:** <video_id>
 
 ### Retelling
-<the 30-40% length retelling>
+<the 50% length retelling>
 
 ### Actionable Insights
 - <concrete thing a reader could do>
@@ -230,6 +278,72 @@ REQUIRED OUTPUT FORMAT (markdown — do not deviate):
   "reason": "<short reason grounded in the transcript>"
 }
 ```
+
+SCORING RUBRIC — READ THIS CAREFULLY BEFORE ASSIGNING value_score.
+
+`value_score` is a 0-100 integer that ranks this video against an idealized
+"buildable technical tutorial." USE THE FULL RANGE. A typical day's batch
+should have scores spread from ~20 to ~95, NOT cluster at 90+. Defaulting
+to 95 because the transcript exists is WRONG — most videos do not earn 95.
+
+Anchored buckets (assign by best fit, not by ceiling):
+
+  - 90-100: CONCRETE BUILD TUTORIAL. Contains named files, specific commands,
+    visible code or config, and a reproducible setup the reader could follow
+    end-to-end.  Examples that earn 90+: "Master 80% of Claude Code with 15
+    Things" listing each tool with worked examples; a video that types
+    `pip install X` then walks through a specific .py file line-by-line.
+    If you can't point to specific code/config artifacts in the transcript,
+    it does NOT earn 90+.
+
+  - 75-89: STRONG TECHNICAL EXPLAINER. Named tools, named systems, mechanism
+    explanations ("this works because..."), but missing reproducible
+    code/config.  A rigorous architecture talk; a hands-on demo that shows
+    output without showing the code paths to reproduce it.
+
+  - 60-74: EDUCATIONAL EXPLAINER. Speaker teaches a real technical concept
+    with named systems, but no code is shown and no specific implementation
+    details are given.  A "how X works" explainer at the conceptual level.
+
+  - 40-59: SURVEY / OVERVIEW / OPINION. Talks ABOUT a technical topic without
+    teaching how to do it.  Industry commentary, panel discussions, news
+    roundups, "the future of AI" pieces.  Worth watching for context, not
+    for implementation.
+
+  - 20-39: SALES / MARKETING / PROMOTIONAL even if AI-themed.  "Make $X with
+    AI," "Anyone can start a $1k business," affiliate-link pitches, "this
+    one tool changed everything" framing.
+
+  - 0-19: OFF-TOPIC, CLICKBAIT, OR LOW-SIGNAL.  Unrelated to the operator's
+    technical domain; pure entertainment; deceptive framing.
+
+DISQUALIFIER CAPS (apply BEFORE the bucket choice; the cap wins):
+
+  - Sales-pitch framing in title OR opening minutes ("Make $X with...",
+    "Anyone can start...", "$1M Solo Business," etc.): CAP at 50.  This
+    catches the failure mode where a high-energy promotional video about
+    AI tooling gets mistaken for a tutorial.
+
+  - View-count or "going viral" focus / influencer-meta content: CAP at 50.
+
+  - Affiliate links or promotional URLs are the dominant call-to-action:
+    CAP at 50.
+
+  - Transcript text is "[Metadata-only — transcript unavailable]": CAP at 30
+    AND set evidence_quality="metadata_only".  Without a transcript you
+    cannot verify any of the above signals, so we score conservatively.
+
+TIER MUST AGREE WITH SCORE:
+  - value_tier="high"   requires value_score >= 75
+  - value_tier="medium" requires 50 <= value_score < 75
+  - value_tier="low"    requires value_score < 50
+
+CODE IMPLEMENTATION PROSPECT:
+  - `code_implementation_prospect` is TRUE only if the video would be
+    valuable as input to an automated build agent — i.e. contains enough
+    concrete instructions (specific tools, commands, config, file paths)
+    that an agent could attempt to reproduce the result.  Concept explainers,
+    sales pitches, and news roundups are FALSE even if they're high-quality.
 
 INPUT FOLLOWS:
 """


### PR DESCRIPTION
## Summary

The 2026-05-20 WEDNESDAY dry-run smoke against PR #407+#408 surfaced **score saturation**: 12 of 29 videos got \`value_score=95\` from the map LLM, collapsing the demo-worthiness gate's discrimination among tied candidates. With \`top_n=4\` and 8 candidates tied at 95, tutorial dispatch became effectively arbitrary input order.

## Tier A — Anchored rubric inline in RETELL_PROMPT (this PR)

- **Anchored buckets** with worked examples of what each range earns:
  - \`90-100\` Concrete build tutorial — named files, commands, visible code
  - \`75-89\` Strong technical explainer — named tools, mechanism explanations
  - \`60-74\` Educational explainer at the conceptual level (no code shown)
  - \`40-59\` Survey / overview / opinion / commentary
  - \`20-39\` Sales / marketing / promotional content
  - \`0-19\` Off-topic, clickbait, low-signal
- **Disqualifier caps** that override bucket choice (sales-pitch framing / view-count focus / affiliate-link dominant → cap 50; metadata-only → cap 30 + \`evidence_quality="metadata_only"\`).
- **Tier–score agreement rule**: \`high\` requires \`score >= 75\`, \`medium\` 50-74, \`low\` < 50.
- **\`code_implementation_prospect\` tightened**: \`True\` only when an automated build agent could realistically attempt to reproduce the result.
- **Explicit "do not default to 95"** admonition.

## Roadmap notation (deferred work, recorded in code + docs)

A comment block above \`RETELL_PROMPT\` and a new § 1.1B in \`docs/03_Operations/99_Tutorial_Pipeline_Architecture_And_Operations.md\` document the multi-tier improvement plan:

| Tier | Status | Description |
|---|---|---|
| **A** | **Shipped (this PR)** | Inline anchored rubric in \`RETELL_PROMPT\` |
| **B** | Deferred — needs Tier A measurements | Extract rubric to \`youtube_scoring_rubric.md\`; \`.format()\` it into the prompt; single editable source-of-truth |
| **C** | Deferred — depends on Tier B + 1-2 wks of data | Labeled-outcomes store: capture Cody demo success/failure + operator dashboard marks + "shoulda-dispatched" signals |
| **D** | Deferred — depends on B + C | Weekly **Claude Code skill** that reads the Tier C store, identifies miscalls, and proposes rubric-edit PRs for operator review |

**Tier D is explicitly NOT "a ranking skill that learns."** Ranking stays a synchronous deterministic SDK call. The "learning" loop is offline and weekly — it edits the prompt the next cron uses. A Claude Code skill fits as the *rubric tuner* (a meta-skill that proposes PRs), not as the ranker itself.

## Tests

- 41/41 digest tests pass (no logic changes; prompt-text edit only).
- Will smoke against the same 29-video WEDNESDAY playlist (still unprocessed because earlier was \`--dry-run\`) after merge+deploy to compare score distributions on identical input.

## Sample verification metric (will post in this thread after smoke)

| Metric | WEDNESDAY pre-Tier-A | WEDNESDAY post-Tier-A | Target |
|---|---|---|---|
| videos at \`score=95\` | 12/29 | TBD | < 5 |
| top dispatch picks | 4/8 ties | TBD | clear ordering |
| score range used (max - min) | 95-0 | TBD | wider effective range above the metadata-only floor |