### PR TITLE
fix(p7): walk past SDK frames in caller attribution

### DIFF
--- a/src/universal_agent/services/zai_observability.py
+++ b/src/universal_agent/services/zai_observability.py
@@ -134,27 +134,49 @@ def _is_zai_url(url: str) -> bool:
 
 # ── Caller attribution ────────────────────────────────────────────────────
 
+# Frame-path fragments to skip when walking the stack. These are framework
+# / SDK internals that we want to walk PAST to find the actual UA caller
+# that issued the ZAI request.
 _SKIP_FRAME_FRAGMENTS = (
     "/httpx/",
     "/anyio/",
     "/asyncio/",
+    "/.venv/",                 # any virtualenv path
+    "/site-packages/",         # any pip-installed dependency
+    "/anthropic/",             # Anthropic SDK (used for ZAI's Anthropic-compatible endpoint)
+    "/openai/",                # OpenAI SDK (used for ZAI's OpenAI-compatible endpoint)
+    "/google/genai/",          # google-genai SDK
+    "/google/generativeai/",   # legacy google-generativeai
     "zai_observability.py",
 )
 
 
 def _identify_caller() -> str:
+    """Walk the stack to find the first frame OUTSIDE framework/SDK code.
+    Returns a path relative to universal_agent/ if the caller is a UA
+    source file. Best-effort — never raises.
+
+    Note: the universal_agent project tree contains `.venv/` so naive
+    `"universal_agent" in filename` checks match SDK frames inside the
+    venv. The skip list above filters those out so we land on the
+    actual UA module that issued the call (e.g. cody_implementation,
+    mission_control_tier1, briefings_agent).
+    """
     try:
         stack = traceback.extract_stack()
         for frame in reversed(stack):
             filename = frame.filename
             if any(skip in filename for skip in _SKIP_FRAME_FRAGMENTS):
                 continue
-            if "universal_agent" in filename:
-                parts = filename.split("universal_agent/")
+            # Only treat as a UA-source frame if it's actually under the
+            # source tree, not the venv. The skip list already excludes
+            # .venv/ and site-packages, so any frame matching
+            # "universal_agent/" here is a real UA-source file.
+            if "/universal_agent/" in filename:
+                parts = filename.split("/universal_agent/")
                 if len(parts) > 1:
                     return f"universal_agent/{parts[-1]}"
-            if "site-packages" in filename:
-                continue
+            # Non-UA, non-framework frame (e.g. user script, REPL).
             parts = filename.split("/")
             if len(parts) >= 2:
                 return "/".join(parts[-2:])


### PR DESCRIPTION
## Summary

First organic ZAI capture on prod showed `caller: anthropic/_base_client.py` instead of the actual UA module that issued the call. P7's stack walker stopped too early — `_SKIP_FRAME_FRAGMENTS` didn't include `/.venv/` or `/site-packages/`, and since the venv lives under `universal_agent/.venv/`, the substring match `"universal_agent" in filename` matched SDK frames inside the venv.

This fix:
- Skips `/.venv/`, `/site-packages/`, `/anthropic/`, `/openai/`, `/google/genai/`, `/google/generativeai/`
- Tightens the UA-source match from substring `"universal_agent"` to path-segment `"/universal_agent/"` so it only matches real UA source files, not venv-internal SDK paths

So now when Anthropic SDK is used to call ZAI's Anthropic-compatible endpoint (which is most of UA's ZAI traffic), the captured `caller` will point at the actual UA module (e.g. `cody_implementation.py`, `mission_control_tier1.py`, `briefings_agent.py`) — exactly what we need for the noon attribution report.

## Test plan

- [x] 18 existing P7 tests pass
- [ ] After deploy: next organic capture should show a real UA-source path in `caller`, not an SDK file

🤖 Generated with [Claude Code](https://claude.com/claude-code)