### PR TITLE
feat(watchdog): P7 — universal ZAI HTTP observability hook

### DIFF
--- a/src/universal_agent/infisical_loader.py
+++ b/src/universal_agent/infisical_loader.py
@@ -521,4 +521,18 @@ def initialize_runtime_secrets(
             errors=tuple(errors),
         )
         _BOOTSTRAP_RESULT = result
+
+        # P7 (2026-05-21): install universal ZAI HTTP observability hooks.
+        # Monkey-patches httpx.Client/AsyncClient __init__ so every outbound
+        # request to api.z.ai gets captured into a rolling JSONL — closes
+        # the P4 instrumentation gap where 8+ files bypassed ZAIRateLimiter.
+        # Best-effort: failure here must NOT break runtime bootstrap.
+        try:
+            from universal_agent.services.zai_observability import (
+                install_zai_observability,
+            )
+            install_zai_observability()
+        except Exception:  # noqa: BLE001 — never break bootstrap over observability
+            pass
+
         return result

--- a/src/universal_agent/services/zai_observability.py
+++ b/src/universal_agent/services/zai_observability.py
@@ -1,0 +1,313 @@
+"""Universal ZAI HTTP observability.
+
+P7 (2026-05-21): closes the instrumentation gap from P4 (#402). The
+ZAIRateLimiter only catches calls that go through `with_rate_limit_retry`
+— ~2 files in the codebase. At least 8+ other files call ZAI directly
+via httpx, bypassing the rate-limiter entirely. Confirmed via two ZAI
+429s on prod at 2026-05-21 06:10:53 UTC that did NOT update the P4
+snapshot.
+
+This module monkey-patches `httpx.Client.__init__` and
+`httpx.AsyncClient.__init__` at process start so every outbound HTTP
+request automatically gets an event hook installed. The hook filters
+by host — only requests to `api.z.ai` (and friends) are captured —
+keeping the events file focused.
+
+Captures per request:
+- Timestamp, method, URL path, status code
+- Response-time milliseconds
+- Rate-limit headers: `retry-after`, `x-ratelimit-remaining`, `x-ratelimit-limit`
+- Body snippet on non-2xx (first 500 bytes)
+- Caller attribution via stack walk (which UA module issued the call)
+- Category: ok / rate_limited_429 / fup_signal / server_error_5xx /
+  client_error_4xx
+
+Rolling JSONL buffer at `AGENT_RUN_WORKSPACES/zai_inference_events.jsonl`
+with `UA_ZAI_EVENTS_MAX_LINES` cap (default 10000 — ~3 days at current
+load levels). Periodic trim keeps file size bounded.
+
+Install once at process start via `install_zai_observability()`. Called
+from `infisical_loader.initialize_runtime_secrets()` so every UA process
+(gateway, cron subprocess, heartbeat daemon, briefings_agent) is
+instrumented without per-file changes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import random
+import time
+import traceback
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+# ── Configuration ──────────────────────────────────────────────────────────
+
+ZAI_HOSTS = frozenset({
+    "api.z.ai",
+    "open.bigmodel.cn",
+})
+
+
+EVENT_CATEGORY_OK = "ok"
+EVENT_CATEGORY_RATE_LIMITED = "rate_limited_429"
+EVENT_CATEGORY_FUP = "fup_signal"
+EVENT_CATEGORY_SERVER_ERROR = "server_error_5xx"
+EVENT_CATEGORY_CLIENT_ERROR = "client_error_4xx"
+
+
+def _events_max_lines() -> int:
+    try:
+        return max(100, int(os.getenv("UA_ZAI_EVENTS_MAX_LINES", "10000")))
+    except ValueError:
+        return 10000
+
+
+def _trim_threshold_ratio() -> float:
+    try:
+        return max(0.05, float(os.getenv("UA_ZAI_EVENTS_TRIM_RATIO", "0.25")))
+    except ValueError:
+        return 0.25
+
+
+def _events_path() -> Path:
+    env_override = os.getenv("UA_ZAI_EVENTS_PATH")
+    if env_override:
+        return Path(env_override)
+    repo_root = Path(__file__).resolve().parents[3]
+    return repo_root / "AGENT_RUN_WORKSPACES" / "zai_inference_events.jsonl"
+
+
+# ── Classification ─────────────────────────────────────────────────────────
+
+def _fup_keywords() -> frozenset[str]:
+    try:
+        from universal_agent.rate_limiter import FUP_KEYWORDS
+        return FUP_KEYWORDS
+    except Exception:  # noqa: BLE001
+        return frozenset({
+            "fair use",
+            "fair-use",
+            "fup",
+            "policy violation",
+            "policy-violation",
+            "abuse",
+            "concurrency limit",
+            "weekly limit",
+            "account suspended",
+            "account flagged",
+            "1313",
+        })
+
+
+def _is_fup_body(body: str) -> bool:
+    if not body:
+        return False
+    lower = body.lower()
+    return any(kw in lower for kw in _fup_keywords())
+
+
+def _classify_response(status: int, body_snippet: str, reason_phrase: str = "") -> str:
+    if _is_fup_body(body_snippet):
+        return EVENT_CATEGORY_FUP
+    if status == 429:
+        return EVENT_CATEGORY_RATE_LIMITED
+    if 500 <= status < 600:
+        return EVENT_CATEGORY_SERVER_ERROR
+    if 400 <= status < 500:
+        return EVENT_CATEGORY_CLIENT_ERROR
+    return EVENT_CATEGORY_OK
+
+
+def _is_zai_url(url: str) -> bool:
+    if not url:
+        return False
+    return any(h in url for h in ZAI_HOSTS)
+
+
+# ── Caller attribution ────────────────────────────────────────────────────
+
+_SKIP_FRAME_FRAGMENTS = (
+    "/httpx/",
+    "/anyio/",
+    "/asyncio/",
+    "zai_observability.py",
+)
+
+
+def _identify_caller() -> str:
+    try:
+        stack = traceback.extract_stack()
+        for frame in reversed(stack):
+            filename = frame.filename
+            if any(skip in filename for skip in _SKIP_FRAME_FRAGMENTS):
+                continue
+            if "universal_agent" in filename:
+                parts = filename.split("universal_agent/")
+                if len(parts) > 1:
+                    return f"universal_agent/{parts[-1]}"
+            if "site-packages" in filename:
+                continue
+            parts = filename.split("/")
+            if len(parts) >= 2:
+                return "/".join(parts[-2:])
+            return filename
+    except Exception:  # noqa: BLE001
+        return "unknown"
+    return "unknown"
+
+
+# ── Event persistence ─────────────────────────────────────────────────────
+
+def _trim_events_file(path: Path, max_lines: int) -> None:
+    try:
+        if not path.exists():
+            return
+        with open(path) as f:
+            lines = f.readlines()
+        if len(lines) <= max_lines:
+            return
+        keep = lines[-max_lines:]
+        with open(path, "w") as f:
+            f.writelines(keep)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("zai_observability trim failed: %s", exc)
+
+
+def _append_event(event: dict) -> None:
+    try:
+        path = _events_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "a") as f:
+            f.write(json.dumps(event, default=str) + "\n")
+        if random.random() < 0.02:
+            max_lines = _events_max_lines()
+            ratio = _trim_threshold_ratio()
+            size_estimate = path.stat().st_size
+            if size_estimate > max_lines * 500 * (1 + ratio):
+                _trim_events_file(path, max_lines)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("zai_observability append failed: %s", exc)
+
+
+# ── httpx hooks ───────────────────────────────────────────────────────────
+
+_REQUEST_START_EXT_KEY = "zai_obs_started_at"
+
+
+def _on_request_sync(request: httpx.Request) -> None:
+    request.extensions[_REQUEST_START_EXT_KEY] = time.monotonic()
+
+
+async def _on_request_async(request: httpx.Request) -> None:
+    request.extensions[_REQUEST_START_EXT_KEY] = time.monotonic()
+
+
+def _capture(request: httpx.Request, response: httpx.Response) -> None:
+    if not _is_zai_url(str(request.url)):
+        return
+    started_at = request.extensions.get(_REQUEST_START_EXT_KEY)
+    response_time_ms: Optional[float] = None
+    if started_at is not None:
+        response_time_ms = round((time.monotonic() - started_at) * 1000.0, 1)
+
+    body_snippet = ""
+    if response.status_code >= 400:
+        try:
+            raw = response.text
+            body_snippet = raw[:500] if raw else ""
+        except Exception:  # noqa: BLE001
+            body_snippet = ""
+
+    event = {
+        "ts": time.time(),
+        "method": request.method,
+        "url_path": request.url.path,
+        "host": request.url.host,
+        "status": response.status_code,
+        "response_time_ms": response_time_ms,
+        "retry_after": response.headers.get("retry-after"),
+        "ratelimit_remaining": response.headers.get("x-ratelimit-remaining"),
+        "ratelimit_limit": response.headers.get("x-ratelimit-limit"),
+        "category": _classify_response(response.status_code, body_snippet, response.reason_phrase or ""),
+        "caller": _identify_caller(),
+    }
+    if body_snippet:
+        event["body_snippet"] = body_snippet
+
+    _append_event(event)
+
+
+def _on_response_sync(response: httpx.Response) -> None:
+    try:
+        _capture(response.request, response)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("zai_observability sync capture failed: %s", exc)
+
+
+async def _on_response_async(response: httpx.Response) -> None:
+    try:
+        _capture(response.request, response)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("zai_observability async capture failed: %s", exc)
+
+
+# ── Install hooks ─────────────────────────────────────────────────────────
+
+# Capture the ORIGINAL httpx __init__ once at module-import time. If
+# install_zai_observability() is called multiple times (e.g. tests that
+# reset the _INSTALLED flag), the patched init always calls into the
+# pristine original — no recursion.
+_ORIG_SYNC_INIT = httpx.Client.__init__
+_ORIG_ASYNC_INIT = httpx.AsyncClient.__init__
+
+_INSTALLED = False
+
+
+def _patched_sync_init(self, *args, **kwargs):
+    hooks = dict(kwargs.pop("event_hooks", None) or {})
+    request_hooks = list(hooks.get("request") or [])
+    response_hooks = list(hooks.get("response") or [])
+    if _on_request_sync not in request_hooks:
+        request_hooks.append(_on_request_sync)
+    if _on_response_sync not in response_hooks:
+        response_hooks.append(_on_response_sync)
+    hooks["request"] = request_hooks
+    hooks["response"] = response_hooks
+    kwargs["event_hooks"] = hooks
+    _ORIG_SYNC_INIT(self, *args, **kwargs)
+
+
+def _patched_async_init(self, *args, **kwargs):
+    hooks = dict(kwargs.pop("event_hooks", None) or {})
+    request_hooks = list(hooks.get("request") or [])
+    response_hooks = list(hooks.get("response") or [])
+    if _on_request_async not in request_hooks:
+        request_hooks.append(_on_request_async)
+    if _on_response_async not in response_hooks:
+        response_hooks.append(_on_response_async)
+    hooks["request"] = request_hooks
+    hooks["response"] = response_hooks
+    kwargs["event_hooks"] = hooks
+    _ORIG_ASYNC_INIT(self, *args, **kwargs)
+
+
+def install_zai_observability() -> bool:
+    """Monkey-patch httpx.Client/AsyncClient __init__ so every new client
+    automatically carries the observability hooks. Idempotent across
+    process lifetime — first call installs, subsequent calls are no-op."""
+    global _INSTALLED
+    if _INSTALLED:
+        return False
+    httpx.Client.__init__ = _patched_sync_init
+    httpx.AsyncClient.__init__ = _patched_async_init
+    _INSTALLED = True
+    logger.info("zai_observability: hooks installed on httpx.Client + httpx.AsyncClient")
+    return True

--- a/tests/unit/test_proactive_health_payload.py
+++ b/tests/unit/test_proactive_health_payload.py
@@ -416,13 +416,29 @@ def test_proactive_artifact_digest_invariant_fires_when_emails_stale(
 ) -> None:
     """The bug-reproduction case: aggregator should DETECT that no digest
     email has been sent in 26h+. Before P0b, the invariant queried the empty
-    runtime_state.db and silently passed — it could never fire on real data."""
+    runtime_state.db and silently passed — it could never fire on real data.
+
+    P7 (2026-05-21): test was time-bombed. It (a) hard-coded fixed_now to
+    2026-05-20 18:00 UTC which is now in the past, (b) reloaded the invariants
+    module AFTER the monkeypatch, undoing it. CI runs after that date hit the
+    invariant's `now.hour < 9` hour-gate and got [] back. Fix: reload FIRST,
+    then patch, and use a clock-relative fixed_now so the test is durable."""
     from datetime import datetime, timezone, timedelta
-    # Pin the clock to a moment WELL past the 9 AM probe window so the
-    # invariant's hour-gate doesn't filter the test out.
+
+    # Reload BEFORE the monkeypatch — reload would otherwise re-create
+    # _now_houston and undo the patch.
+    import importlib
     from universal_agent.services.invariants import proactive_pipeline_invariants as ppi
-    fixed_now = datetime(2026, 5, 20, 18, 0, tzinfo=timezone.utc)  # 1 PM Houston
-    monkeypatch.setattr(ppi, "_now_houston", lambda: fixed_now.astimezone(ppi.HOUSTON_TZ) if hasattr(ppi, "HOUSTON_TZ") else fixed_now)
+    importlib.reload(ppi)
+
+    # Force _now_houston to a fixed hour past the invariant's 9 AM probe
+    # gate. Use 18:00 UTC ("hour" alone is what the gate checks).
+    real_now = datetime.now(timezone.utc)
+    fixed_now = real_now.replace(hour=18, minute=0, second=0, microsecond=0)
+    monkeypatch.setattr(ppi, "_now_houston", lambda: fixed_now)
+    # The invariant also computes age_hours via real `datetime.now(timezone.utc)`
+    # internally — we can't patch that easily, so seed `stale` relative to
+    # REAL now (35h ago) so age_hours always exceeds the 30h threshold.
 
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row
@@ -442,19 +458,15 @@ def test_proactive_artifact_digest_invariant_fires_when_emails_stale(
         );
         """
     )
-    stale = (datetime.now(timezone.utc) - timedelta(hours=30)).isoformat()
+    # Seed a row 35h before REAL now so it exceeds the invariant's internal
+    # 30h threshold (which uses datetime.now(timezone.utc), not _now_houston).
+    stale = (real_now - timedelta(hours=35)).isoformat()
     conn.execute(
         "INSERT INTO proactive_artifact_emails (artifact_id, subject, recipient, sent_at) "
         "VALUES ('a1', 'Old Digest', 'kevinjdragan@gmail.com', ?)",
         (stale,),
     )
     conn.commit()
-
-    # Need the invariant registered. The conftest pattern from the existing
-    # YouTube test resets the registry — re-import to pick up proactive_*.
-    import importlib
-    from universal_agent.services.invariants import proactive_pipeline_invariants
-    importlib.reload(proactive_pipeline_invariants)
 
     payload = build_proactive_health_payload(
         activity_conn=conn,

--- a/tests/unit/test_zai_observability.py
+++ b/tests/unit/test_zai_observability.py
@@ -1,0 +1,216 @@
+"""Tests for the universal ZAI HTTP observability hook (P7 #2026-05-21)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from universal_agent.services.zai_observability import (
+    EVENT_CATEGORY_CLIENT_ERROR,
+    EVENT_CATEGORY_FUP,
+    EVENT_CATEGORY_OK,
+    EVENT_CATEGORY_RATE_LIMITED,
+    EVENT_CATEGORY_SERVER_ERROR,
+    ZAI_HOSTS,
+    _classify_response,
+    _events_path,
+    _is_zai_url,
+    _trim_events_file,
+    install_zai_observability,
+)
+
+
+@pytest.fixture
+def isolated_events_path(tmp_path, monkeypatch):
+    events = tmp_path / "zai_inference_events.jsonl"
+    monkeypatch.setenv("UA_ZAI_EVENTS_PATH", str(events))
+    yield events
+
+
+def test_zai_hosts_includes_api_z_ai():
+    assert "api.z.ai" in ZAI_HOSTS
+
+
+def test_is_zai_url_matches_known_hosts():
+    assert _is_zai_url("https://api.z.ai/api/anthropic/v1/messages")
+    assert _is_zai_url("https://api.z.ai/api/coding/paas/v4/chat/completions")
+    assert not _is_zai_url("https://api.openai.com/v1/chat/completions")
+    assert not _is_zai_url("https://api.anthropic.com/v1/messages")
+    assert not _is_zai_url("https://www.googleapis.com/youtube/v3/playlistItems")
+
+
+def test_classify_response_200_is_ok():
+    assert _classify_response(200, "", "") == EVENT_CATEGORY_OK
+
+
+def test_classify_response_429_is_rate_limited():
+    assert _classify_response(429, "Too Many Requests", "") == EVENT_CATEGORY_RATE_LIMITED
+
+
+def test_classify_response_fup_body_overrides_429():
+    """FUP body language outranks the status code — critical-immediate."""
+    assert _classify_response(429, "fair use policy violation: account flagged", "") == EVENT_CATEGORY_FUP
+
+
+def test_classify_response_403_with_fup_body_is_fup():
+    assert _classify_response(403, "concurrency limit exceeded for account", "") == EVENT_CATEGORY_FUP
+
+
+def test_classify_response_5xx_is_server_error():
+    assert _classify_response(503, "service unavailable", "") == EVENT_CATEGORY_SERVER_ERROR
+    assert _classify_response(502, "", "") == EVENT_CATEGORY_SERVER_ERROR
+
+
+def test_classify_response_400_is_client_error():
+    assert _classify_response(400, "bad request", "") == EVENT_CATEGORY_CLIENT_ERROR
+
+
+def test_events_path_respects_env_override(isolated_events_path):
+    assert str(_events_path()) == str(isolated_events_path)
+
+
+def test_events_path_default_under_workspaces(monkeypatch):
+    monkeypatch.delenv("UA_ZAI_EVENTS_PATH", raising=False)
+    path = _events_path()
+    assert "AGENT_RUN_WORKSPACES" in str(path)
+    assert path.name == "zai_inference_events.jsonl"
+
+
+def test_trim_events_file_keeps_last_n(isolated_events_path):
+    with open(isolated_events_path, "w") as f:
+        for i in range(100):
+            f.write(json.dumps({"i": i}) + "\n")
+    _trim_events_file(isolated_events_path, max_lines=30)
+    lines = isolated_events_path.read_text().strip().split("\n")
+    assert len(lines) == 30
+    assert json.loads(lines[0])["i"] == 70
+    assert json.loads(lines[-1])["i"] == 99
+
+
+def test_trim_below_max_is_noop(isolated_events_path):
+    with open(isolated_events_path, "w") as f:
+        for i in range(5):
+            f.write(json.dumps({"i": i}) + "\n")
+    mtime_before = isolated_events_path.stat().st_mtime
+    time.sleep(0.01)
+    _trim_events_file(isolated_events_path, max_lines=10)
+    assert isolated_events_path.stat().st_mtime == mtime_before
+
+
+def test_install_zai_observability_is_idempotent():
+    import universal_agent.services.zai_observability as zo
+    zo._INSTALLED = False
+    try:
+        assert zo.install_zai_observability() is True
+        assert zo.install_zai_observability() is False
+    finally:
+        zo._INSTALLED = True
+
+
+def test_hooks_capture_zai_429_response(isolated_events_path):
+    """End-to-end: install hook, mock a 429 ZAI response, confirm capture."""
+    import universal_agent.services.zai_observability as zo
+    zo._INSTALLED = False
+    zo.install_zai_observability()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            429,
+            text='{"error": "rate limit"}',
+            headers={"retry-after": "30", "x-ratelimit-remaining": "0"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        client.post(
+            "https://api.z.ai/api/anthropic/v1/messages",
+            json={"model": "glm-4.6", "messages": []},
+        )
+
+    assert isolated_events_path.exists()
+    line = isolated_events_path.read_text().strip().split("\n")[-1]
+    event = json.loads(line)
+    assert event["status"] == 429
+    assert event["category"] == EVENT_CATEGORY_RATE_LIMITED
+    assert event["url_path"] == "/api/anthropic/v1/messages"
+    assert event["retry_after"] == "30"
+    assert event["ratelimit_remaining"] == "0"
+    assert event.get("caller")
+    assert event.get("response_time_ms") is not None
+
+
+def test_hooks_skip_non_zai_calls(isolated_events_path):
+    """Only ZAI URLs should be captured."""
+    import universal_agent.services.zai_observability as zo
+    zo._INSTALLED = False
+    zo.install_zai_observability()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="ok")
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        client.get("https://www.googleapis.com/youtube/v3/playlistItems")
+        client.get("https://api.agentmail.to/v0/inboxes")
+        client.get("https://export.arxiv.org/api/query")
+
+    if isolated_events_path.exists():
+        assert isolated_events_path.read_text().strip() == ""
+
+
+@pytest.mark.asyncio
+async def test_async_hooks_capture_zai_response(isolated_events_path):
+    """AsyncClient is the primary path for UA — Cody, Atlas, briefings_agent."""
+    import universal_agent.services.zai_observability as zo
+    zo._INSTALLED = False
+    zo.install_zai_observability()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            text='{"ok": true}',
+            headers={"x-ratelimit-remaining": "150"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        await client.post(
+            "https://api.z.ai/api/coding/paas/v4/chat/completions",
+            json={"model": "glm-4.6"},
+        )
+
+    assert isolated_events_path.exists()
+    event = json.loads(isolated_events_path.read_text().strip().split("\n")[-1])
+    assert event["status"] == 200
+    assert event["category"] == EVENT_CATEGORY_OK
+    assert event["ratelimit_remaining"] == "150"
+
+
+def test_hook_never_raises_on_bad_write_path(isolated_events_path, monkeypatch):
+    """Hot path safety: a broken events-file path must not crash the request."""
+    import universal_agent.services.zai_observability as zo
+    zo._INSTALLED = False
+    zo.install_zai_observability()
+
+    monkeypatch.setenv("UA_ZAI_EVENTS_PATH", "/proc/nonexistent_dir/events.jsonl")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="ok")
+
+    transport = httpx.MockTransport(handler)
+    with httpx.Client(transport=transport) as client:
+        resp = client.post("https://api.z.ai/api/anthropic/v1/messages", json={"x": 1})
+    assert resp.status_code == 200
+
+
+def test_fup_keywords_match_p4_set():
+    """Keep classifier in lockstep with the P4 rate_limiter FUP_KEYWORDS."""
+    from universal_agent.rate_limiter import FUP_KEYWORDS
+    for kw in FUP_KEYWORDS:
+        assert _classify_response(429, f"error: {kw} triggered", "") == EVENT_CATEGORY_FUP


### PR DESCRIPTION
## Summary

Closes the P4 instrumentation gap that we hit on prod tonight (2026-05-21 06:10:53 UTC — 2 ZAI 429s on the wire that the rate-limiter snapshot did NOT count).

P4's `ZAIRateLimiter` only catches calls through `with_rate_limit_retry` — 2 files. At least 8+ other files call ZAI directly via httpx bypassing it.

P7 fixes this **universally** by monkey-patching `httpx.Client.__init__` and `httpx.AsyncClient.__init__` at process bootstrap. Every outbound HTTP call gets event hooks installed automatically — no per-file changes. Filters by host so only `api.z.ai` responses are captured.

## What gets captured per response

- `ts`, `method`, `url_path`, `host`, `status`
- `response_time_ms` (request hook → response hook delta)
- `retry-after`, `x-ratelimit-remaining`, `x-ratelimit-limit` headers
- `body_snippet` (first 500 bytes) on non-2xx
- 5-category classification: `ok` / `rate_limited_429` / `fup_signal` / `server_error_5xx` / `client_error_4xx`
- **Caller attribution** via stack walk (so we know which UA module issued the call)

FUP detection reuses P4's `FUP_KEYWORDS` set so the two paths stay in lockstep — a 429 OR 403 with body containing fair-use / policy-violation / abuse / concurrency-limit etc. classifies as FUP.

## Storage

Rolling JSONL at `AGENT_RUN_WORKSPACES/zai_inference_events.jsonl` with `UA_ZAI_EVENTS_MAX_LINES` cap (default **10000** — ~3 days at current load levels). Amortized trim (2% of writes do a size check) keeps the file bounded.

## Install point

`infisical_loader.initialize_runtime_secrets()` — fires at every UA process bootstrap (gateway, cron subprocess, heartbeat daemon, briefings_agent). One install hits everything. Idempotent + recursion-safe.

## Hot path safety

Response hook never raises. File-write failures, caller-attribution failures, body-parse failures all caught + logged at debug level. Bad `UA_ZAI_EVENTS_PATH` cannot crash a ZAI request.

## Test plan

- [x] 18 tests covering host detection, classification, FUP keyword match, file rotation, idempotent install, sync + async capture, non-ZAI URL skip, hot-path safety, caller attribution, P4 keyword lockstep
- [x] No regression on P4 (37 watchdog tests pass together)
- [ ] After deploy: confirm `zai_inference_events.jsonl` populates on prod within ~30 min; cross-check against journalctl 429 timestamps to verify full coverage

## What's next (separate PRs, not in this one)

- **W2**: extend `zai_inference_health` invariant to consume the broader event stream (per-caller breakdown, slow-response detection, x-ratelimit-remaining early-warning)
- **W3**: efficiency fixes based on what the data shows (stagger crons, per-consumer concurrency caps, rolling-window throttle)

Operator direction (2026-05-21): ship observation first, gather morning's data, evaluate at noon before any enforcement changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)