### PR TITLE
feat(intel): auto-promote top-scored CSI demo-triage candidates with daily cap

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -14718,6 +14718,7 @@ async def lifespan(app: FastAPI):
                 _ensure_csi_convergence_cron_job()
                 _ensure_claude_code_intel_cron_job()
                 _ensure_csi_demo_triage_rank_cron_job()
+                _ensure_intel_auto_promoter_cron_job()
                 _ensure_paper_to_podcast_cron_job()
                 _ensure_youtube_daily_digest_cron_job()
                 _ensure_nightly_wiki_cron_job()
@@ -19368,6 +19369,44 @@ def _ensure_csi_demo_triage_rank_cron_job() -> Optional[dict[str, Any]]:
         # observability separately from the candidate rows it touches.
     )
 
+
+def _intel_auto_promoter_cron_enabled() -> bool:
+    """Whether the CSI intel auto-promoter cron should be registered.
+
+    Default ON. Disable with UA_INTEL_AUTO_PROMOTE_CRON_ENABLED=0.
+    Note: the runtime promotion itself is *separately* gated by
+    UA_INTEL_AUTO_PROMOTE_ENABLED so the cron can stay registered
+    while promotions are paused.
+    """
+    raw = os.getenv("UA_INTEL_AUTO_PROMOTE_CRON_ENABLED", "1").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _ensure_intel_auto_promoter_cron_job() -> Optional[dict[str, Any]]:
+    """Register the CSI intel auto-promoter cron.
+
+    Fires 30 minutes after the ranker on each tick so freshly-scored
+    candidates promote in the same active-hours window. Houston-time
+    schedule keeps the run inside the 6 AM-10 PM content-generation
+    window per CLAUDE.md operating-hours policy.
+    """
+    if not _intel_auto_promoter_cron_enabled():
+        return None
+    return _register_system_cron_job(
+        system_job="intel_auto_promoter",
+        default_cron="35 10,15 * * *",
+        default_timezone="America/Chicago",
+        command="!script universal_agent.scripts.intel_auto_promoter_cron",
+        description=(
+            "Auto-approve top-scored CSI demo-triage candidates so they flow "
+            "into Cody's queue without operator clicks. Capped per day; uses "
+            "the same approve_candidate path as the dashboard button."
+        ),
+        timeout_seconds=180,
+        enabled=True,
+        cron_env_var="UA_INTEL_AUTO_PROMOTE_CRON_EXPR",
+        timezone_env_var="UA_INTEL_AUTO_PROMOTE_CRON_TIMEZONE",
+    )
 
 
 def _ensure_claude_code_intel_cron_job() -> None:

--- a/src/universal_agent/scripts/intel_auto_promoter_cron.py
+++ b/src/universal_agent/scripts/intel_auto_promoter_cron.py
@@ -1,0 +1,51 @@
+"""Cron entry point: auto-promote top-scored CSI demo-triage candidates.
+
+Fires after `csi_demo_triage_rank` so freshly-scored candidates flow
+through the same UTC day. Gated by `UA_INTEL_AUTO_PROMOTE_*` env vars
+(see `services/intel_auto_promoter.py`).
+
+Operator gate: `UA_INTEL_AUTO_PROMOTE_ENABLED=0` to disable without a
+redeploy. Daily-cap default 2 prevents Cody from being buried under a
+backlog spike.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+from universal_agent.infisical_loader import initialize_runtime_secrets
+from universal_agent.services.intel_auto_promoter import promote_top_candidates
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", default="", help="Deployment profile for Infisical secret loading.")
+    parser.add_argument("--dry-run", action="store_true", help="Report what would be promoted, write nothing.")
+    return parser.parse_args()
+
+
+def _emit(payload: dict[str, Any], *, code: int = 0) -> int:
+    print(json.dumps(payload, indent=2, ensure_ascii=True, sort_keys=True))
+    return code
+
+
+def main() -> int:
+    args = _parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+    initialize_runtime_secrets(profile=args.profile or None)
+
+    if os.getenv("UA_INTEL_AUTO_PROMOTE_ENABLED", "1").strip().lower() not in {"1", "true", "yes", "on"}:
+        return _emit({"ok": True, "skipped": "disabled_by_env"})
+
+    result = promote_top_candidates(dry_run=True if args.dry_run else None)
+    payload: dict[str, Any] = {"ok": result.error is None, **dataclasses.asdict(result)}
+    return _emit(payload, code=0 if result.error is None else 1)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/universal_agent/services/intel_auto_promoter.py
+++ b/src/universal_agent/services/intel_auto_promoter.py
@@ -1,0 +1,238 @@
+"""Auto-promote top-scored CSI demo-triage candidates into Task Hub.
+
+Today every tier-3 ClaudeDevs intel signal lands in `demo_triage_candidates`
+with `state='pending'`. The `csi_demo_triage_ranker` cron scores each one
+0-10 via LLM. The only path from a scored candidate to a `cody_scaffold_request`
+Task Hub row (and downstream Cody demo build) is the operator clicking
+"Approve" in the dashboard. With 7-9 high-confidence signals accumulating
+per day and no operator clicks happening overnight, the pipeline stalls.
+
+This service runs as a cron AFTER the ranker. For each pending candidate
+above `min_score`, it calls the canonical `csi_demo_triage.approve_candidate`
+helper — the same one the dashboard button uses — so the resulting Task Hub
+row is byte-identical to operator-approved promotions. Gating:
+
+  - `UA_INTEL_AUTO_PROMOTE_ENABLED`        — kill switch (default "1")
+  - `UA_INTEL_AUTO_PROMOTE_MIN_SCORE`      — score threshold 0-10 (default 7.5)
+  - `UA_INTEL_AUTO_PROMOTE_DAILY_CAP`      — max promotions per UTC day (default 2)
+  - `UA_INTEL_AUTO_PROMOTE_DRY_RUN`        — report-only mode (default "0")
+
+The daily cap is enforced by counting `state='approved'` rows whose
+`decided_by` starts with `auto_promoter:` and whose `decided_at` falls in
+the current UTC day. That bound naturally rolls forward at midnight.
+
+`decided_by` carries the score + run-id stamp so any auto-promotion is
+traceable end-to-end: `auto_promoter:score=8.4:run=2026-05-22`.
+
+Cody's natural 1-concurrent VP cap and the persistent-queue Task Hub
+together make this safe to fire continuously: a backlog of high-scored
+candidates drains at Cody's pace, not the promoter's.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import logging
+import os
+import sqlite3
+from typing import Any
+
+from universal_agent.services import csi_demo_triage
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+_DEFAULT_MIN_SCORE = 7.5
+_DEFAULT_DAILY_CAP = 2
+
+
+def _env_enabled(name: str, default: str = "1") -> bool:
+    return os.getenv(name, default).strip().lower() in _TRUTHY
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = (os.getenv(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _utc_today_start_iso() -> str:
+    """Start of the current UTC day, as ISO timestamp matching `decided_at` format."""
+    now = datetime.now(timezone.utc)
+    return now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
+
+
+def _count_auto_promotions_today(conn: sqlite3.Connection) -> int:
+    """Return how many `auto_promoter:` approvals have fired this UTC day."""
+    start = _utc_today_start_iso()
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS n
+        FROM demo_triage_candidates
+        WHERE state = ?
+          AND decided_by LIKE 'auto_promoter:%'
+          AND decided_at >= ?
+        """,
+        (csi_demo_triage.STATE_APPROVED, start),
+    ).fetchone()
+    return int(row["n"] if row is not None else 0)
+
+
+@dataclass
+class PromoterResult:
+    started_at: str
+    finished_at: str = ""
+    candidates_eligible: int = 0
+    daily_cap: int = 0
+    promoted_today_before_run: int = 0
+    promoted_this_run: int = 0
+    promoted_post_ids: list[str] = field(default_factory=list)
+    skipped_below_score: int = 0
+    skipped_cap_reached: int = 0
+    skipped_already_decided: int = 0
+    dry_run: bool = False
+    error: str | None = None
+
+
+def promote_top_candidates(
+    *,
+    conn: sqlite3.Connection | None = None,
+    task_hub_conn: sqlite3.Connection | None = None,
+    artifacts_root: Any = None,
+    min_score: float | None = None,
+    daily_cap: int | None = None,
+    dry_run: bool | None = None,
+) -> PromoterResult:
+    """Promote pending candidates whose ranking_score >= min_score, capped per day.
+
+    Iteration order: highest score first so the most confidently-good
+    candidates land before the cap binds.
+    """
+    started_at = datetime.now(timezone.utc).isoformat()
+    if min_score is None:
+        min_score = _env_float("UA_INTEL_AUTO_PROMOTE_MIN_SCORE", _DEFAULT_MIN_SCORE)
+    if daily_cap is None:
+        daily_cap = _env_int("UA_INTEL_AUTO_PROMOTE_DAILY_CAP", _DEFAULT_DAILY_CAP)
+    if dry_run is None:
+        dry_run = _env_enabled("UA_INTEL_AUTO_PROMOTE_DRY_RUN", default="0")
+
+    result = PromoterResult(
+        started_at=started_at,
+        daily_cap=int(daily_cap),
+        dry_run=bool(dry_run),
+    )
+
+    own_conn = conn is None
+    if conn is None:
+        conn = csi_demo_triage.open_db(artifacts_root)
+    else:
+        csi_demo_triage.ensure_schema(conn)
+
+    try:
+        already = _count_auto_promotions_today(conn)
+        result.promoted_today_before_run = already
+        if already >= daily_cap and not dry_run:
+            logger.info(
+                "intel_auto_promoter: daily cap already met (%d/%d) — nothing to do",
+                already, daily_cap,
+            )
+            result.finished_at = datetime.now(timezone.utc).isoformat()
+            return result
+
+        rows = conn.execute(
+            """
+            SELECT *
+            FROM demo_triage_candidates
+            WHERE state = ?
+              AND ranking_score IS NOT NULL
+            ORDER BY ranking_score DESC, first_seen_at ASC
+            """,
+            (csi_demo_triage.STATE_PENDING,),
+        ).fetchall()
+        eligible = [r for r in rows if (r["ranking_score"] or 0) >= min_score]
+        result.candidates_eligible = len(eligible)
+        result.skipped_below_score = len(rows) - len(eligible)
+
+        run_tag = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        promoted_remaining = max(daily_cap - already, 0)
+
+        for row in eligible:
+            if promoted_remaining <= 0:
+                result.skipped_cap_reached += 1
+                continue
+
+            post_id = row["post_id"]
+            score = float(row["ranking_score"])
+            decided_by = f"auto_promoter:score={score:.1f}:run={run_tag}"
+
+            if dry_run:
+                logger.info(
+                    "intel_auto_promoter[dry-run]: would promote post_id=%s score=%.1f",
+                    post_id, score,
+                )
+                result.promoted_this_run += 1
+                result.promoted_post_ids.append(str(post_id))
+                promoted_remaining -= 1
+                continue
+
+            try:
+                approve = csi_demo_triage.approve_candidate(
+                    post_id=str(post_id),
+                    decided_by=decided_by,
+                    conn=conn,
+                    task_hub_conn=task_hub_conn,
+                )
+            except Exception:
+                logger.exception(
+                    "intel_auto_promoter: approve_candidate raised for post_id=%s",
+                    post_id,
+                )
+                continue
+
+            if not approve.get("ok"):
+                reason = str(approve.get("reason") or "")
+                if reason.startswith("already_"):
+                    result.skipped_already_decided += 1
+                else:
+                    logger.warning(
+                        "intel_auto_promoter: approve refused for post_id=%s reason=%s",
+                        post_id, reason,
+                    )
+                continue
+
+            result.promoted_this_run += 1
+            result.promoted_post_ids.append(str(post_id))
+            promoted_remaining -= 1
+            logger.info(
+                "intel_auto_promoter: promoted post_id=%s score=%.1f task_id=%s",
+                post_id, score, approve.get("task_id"),
+            )
+
+        result.finished_at = datetime.now(timezone.utc).isoformat()
+        return result
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("intel_auto_promoter: top-level failure")
+        result.error = f"{type(exc).__name__}: {exc}"
+        result.finished_at = datetime.now(timezone.utc).isoformat()
+        return result
+    finally:
+        if own_conn:
+            try:
+                conn.close()
+            except Exception:
+                pass

--- a/tests/unit/test_intel_auto_promoter.py
+++ b/tests/unit/test_intel_auto_promoter.py
@@ -1,0 +1,214 @@
+"""Tests for the intel auto-promoter.
+
+Pins the contract that:
+  - candidates below the score floor are skipped (not approved)
+  - the daily cap binds (highest-score wins)
+  - the `decided_by` stamp carries score + run-id for audit
+  - the daily-cap counter ignores manual-approval decisions
+  - dry-run reports but writes nothing
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sqlite3
+from typing import Any
+
+import pytest
+
+from universal_agent import task_hub
+from universal_agent.services import (
+    csi_demo_triage as triage,
+    intel_auto_promoter as promoter,
+)
+
+
+def _open_triage(tmp_path: Path) -> sqlite3.Connection:
+    return triage.open_db(artifacts_root=tmp_path)
+
+
+def _open_task_hub(tmp_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(tmp_path / "task_hub.db"))
+    conn.row_factory = sqlite3.Row
+    task_hub.ensure_schema(conn)
+    return conn
+
+
+def _write_packet(tmp_path: Path, actions: list[dict[str, Any]]) -> Path:
+    packet_dir = tmp_path / "packets" / "2026-05-22" / "auto_promoter__test"
+    packet_dir.mkdir(parents=True, exist_ok=True)
+    (packet_dir / "manifest.json").write_text(
+        json.dumps({"handle": "ClaudeDevs", "lane": "claude_code_intel"}),
+        encoding="utf-8",
+    )
+    (packet_dir / "actions_refined.json").write_text(json.dumps(actions), encoding="utf-8")
+    return packet_dir
+
+
+def _action(post_id: str, *, tier: int = 3) -> dict[str, Any]:
+    return {
+        "post_id": post_id,
+        "tier": tier,
+        "action_type": "demo_task",
+        "url": f"https://x.com/ClaudeDevs/status/{post_id}",
+        "text": f"Test post {post_id}",
+        "links": [],
+    }
+
+
+def _seed_with_scores(tmp_path: Path, scores: dict[str, float]) -> tuple[sqlite3.Connection, sqlite3.Connection]:
+    """Insert candidates from `scores` map and stamp their ranking_score."""
+    actions = [_action(pid) for pid in scores]
+    packet = _write_packet(tmp_path, actions)
+    triage.sync_candidates_from_packet(packet_dir=packet, artifacts_root=tmp_path)
+
+    triage_conn = _open_triage(tmp_path)
+    th_conn = _open_task_hub(tmp_path)
+    now = datetime.now(timezone.utc).isoformat()
+    for post_id, score in scores.items():
+        triage_conn.execute(
+            """
+            UPDATE demo_triage_candidates
+               SET ranking_score = ?,
+                   ranking_evaluated_at = ?,
+                   ranking_run_id = 'test'
+             WHERE post_id = ?
+            """,
+            (float(score), now, post_id),
+        )
+    triage_conn.commit()
+    return triage_conn, th_conn
+
+
+def test_promoter_promotes_above_threshold_in_score_order(tmp_path: Path):
+    triage_conn, th_conn = _seed_with_scores(
+        tmp_path,
+        {"high": 8.5, "highest": 9.2, "below": 6.0},
+    )
+
+    result = promoter.promote_top_candidates(
+        conn=triage_conn,
+        task_hub_conn=th_conn,
+        min_score=7.5,
+        daily_cap=5,
+    )
+
+    assert result.error is None
+    assert result.candidates_eligible == 2  # high + highest
+    assert result.skipped_below_score == 1  # below
+    assert result.promoted_this_run == 2
+    assert result.promoted_post_ids == ["highest", "high"]  # score-desc order
+
+    rows = th_conn.execute(
+        "SELECT task_id, source_kind FROM task_hub_items ORDER BY task_id"
+    ).fetchall()
+    assert len(rows) == 2
+    assert all(r["source_kind"] == "cody_scaffold_request" for r in rows)
+
+    # Audit trail: decided_by stamps include score + run-id.
+    decided_rows = triage_conn.execute(
+        "SELECT post_id, decided_by FROM demo_triage_candidates "
+        "WHERE state = 'approved' ORDER BY post_id"
+    ).fetchall()
+    decided_map = {r["post_id"]: r["decided_by"] for r in decided_rows}
+    assert decided_map["highest"].startswith("auto_promoter:score=9.2:run=")
+    assert decided_map["high"].startswith("auto_promoter:score=8.5:run=")
+
+
+def test_promoter_respects_daily_cap(tmp_path: Path):
+    triage_conn, th_conn = _seed_with_scores(
+        tmp_path,
+        {"a": 9.0, "b": 8.5, "c": 8.0},
+    )
+
+    result = promoter.promote_top_candidates(
+        conn=triage_conn,
+        task_hub_conn=th_conn,
+        min_score=7.0,
+        daily_cap=2,
+    )
+
+    assert result.promoted_this_run == 2
+    assert result.skipped_cap_reached == 1
+    # The two highest scores landed, the third was capped out.
+    assert sorted(result.promoted_post_ids) == ["a", "b"]
+
+
+def test_promoter_short_circuits_when_cap_already_met(tmp_path: Path):
+    triage_conn, th_conn = _seed_with_scores(
+        tmp_path,
+        {"x": 9.5, "y": 9.0},
+    )
+    # Pre-promote one row so the cap=1 limit binds immediately.
+    triage.approve_candidate(
+        post_id="x",
+        decided_by="auto_promoter:score=9.5:run=2026-05-22",
+        conn=triage_conn,
+        task_hub_conn=th_conn,
+    )
+
+    result = promoter.promote_top_candidates(
+        conn=triage_conn,
+        task_hub_conn=th_conn,
+        min_score=7.0,
+        daily_cap=1,
+    )
+
+    assert result.promoted_today_before_run == 1
+    assert result.promoted_this_run == 0
+
+
+def test_promoter_dry_run_writes_nothing(tmp_path: Path):
+    triage_conn, th_conn = _seed_with_scores(
+        tmp_path,
+        {"alpha": 9.0, "beta": 8.0},
+    )
+
+    result = promoter.promote_top_candidates(
+        conn=triage_conn,
+        task_hub_conn=th_conn,
+        min_score=7.0,
+        daily_cap=5,
+        dry_run=True,
+    )
+
+    assert result.promoted_this_run == 2  # counter reflects intent
+    assert result.dry_run is True
+    # No mutations to triage or task_hub.
+    pending = triage_conn.execute(
+        "SELECT COUNT(*) AS n FROM demo_triage_candidates WHERE state = 'pending'"
+    ).fetchone()
+    assert int(pending["n"]) == 2
+    th_count = th_conn.execute(
+        "SELECT COUNT(*) AS n FROM task_hub_items"
+    ).fetchone()
+    assert int(th_count["n"]) == 0
+
+
+def test_promoter_daily_cap_counter_ignores_manual_decisions(tmp_path: Path):
+    """Manual operator approvals must NOT eat into the auto-promoter cap."""
+    triage_conn, th_conn = _seed_with_scores(
+        tmp_path,
+        {"manual_one": 9.0, "auto_one": 8.5},
+    )
+    # Manual approval (decided_by != auto_promoter:*) should be ignored
+    # by the daily-cap counter.
+    triage.approve_candidate(
+        post_id="manual_one",
+        decided_by="kevin",
+        conn=triage_conn,
+        task_hub_conn=th_conn,
+    )
+
+    result = promoter.promote_top_candidates(
+        conn=triage_conn,
+        task_hub_conn=th_conn,
+        min_score=7.0,
+        daily_cap=1,
+    )
+
+    # promoted_today_before_run counts only auto_promoter rows → 0.
+    assert result.promoted_today_before_run == 0
+    assert result.promoted_this_run == 1
+    assert result.promoted_post_ids == ["auto_one"]


### PR DESCRIPTION
## Summary
- New `intel_auto_promoter` cron fires 30 minutes after the existing CSI ranker and auto-approves the top-scored pending tier-3 candidates via the canonical `approve_candidate` path
- Capped per UTC day (default 2) and gated by score threshold (default 7.5/10) so it can't go runaway
- Audit trail stamps `decided_by=auto_promoter:score=X.X:run=YYYY-MM-DD` on every promotion; manual operator approvals don't eat into the auto cap

## Why
Operator observation 2026-05-22: 7-9 high-confidence ClaudeDevs YouTube intel signals had accumulated this week. The ranker scores them, but the pipeline stalls at the human "Approve" click. Cody's natural 1-concurrent VP cap + Task Hub's persistent queue mean that even if all candidates pass the cap, the system can't overload itself — Cody will eventually get to each one.

## Gating env vars
| Var | Default | Purpose |
|---|---|---|
| `UA_INTEL_AUTO_PROMOTE_ENABLED` | `1` | Runtime kill switch (no redeploy needed to pause) |
| `UA_INTEL_AUTO_PROMOTE_MIN_SCORE` | `7.5` | Only promote candidates this confidently good |
| `UA_INTEL_AUTO_PROMOTE_DAILY_CAP` | `2` | Max auto-promotions per UTC day |
| `UA_INTEL_AUTO_PROMOTE_DRY_RUN` | `0` | Report what would promote without writing |
| `UA_INTEL_AUTO_PROMOTE_CRON_ENABLED` | `1` | Cron-registration kill switch |

## Test plan
- [x] `pytest tests/unit/test_intel_auto_promoter.py` — 5 new tests pass (score floor, cap binds, short-circuit when cap met, dry-run isolation, manual-approval isolation from auto-cap)
- [x] `pytest tests/unit/test_cron_dormancy_defaults.py` — registration falls inside 6 AM–10 PM Houston active window
- [x] `ruff check` + `py_compile` clean on touched files
- [ ] Post-deploy smoke: confirm one auto-promotion lands in next active-hours tick, then watch `decided_by LIKE 'auto_promoter:%'` in `demo_triage_candidates` for the first 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)