### PR TITLE
feat(digest): move TOC to end of exec summary, show channel + title

### DIFF
--- a/src/universal_agent/scripts/youtube_daily_digest.py
+++ b/src/universal_agent/scripts/youtube_daily_digest.py
@@ -1351,7 +1351,12 @@ _DIGEST_HTML_HEAD_CSS = """
     padding: 0;
   }
   .digest-toc ol { margin: 4px 0 0; padding-left: 22px; }
-  .digest-toc li { margin: 2px 0; font-size: 14px; }
+  .digest-toc li { margin: 4px 0; font-size: 14px; line-height: 1.45; }
+  .digest-toc a { text-decoration: none; color: inherit; }
+  .digest-toc a:hover .toc-title { text-decoration: underline; color: #0969da; }
+  .toc-channel { color: #1f2328; font-weight: 600; }
+  .toc-sep { color: #8c959f; }
+  .toc-title { color: #0969da; }
 """
 
 
@@ -1385,26 +1390,86 @@ def _per_video_range(full_content: str) -> tuple[int, int] | None:
     return start, end
 
 
-def _build_toc_html(full_content: str) -> str:
-    """Build a small per-video table of contents from the markdown source.
+_DURATION_PATTERN = re.compile(r"^\d+:\d+(:\d+)?$")
+_DATE_PATTERN = re.compile(r"^[A-Za-z]+\s+\d+,\s+\d{4}$")
 
-    Returns "" if there are fewer than two video sections.
+
+def _extract_channel_from_meta(meta_line: str) -> str:
+    """Pull the channel name out of a per-video `<small>` metadata strip.
+
+    The strip is built by `_build_per_video_header` as
+    "Channel · 12:34 · May 19, 2026 · [watch ↗](...)" — channel is always
+    first when present. If channel was missing the first segment will be
+    duration / date / watch-link instead, so we shape-check before returning.
+    """
+    if not meta_line:
+        return ""
+    first = meta_line.split(" · ", 1)[0].strip()
+    if not first:
+        return ""
+    if _DURATION_PATTERN.match(first):
+        return ""
+    if _DATE_PATTERN.match(first):
+        return ""
+    if first.startswith("[") or "watch" in first.lower():
+        return ""
+    return first
+
+
+def _extract_video_entries(per_video_section: str) -> list[tuple[str, str]]:
+    """Walk the per-video markdown section, return ``[(title, channel), ...]``
+    in document order. Channel is empty string when the metadata strip was
+    missing or malformed for that video."""
+    entries: list[tuple[str, str]] = []
+    # Split on H2 boundaries — blocks[0] is preamble; everything after each
+    # boundary starts with the H2's text on its own line.
+    blocks = re.split(r"(?m)^##\s+", per_video_section)
+    for block in blocks[1:]:
+        lines = block.split("\n", 1)
+        title = lines[0].strip()
+        if not title or title.lower().startswith("per-video retellings"):
+            continue
+        rest = lines[1] if len(lines) > 1 else ""
+        channel = ""
+        small_match = re.search(r"<small>(.+?)</small>", rest, flags=re.DOTALL)
+        if small_match:
+            channel = _extract_channel_from_meta(small_match.group(1))
+        entries.append((title, channel))
+    return entries
+
+
+def _build_toc_html(full_content: str) -> str:
+    """Build a per-video table of contents from the markdown source.
+
+    Each entry is "Channel — Title" linked to that video's anchor. The TOC is
+    placed at the END of the executive summary (right before "Per-Video
+    Retellings") so the operator reads themes first, then drills into specific
+    videos via click. Returns "" when fewer than two video sections exist.
     """
     bounds = _per_video_range(full_content)
     if not bounds:
         return ""
     per_video_section = full_content[bounds[0]:bounds[1]]
-    titles = _VIDEO_HEADING_PATTERN.findall(per_video_section)
-    if len(titles) < 2:
+    entries = _extract_video_entries(per_video_section)
+    if len(entries) < 2:
         return ""
     items: list[str] = []
-    for idx, raw_title in enumerate(titles, start=1):
-        title = html_module.escape(raw_title.strip())
+    for idx, (raw_title, channel) in enumerate(entries, start=1):
+        title_esc = html_module.escape(raw_title.strip())
         anchor = _slugify_anchor(raw_title, idx)
-        items.append(f'<li><a href="#{anchor}">{title}</a></li>')
+        if channel:
+            channel_esc = html_module.escape(channel.strip())
+            label = (
+                f'<span class="toc-channel">{channel_esc}</span>'
+                f'<span class="toc-sep"> — </span>'
+                f'<span class="toc-title">{title_esc}</span>'
+            )
+        else:
+            label = f'<span class="toc-title">{title_esc}</span>'
+        items.append(f'<li><a href="#{anchor}">{label}</a></li>')
     return (
         '<div class="digest-toc">'
-        '<h2>Today\'s videos</h2>'
+        '<h2>Jump to a video</h2>'
         f'<ol>{"".join(items)}</ol>'
         '</div>'
     )
@@ -1462,15 +1527,31 @@ def _render_full_digest_html(
     fragment = _inject_video_anchors(fragment)
     toc_html = _build_toc_html(full_content)
     title = f"Daily YouTube Digest — {day_name.title()}, {date_str}"
-    # Insert the TOC right after the first <h1> so it sits between the title
-    # and the meta-synthesis section.
+    # Insert the TOC immediately BEFORE the per-video section heading — i.e.
+    # at the end of the executive summary. Operator reads themes first, then
+    # uses the TOC to jump into specific videos. Falls back to "after </h1>"
+    # if the per-video marker is missing (defensive — shouldn't happen with
+    # the digest's deterministic assembly).
     if toc_html:
-        fragment = re.sub(
-            r"(</h1>)",
-            lambda m: m.group(1) + "\n" + toc_html,
+        per_video_h2 = re.search(
+            r"<h2[^>]*>\s*Per[- ]Video Retellings\s*</h2>",
             fragment,
-            count=1,
+            flags=re.IGNORECASE,
         )
+        if per_video_h2:
+            fragment = (
+                fragment[: per_video_h2.start()]
+                + toc_html
+                + "\n"
+                + fragment[per_video_h2.start():]
+            )
+        else:
+            fragment = re.sub(
+                r"(</h1>)",
+                lambda m: m.group(1) + "\n" + toc_html,
+                fragment,
+                count=1,
+            )
     return (
         "<!DOCTYPE html>\n"
         '<html lang="en">\n'

--- a/tests/unit/test_youtube_digest_toc.py
+++ b/tests/unit/test_youtube_digest_toc.py
@@ -123,7 +123,7 @@ def test_toc_lives_at_end_of_executive_summary():
         _video_block("Vid Two", "AICodeKing", 1500, "20260520", "def"),
     ]
     md = _digest_md(blocks)
-    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")  # date-pinned-ok: display-only fixture
 
     meta_idx = html.index("Meta-Synthesis")
     toc_idx = html.index('<div class="digest-toc"')
@@ -138,7 +138,7 @@ def test_toc_contains_channel_and_title():
         _video_block("9 Layers Pro Playbook", "AICodeKing", 1500, "20260520", "def"),
     ]
     md = _digest_md(blocks)
-    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")  # date-pinned-ok: display-only fixture
 
     # Extract the TOC slice
     toc_start = html.index('<div class="digest-toc"')
@@ -161,7 +161,7 @@ def test_toc_gracefully_omits_channel_when_missing():
         _video_block("Channel Missing", None, 600, "20260520", "def"),
     ]
     md = _digest_md(blocks)
-    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")  # date-pinned-ok: display-only fixture
 
     toc_start = html.index('<div class="digest-toc"')
     toc_end = html.index("Per-Video Retellings</h2>")
@@ -180,7 +180,7 @@ def test_toc_anchor_ids_align_with_h2_ids():
         _video_block("Second Vid", "Cole Medin", 1500, "20260520", "def"),
     ]
     md = _digest_md(blocks)
-    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")  # date-pinned-ok: display-only fixture
 
     # Pull the TOC and per-video sections
     toc_start = html.index('<div class="digest-toc"')
@@ -199,7 +199,7 @@ def test_toc_renders_with_single_video_returns_empty_string():
     """Under 2 videos we don't bother with the TOC."""
     blocks = [_video_block("Only One", "Cole Medin", 754, "20260519", "abc")]
     md = _digest_md(blocks)
-    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")  # date-pinned-ok: display-only fixture
     # The CSS block always contains `.digest-toc` selectors; check for the
     # body-side div instead.
     assert '<div class="digest-toc"' not in html

--- a/tests/unit/test_youtube_digest_toc.py
+++ b/tests/unit/test_youtube_digest_toc.py
@@ -1,0 +1,205 @@
+"""Tests for the channel-enriched TOC + end-of-executive-summary positioning."""
+from __future__ import annotations
+
+from universal_agent.scripts.youtube_daily_digest import (
+    VideoTranscriptPayload,
+    _build_per_video_header,
+    _extract_channel_from_meta,
+    _extract_video_entries,
+    _render_full_digest_html,
+)
+
+
+def _digest_md(blocks: list[str]) -> str:
+    reduce_out = (
+        "## Meta-Synthesis: Daily Digest\n\n"
+        "### Cross-Video Themes\n\nThemes.\n\n"
+        "### Learning Insights\n\nInsights.\n"
+    )
+    dispatch = (
+        "## Tutorial Pipeline Dispatch\n\n"
+        "- Dispatched 0 videos (synthetic test).\n"
+    )
+    per_video = "\n\n---\n\n".join(blocks)
+    return (
+        "# Daily YouTube Digest: Friday, 2026-05-22\n\n"
+        f"{reduce_out}\n\n---\n\n"
+        f"## Per-Video Retellings\n\n{per_video}\n\n"
+        f"---\n\n{dispatch}\n"
+    )
+
+
+def _video_block(title: str, channel: str | None, duration_s: int, date: str, vid: str) -> str:
+    meta: dict = {"duration": duration_s, "upload_date": date}
+    if channel is not None:
+        meta["channel"] = channel
+    payload = VideoTranscriptPayload(
+        video_id=vid, title=title, transcript_text="x", metadata=meta,
+    )
+    header = _build_per_video_header(payload)
+    return (
+        f"{header}\n"
+        "### Retelling\n\nBody.\n\n"
+        "### Thesis\nThesis.\n"
+    )
+
+
+# --- _extract_channel_from_meta -------------------------------------------
+
+
+def test_channel_extractor_normal_case():
+    line = "Cole Medin · 12:34 · May 19, 2026 · [watch ↗](https://youtu.be/abc)"
+    assert _extract_channel_from_meta(line) == "Cole Medin"
+
+
+def test_channel_extractor_returns_empty_when_first_is_duration():
+    assert _extract_channel_from_meta("12:34 · May 19, 2026") == ""
+    assert _extract_channel_from_meta("1:23:45 · May 19, 2026") == ""
+
+
+def test_channel_extractor_returns_empty_when_first_is_date():
+    assert _extract_channel_from_meta("May 19, 2026 · [watch ↗](...)") == ""
+
+
+def test_channel_extractor_returns_empty_when_first_is_watch_link():
+    assert _extract_channel_from_meta("[watch ↗](https://youtu.be/abc)") == ""
+
+
+def test_channel_extractor_handles_empty():
+    assert _extract_channel_from_meta("") == ""
+    assert _extract_channel_from_meta("   ") == ""
+
+
+def test_channel_extractor_preserves_channel_with_unicode_or_pipes():
+    # Real channel name from the seed list: "Pyotr Kurzin | Geopolitics"
+    line = "Pyotr Kurzin | Geopolitics · 12:34 · May 19, 2026"
+    assert _extract_channel_from_meta(line) == "Pyotr Kurzin | Geopolitics"
+
+
+# --- _extract_video_entries ----------------------------------------------
+
+
+def test_video_entries_walks_per_video_section():
+    md = (
+        "## First Title\n\n"
+        "<small>Channel A · 12:34 · May 19, 2026 · [watch ↗](...)</small>\n\n"
+        "### Retelling\nBody.\n\n"
+        "---\n\n"
+        "## Second Title\n\n"
+        "<small>Channel B · 5:00 · May 20, 2026 · [watch ↗](...)</small>\n\n"
+        "### Retelling\nBody.\n"
+    )
+    entries = _extract_video_entries(md)
+    assert entries == [("First Title", "Channel A"), ("Second Title", "Channel B")]
+
+
+def test_video_entries_handles_missing_meta_strip():
+    md = (
+        "## Only Title No Meta\n\n"
+        "### Retelling\nBody.\n"
+    )
+    entries = _extract_video_entries(md)
+    assert entries == [("Only Title No Meta", "")]
+
+
+def test_video_entries_skips_per_video_retellings_header():
+    md = (
+        "## Per-Video Retellings\n\n"
+        "## Actual Video Title\n\n"
+        "<small>Channel A · 12:34 · May 19, 2026 · [watch ↗](...)</small>\n\n"
+        "### Retelling\nBody.\n"
+    )
+    entries = _extract_video_entries(md)
+    assert entries == [("Actual Video Title", "Channel A")]
+
+
+# --- End-to-end TOC positioning + rendering -------------------------------
+
+
+def test_toc_lives_at_end_of_executive_summary():
+    """TOC must render AFTER Meta-Synthesis and BEFORE Per-Video Retellings."""
+    blocks = [
+        _video_block("Vid One", "Cole Medin", 754, "20260519", "abc"),
+        _video_block("Vid Two", "AICodeKing", 1500, "20260520", "def"),
+    ]
+    md = _digest_md(blocks)
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+
+    meta_idx = html.index("Meta-Synthesis")
+    toc_idx = html.index('<div class="digest-toc"')
+    per_video_idx = html.index("Per-Video Retellings</h2>")
+
+    assert meta_idx < toc_idx < per_video_idx
+
+
+def test_toc_contains_channel_and_title():
+    blocks = [
+        _video_block("Building Agents With Mastra", "Cole Medin", 754, "20260519", "abc"),
+        _video_block("9 Layers Pro Playbook", "AICodeKing", 1500, "20260520", "def"),
+    ]
+    md = _digest_md(blocks)
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+
+    # Extract the TOC slice
+    toc_start = html.index('<div class="digest-toc"')
+    toc_end = html.index("Per-Video Retellings</h2>")
+    toc = html[toc_start:toc_end]
+
+    assert "Cole Medin" in toc
+    assert "Building Agents With Mastra" in toc
+    assert "AICodeKing" in toc
+    assert "9 Layers Pro Playbook" in toc
+    # CSS classes for the new spans
+    assert "toc-channel" in toc
+    assert "toc-title" in toc
+
+
+def test_toc_gracefully_omits_channel_when_missing():
+    """A video missing channel metadata still appears in TOC, just title-only."""
+    blocks = [
+        _video_block("Channel Known", "Cole Medin", 754, "20260519", "abc"),
+        _video_block("Channel Missing", None, 600, "20260520", "def"),
+    ]
+    md = _digest_md(blocks)
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+
+    toc_start = html.index('<div class="digest-toc"')
+    toc_end = html.index("Per-Video Retellings</h2>")
+    toc = html[toc_start:toc_end]
+
+    # Both video titles present
+    assert "Channel Known" in toc
+    assert "Channel Missing" in toc
+    # Exactly one channel span (the one we have data for)
+    assert toc.count('class="toc-channel"') == 1
+
+
+def test_toc_anchor_ids_align_with_h2_ids():
+    blocks = [
+        _video_block("First Vid", "AICodeKing", 754, "20260519", "abc"),
+        _video_block("Second Vid", "Cole Medin", 1500, "20260520", "def"),
+    ]
+    md = _digest_md(blocks)
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+
+    # Pull the TOC and per-video sections
+    toc_start = html.index('<div class="digest-toc"')
+    toc_end = html.index("Per-Video Retellings</h2>")
+    toc = html[toc_start:toc_end]
+    rest = html[toc_end:]
+
+    # Confirm v1 and v2 anchors are referenced in TOC and defined later
+    assert 'href="#v1-first-vid"' in toc
+    assert 'href="#v2-second-vid"' in toc
+    assert 'id="v1-first-vid"' in rest
+    assert 'id="v2-second-vid"' in rest
+
+
+def test_toc_renders_with_single_video_returns_empty_string():
+    """Under 2 videos we don't bother with the TOC."""
+    blocks = [_video_block("Only One", "Cole Medin", 754, "20260519", "abc")]
+    md = _digest_md(blocks)
+    html = _render_full_digest_html(md, day_name="Friday", date_str="2026-05-22")
+    # The CSS block always contains `.digest-toc` selectors; check for the
+    # body-side div instead.
+    assert '<div class="digest-toc"' not in html


### PR DESCRIPTION
## Summary

You asked for an index at the end of the executive summary showing channel + title with click-through to each per-video section. Doing exactly that.

## What changed

**Position.** Last PR (#428) put the TOC right after the H1 at the top of the document. Moving it to sit immediately before \"Per-Video Retellings\" — i.e. at the end of the executive summary — so the reading flow is: themes → insights → \"jump to a specific video\" → per-video retellings.

**Content.** Each entry now renders as **\"Channel — Title\"** instead of just title. Channel is bold-dark, title is link-blue. Missing-channel entries gracefully fall back to title-only (rare; only happens when YouTube Data API metadata didn't populate).

Rendered HTML:

```html
<div class=\"digest-toc\">
  <h2>Jump to a video</h2>
  <ol>
    <li>
      <a href=\"#v1-your-ai-assistant-doesn-t-need-a-bigger-model-it\">
        <span class=\"toc-channel\">Cole Medin</span>
        <span class=\"toc-sep\"> — </span>
        <span class=\"toc-title\">Your AI Assistant Doesn't Need a Bigger Model</span>
      </a>
    </li>
    ...
  </ol>
</div>
```

## Implementation

| File | Change |
|---|---|
| \`scripts/youtube_daily_digest.py\` | New \`_extract_channel_from_meta\` (parses channel from per-video \`<small>\` strip with shape-checks vs duration/date/link). New \`_extract_video_entries\` (walks H2 boundaries → \`[(title, channel), …]\`). \`_build_toc_html\` uses the new extractor + emits the channel/title span layout. \`_render_full_digest_html\` inserts TOC immediately before \`<h2>Per-Video Retellings</h2>\` (was: after \`</h1>\`). CSS extended with \`.digest-toc a\` link styling + \`.toc-channel\` / \`.toc-sep\` / \`.toc-title\` rules. |
| \`tests/unit/test_youtube_digest_toc.py\` (new, 200 LoC) | 12 unit tests covering channel-extractor shape-checks, entry walking, TOC positioning, channel-present vs channel-missing rendering, anchor-id alignment, and the under-2-videos no-op path. |

## Why this design

* **Channel name first**, then em-dash, then title. Channel is the strongest disambiguator (\"is this Anthropic or some random commentator?\") so it leads. Em-dash is the standard typographic separator for this kind of label pair.
* **No timestamps in TOC.** The per-video card already shows duration + date. Adding them to the TOC would make each line wrap on long titles and increase visual clutter. The TOC's job is fast scanning.
* **Anchor IDs unchanged** from the last PR (\`v1-slug\`, \`v2-slug\`, …) so existing email clients with cached versions won't break in-flight.
* **Defensive fallback** in \`_render_full_digest_html\`: if the per-video marker is somehow missing, the TOC still gets placed (at the old post-H1 position) instead of being dropped silently.

## Test plan

- [x] 80 digest-related unit tests pass locally (12 new + 68 existing)
- [x] Probe rendered a synthetic 2-video digest; confirmed TOC at meta=2630 → toc=2778 → per_video=3244 (correctly sandwiched)
- [x] Confirmed anchor IDs in TOC \`href\`s match \`id\` attrs on the H2s
- [x] Ruff clean
- [ ] Live SHA check via \`/api/v1/version\` after merge
- [ ] Tomorrow morning's 6 AM digest will exercise this in production against the gold-poller-augmented FRIDAY playlist — eyeball the email to confirm the TOC sits where you wanted it and the channel names are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)