### PR TITLE
fix(proactive): digest cron reads activity_state.db; briefing top 5 always

### DIFF
--- a/src/universal_agent/scripts/briefings_agent.py
+++ b/src/universal_agent/scripts/briefings_agent.py
@@ -170,16 +170,24 @@ def _build_atlas_briefs_block(briefs: list[dict[str, str]]) -> str:
 
 def _get_atlas_briefs_block_or_empty(
     *,
-    max_age_hours: int = 36,
+    max_age_hours: int = 168,
     limit: int = 5,
 ) -> str:
     """Return the Atlas insight-briefs block, or "" on kill switch / nothing surfaceable.
 
-    Surfaces ATLAS insight briefs that are:
+    Surfaces the top N=`limit` ATLAS insight briefs that are:
       - artifact_type='insight_brief_task'
       - status='candidate' (not yet acted on by Simone/operator)
       - delivery_state='not_surfaced' (not already mentioned in a prior briefing)
-      - created within the last `max_age_hours` so stale briefs don't show up forever
+      - created within the last `max_age_hours` so a long outage doesn't dump
+        ancient briefs into the briefing once the helper comes back online
+
+    Window defaults to 7 days (168h). The convergence cron generates 100-200
+    briefs/day at steady state and we only surface the freshest `limit=5`,
+    so the daily briefing always carries the top 5 *newest* briefs regardless
+    of when the previous briefing actually ran. A shorter window (e.g. 36h)
+    would leave the briefing empty whenever the convergence cron stalled
+    overnight or the briefing crashed — undesirable for a daily morning surface.
 
     Side effect: after rendering, each surfaced brief is transitioned to
     `delivery_state='digest_queued'` + `surfaced_at=now()` so the next

--- a/src/universal_agent/scripts/proactive_digest_agent.py
+++ b/src/universal_agent/scripts/proactive_digest_agent.py
@@ -24,17 +24,29 @@ logger = logging.getLogger(__name__)
 
 async def _run_digest() -> dict:
     """Compose and send the daily proactive artifact digest email."""
+    from universal_agent.durable.db import connect_runtime_db, get_activity_db_path
     from universal_agent.services.intelligence_reporter import IntelligenceReporter
 
-    # Resolve the DB path (same pattern as other cron agents)
+    # Resolve the DB path. `proactive_artifacts` (insight_brief_task, codie PRs,
+    # convergence briefs, etc.) lives in the **activity_state.db**, not the
+    # runtime_state.db that the script previously defaulted to. The original
+    # ``workspaces/runtime_state.db`` fallback meant the digest was reading
+    # an empty/wrong DB for ~weeks — see audit 2026-05-22 (638 briefs piled
+    # up in activity_state.db with zero email deliveries).
+    #
+    # Resolution order (highest precedence first):
+    #   1. UA_DB_PATH env override (operator escape hatch)
+    #   2. canonical get_activity_db_path() — same path the convergence cron
+    #      writes to via connect_runtime_db(get_activity_db_path()).
     db_path = os.getenv("UA_DB_PATH", "")
     if not db_path:
-        workspace_root = os.getenv("UA_WORKSPACE_ROOT", "/opt/universal_agent")
-        db_path = str(Path(workspace_root) / "workspaces" / "runtime_state.db")
+        db_path = get_activity_db_path()
 
     recipient = os.getenv("UA_BRIEFING_RECIPIENT", "kevinjdragan@gmail.com")
 
-    conn = sqlite3.connect(db_path)
+    # Use the same connection helper the producers use so WAL +
+    # busy-timeout pragmas match across writer + reader.
+    conn = connect_runtime_db(db_path)
     conn.row_factory = sqlite3.Row
 
     # Initialize mail service


### PR DESCRIPTION
## Summary
Two follow-up fixes to the ATLAS pipeline audit (see #424). Convergence has been producing 100-200 insight briefs/day for weeks; every downstream consumer was reading the wrong DB or windowed too tight to ever fire.

1. **`proactive_digest_agent`** — was reading `workspaces/runtime_state.db` (wrong dir + wrong DB). Now uses `get_activity_db_path()` + `connect_runtime_db()`. Smoke-tested on prod: `compose_daily_digest(limit=10)` produces non-empty real content. The 08:35 Houston daily digest email will resume.
2. **`_get_atlas_briefs_block_or_empty`** — `max_age_hours` 36 → 168 (7 days). Morning briefing now surfaces the **freshest 5** briefs whenever any landed in the last week, instead of going dark when the convergence cron stalls overnight.

## Atlas-claim path (NOT fixed by this PR — operator step needed)
During the audit I also discovered:
- `task_hub_assignments` has **zero rows ever** for `insight_detection` (or any source_kind). Heartbeat claims aren't persisting to the ledger — needs deeper investigation.
- `atlas_direct_dispatch` cron is registered but gated by `UA_ATLAS_DIRECT_DISPATCH_ENABLED`, which is set to `0` in Infisical production.

**Operator step** to enable Atlas-direct-dispatch:
```
ssh ua@uaonvps
TOK=$(infisical login --method=universal-auth --client-id=\$INFISICAL_CLIENT_ID --client-secret=\$INFISICAL_CLIENT_SECRET --plain --silent)
INFISICAL_TOKEN=\"\$TOK\" infisical secrets set UA_ATLAS_DIRECT_DISPATCH_ENABLED=1 --projectId=\$INFISICAL_PROJECT_ID --env=production --silent
sudo systemctl restart universal-agent
```
CLAUDE.md forbids ad-hoc secret mutation by automation so I left this as a manual step.

## Test plan
- [x] Smoke on prod (read-only): `compose_daily_digest(limit=10)` against activity_state.db returns a 10-item payload with real artifact content
- [x] `pytest tests/unit/test_briefings_agent.py` — 29 passed
- [x] `ruff check` clean
- [ ] Post-deploy: confirm tomorrow's 08:35 CDT digest email lands in inbox; confirm tomorrow's 06:30 CDT briefing carries 5 ATLAS briefs in its block

🤖 Generated with [Claude Code](https://claude.com/claude-code)