### PR TITLE
fix(logging): add debug context to 12 silently-swallowed except blocks

### DIFF
--- a/src/universal_agent/services/claude_code_intel.py
+++ b/src/universal_agent/services/claude_code_intel.py
@@ -210,6 +210,7 @@ def _first_handle_from_lane(lane_slug: str) -> str:
 
         lane = get_lane(lane_slug)
     except Exception:
+        logger.debug("intel_lanes lookup failed for lane %r", lane_slug, exc_info=True)
         return ""
     handles = list(lane.handles or [])
     return str(handles[0]).strip() if handles else ""
@@ -222,6 +223,7 @@ def _all_handles_from_lane(lane_slug: str) -> list[str]:
 
         lane = get_lane(lane_slug)
     except Exception:
+        logger.debug("intel_lanes lookup failed for lane %r", lane_slug, exc_info=True)
         return []
     return [str(h).strip() for h in (lane.handles or []) if str(h).strip()]
 
@@ -460,7 +462,7 @@ def run_sync(
                 if packet_dir.exists() and not any(packet_dir.iterdir()):
                     shutil.rmtree(packet_dir, ignore_errors=True)
             except Exception:
-                pass
+                logger.debug("packet dir cleanup failed for %s", packet_dir, exc_info=True)
             run.ok = True
             run.user_id = str((user_payload.get("data") or {}).get("id") or "")
             run.auth_mode = auth_mode
@@ -960,6 +962,7 @@ def _vault_slug_for_lane(lane_slug: str) -> str:
 
         lane = get_lane(lane_slug)
     except Exception:
+        logger.debug("intel_lanes lookup failed for lane %r, falling back to %s", lane_slug, KB_SLUG, exc_info=True)
         return KB_SLUG
     return str(getattr(lane, "vault_slug", "") or KB_SLUG)
 
@@ -1613,6 +1616,7 @@ def _get_json_with_auth_fallbacks(
         try:
             payload = resp.json()
         except Exception:
+            logger.debug("X API response JSON parse failed (HTTP %d)", resp.status_code, exc_info=True)
             payload = {}
         if resp.status_code < 400:
             out = payload if isinstance(payload, dict) else {}
@@ -1690,6 +1694,7 @@ def _json_response(resp: httpx.Response) -> dict[str, Any]:
     try:
         payload = resp.json()
     except Exception:
+        logger.debug("X API response JSON parse failed (HTTP %d, url=%s)", resp.status_code, resp.url, exc_info=True)
         payload = {}
     if resp.status_code >= 400:
         detail = _x_error_detail(payload if isinstance(payload, dict) else {})
@@ -1721,6 +1726,7 @@ def resolve_state_path(lane_root: Path, handle: str) -> Path:
         try:
             legacy_state = json.loads(legacy.read_text(encoding="utf-8"))
         except Exception:
+            logger.debug("legacy state migration parse failed for %s", legacy, exc_info=True)
             legacy_state = {}
         legacy_handle = str(legacy_state.get("handle") or "").strip().lstrip("@").lower()
         if legacy_handle == safe_handle or not legacy_handle:
@@ -1736,6 +1742,7 @@ def _load_state(path: Path) -> dict[str, Any]:
     try:
         parsed = json.loads(path.read_text(encoding="utf-8"))
     except Exception:
+        logger.debug("state file parse failed for %s, returning empty state", path, exc_info=True)
         return {"seen_post_ids": []}
     return parsed if isinstance(parsed, dict) else {"seen_post_ids": []}
 
@@ -1775,5 +1782,6 @@ def _bounded_int(raw: Any, default: int, *, low: int, high: int) -> int:
     try:
         value = int(raw)
     except Exception:
+        logger.debug("int conversion failed for %r, using default %d", raw, default, exc_info=True)
         value = default
     return max(low, min(value, high))

--- a/src/universal_agent/services/mission_control_intelligence_sweeper.py
+++ b/src/universal_agent/services/mission_control_intelligence_sweeper.py
@@ -477,7 +477,7 @@ class MissionControlSweeper:
                 try:
                     data_conn.close()
                 except Exception:
-                    pass
+                    logger.debug("tier-1 data_conn.close() failed (already closed or broken)", exc_info=True)
 
             sig = evidence_signature(evidence)
             last_signature = sig
@@ -547,7 +547,7 @@ class MissionControlSweeper:
             try:
                 mc_conn.close()
             except Exception:
-                pass
+                logger.debug("tier-1 mc_conn.close() failed (already closed or broken)", exc_info=True)
 
     @staticmethod
     def _write_tier1_meta(
@@ -741,7 +741,7 @@ class MissionControlSweeper:
             try:
                 mc_conn.close()
             except Exception:
-                pass
+                logger.debug("tier-2 mc_conn.close() failed (already closed or broken)", exc_info=True)
 
     @staticmethod
     def _tier2_cascade_reason(result: SweepResult) -> str:


### PR DESCRIPTION
## Summary

CODIE proactive cleanup for today's theme: **improve error messages and logging context in except blocks**.

- Added `logger.debug()` with `exc_info=True` to 12 bare `except Exception:` blocks that silently swallowed errors in two core production services
- **mission_control_intelligence_sweeper.py** (3 sites): `conn.close()` in `finally` blocks now logs instead of `pass`
- **claude_code_intel.py** (9 sites): intel_lanes lookups, JSON parse failures, state file corruption, packet cleanup, and int conversion now include contextual debug info

## Changes

| File | Sites | Pattern |
|------|-------|---------|
| `mission_control_intelligence_sweeper.py` | 3 | `finally: conn.close()` cleanup - logs conn identity |
| `claude_code_intel.py` | 4 | `intel_lanes` lookup failures - logs lane slug |
| `claude_code_intel.py` | 2 | X API JSON parse failures - logs HTTP status + URL |
| `claude_code_intel.py` | 1 | State file parse failure - logs file path |
| `claude_code_intel.py` | 1 | Legacy state migration - logs file path |
| `claude_code_intel.py` | 1 | Packet dir cleanup - logs dir path |
| `claude_code_intel.py` | 1 | Int conversion - logs raw value + default |

## Test plan

- [x] `py_compile` passes on both files
- [x] `ruff check` passes (1 pre-existing F841, not introduced by this PR)
- [x] `pytest tests/unit` - 406 passed, 1 pre-existing failure (unrelated `classify_post` test)
- [x] No behavioral changes - all fallbacks remain identical, only observability added

## Risks

Minimal. All changes are `logger.debug()` additions inside existing `except` blocks. No logic changes, no new exceptions raised, no new imports. Debug-level logs only appear when DEBUG logging is enabled.

## Why

Silently swallowed errors in production services make debugging nearly impossible. When a JSON parse fails or a connection close errors, operators currently see nothing. These debug logs provide the "why did the fallback trigger?" answer without changing any behavior.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
