### PR TITLE
fix(cron): mark SQL-only crons lightweight to bypass Composio bootstrap

### DIFF
--- a/src/universal_agent/gateway_server.py
+++ b/src/universal_agent/gateway_server.py
@@ -18658,6 +18658,15 @@ def _ensure_vp_mission_pr_reconciler_cron_job() -> Optional[dict[str, Any]]:
         cron_env_var="UA_VP_MISSION_PR_RECONCILER_CRON",
         timezone_env_var="UA_VP_MISSION_PR_RECONCILER_TIMEZONE",
         skip_task_hub_link=True,
+        # Lightweight: pure SQL + GitHub HTTP — never touches Composio
+        # tools or instantiates an agent session. The heavyweight bootstrap
+        # would still try to open a Composio tool-router session on every
+        # tick, and that's exactly what caused the 2026-05-23 16:00-18:00 UTC
+        # alert flood when COMPOSIO_API_KEY was rotated upstream and the
+        # in-flight cached value started returning 401. Skipping the
+        # bootstrap makes this cron resilient to Composio outages it doesn't
+        # depend on.
+        lightweight=True,
     )
 
 
@@ -19195,6 +19204,11 @@ def _ensure_hackernews_snapshot_cron_job() -> Optional[dict[str, Any]]:
         enabled=_proactive_cron_enabled("UA_HACKERNEWS_SNAPSHOT_ENABLED"),
         cron_env_var="UA_HACKERNEWS_SNAPSHOT_CRON",
         timezone_env_var="UA_HACKERNEWS_SNAPSHOT_TIMEZONE",
+        # Lightweight: pure HN-API HTTP + bs4 parse — no Composio tools,
+        # no agent session needed. Was caught up in the 2026-05-23
+        # Composio key rotation storm because the heavyweight bootstrap
+        # initializes Composio before yielding to the script.
+        lightweight=True,
     )
 
 
@@ -19316,6 +19330,10 @@ def _ensure_proactive_artifact_digest_cron_job() -> Optional[dict[str, Any]]:
         enabled=_proactive_cron_enabled("UA_PROACTIVE_ARTIFACT_DIGEST_ENABLED"),
         cron_env_var="UA_PROACTIVE_ARTIFACT_DIGEST_CRON",
         timezone_env_var="UA_PROACTIVE_ARTIFACT_DIGEST_TIMEZONE",
+        # Lightweight: SQL read against activity_state.db + AgentMail
+        # send. No Composio tools needed. Mail service uses its own
+        # AGENTMAIL_API_KEY which is independent of Composio.
+        lightweight=True,
     )
 
 
@@ -19499,6 +19517,13 @@ def _ensure_csi_demo_triage_rank_cron_job() -> Optional[dict[str, Any]]:
         # Ship 4 (Task Hub Observability Protocol): opted IN. Re-ranking
         # sweeps benefit from "did this LLM tick run and finish cleanly?"
         # observability separately from the candidate rows it touches.
+        #
+        # Lightweight: pure SQL + one direct ANTHROPIC_BASE_URL/AUTH_TOKEN
+        # LLM call (via run_ranking). No Composio tools, no agent session.
+        # Bypassing the heavyweight bootstrap also avoids the per-tick
+        # Composio tool-router init that becomes a noise generator any
+        # time COMPOSIO_API_KEY is in flux (see 2026-05-23 storm).
+        lightweight=True,
     )
 
 
@@ -19538,6 +19563,10 @@ def _ensure_intel_auto_promoter_cron_job() -> Optional[dict[str, Any]]:
         enabled=True,
         cron_env_var="UA_INTEL_AUTO_PROMOTE_CRON_EXPR",
         timezone_env_var="UA_INTEL_AUTO_PROMOTE_CRON_TIMEZONE",
+        # Lightweight: pure SQL — calls csi_demo_triage.approve_candidate
+        # which is a synchronous DB write. No Composio tools, no agent
+        # session needed.
+        lightweight=True,
     )
 
 


### PR DESCRIPTION
## Summary
Extends PR #435's lightweight-cron pattern to 5 more crons that don't actually need a Composio tool-router session but were still triggering it every tick.

## Why
**Today's incident** (2026-05-23 16:00-18:00 UTC, 12+ ERROR emails): when COMPOSIO_API_KEY got rotated upstream, every heavyweight cron — including ones that never touch Composio — started returning 401 from the per-tick \`backend.composio.dev/api/v3/tool_router/session\` POST that the bootstrap fires unconditionally. Rotation already resolved (Infisical updated; gateway restarted). This PR makes the system **resilient to the next rotation/outage** by stopping wasted Composio init on crons that don't need it.

## Crons newly marked \`lightweight=True\`
| Cron | Workload |
|---|---|
| \`vp_mission_pr_reconciler\` | SQL + GitHub HTTP only |
| \`intel_auto_promoter\` | SQL only (calls \`approve_candidate\`) |
| \`csi_demo_triage_rank\` | SQL + direct \`ANTHROPIC_*\` LLM call |
| \`proactive_artifact_digest\` | SQL + AgentMail (independent of Composio) |
| \`hackernews_snapshot\` | HN-API HTTP + bs4 parse |

## Verified
- Gold-standard pattern: \`simone_chat_auto_complete\` (lightweight since #435) calls \`initialize_runtime_secrets()\` in try/except, never calls Composio, has run flawlessly. All 5 new candidates follow the same shape.
- No script changes required — only registration metadata.
- \`ruff check\` + \`py_compile\` clean.

## Test plan
- [x] Lint + py_compile clean on gateway_server.py
- [ ] Post-deploy: 06:00 UTC reconciler tick runs clean (no Composio init, no 401 even if a future key were stale)
- [ ] 08:35 CDT proactive_artifact_digest fires lightweight; emails compose correctly
- [ ] 10:35 CDT \`intel_auto_promoter\` + \`csi_demo_triage_rank\` execute cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)