### PR TITLE
test(security_paths, heartbeat_scope_filter): add 92 unit tests for zero-coverage modules

### DIFF
--- a/tests/unit/test_heartbeat_scope_filter.py
+++ b/tests/unit/test_heartbeat_scope_filter.py
@@ -1,0 +1,189 @@
+"""Unit tests for heartbeat_scope_filter.py — HEARTBEAT.md scope-section filtering."""
+from __future__ import annotations
+
+import pytest
+
+from universal_agent.heartbeat_scope_filter import filter_heartbeat_by_scope
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+HQ_MARKER = "<!-- scope:hq -->"
+LOCAL_MARKER = "<!-- scope:local -->"
+ALL_MARKER = "<!-- scope:all -->"
+
+
+# ---------------------------------------------------------------------------
+# No markers — content returned as-is
+# ---------------------------------------------------------------------------
+class TestNoMarkers:
+    def test_content_without_markers_returned_unchanged(self):
+        content = "Hello world\nThis is heartbeat content."
+        result = filter_heartbeat_by_scope(content, "global")
+        assert result == content
+
+    def test_empty_string_returned_as_is(self):
+        assert filter_heartbeat_by_scope("", "global") == ""
+
+    def test_whitespace_only_returned_as_is(self):
+        ws = "   \n  "
+        assert filter_heartbeat_by_scope(ws, "global") == ws
+
+    def test_none_handled_gracefully(self):
+        # None is falsy — early return
+        result = filter_heartbeat_by_scope(None, "global")  # type: ignore[arg-type]
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# global scope: keeps hq + all, drops local
+# ---------------------------------------------------------------------------
+class TestGlobalScope:
+    def test_keeps_hq_section(self):
+        content = f"{HQ_MARKER}\nhq content here\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "hq content here" in result
+
+    def test_drops_local_section(self):
+        content = f"{LOCAL_MARKER}\nlocal only content\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "local only content" not in result
+
+    def test_keeps_all_section(self):
+        content = f"{ALL_MARKER}\nshared content\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "shared content" in result
+
+    def test_mixed_sections_global(self):
+        content = (
+            f"{HQ_MARKER}\nhq task\n"
+            f"{LOCAL_MARKER}\nlocal task\n"
+            f"{ALL_MARKER}\nshared task\n"
+        )
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "hq task" in result
+        assert "local task" not in result
+        assert "shared task" in result
+
+    def test_pre_marker_content_always_kept(self):
+        content = f"preamble content\n{LOCAL_MARKER}\nlocal section\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "preamble content" in result
+        assert "local section" not in result
+
+
+# ---------------------------------------------------------------------------
+# local scope: keeps local + all, drops hq
+# ---------------------------------------------------------------------------
+class TestLocalScope:
+    def test_drops_hq_section(self):
+        content = f"{HQ_MARKER}\nhq only content\n"
+        result = filter_heartbeat_by_scope(content, "local")
+        assert "hq only content" not in result
+
+    def test_keeps_local_section(self):
+        content = f"{LOCAL_MARKER}\nlocal content here\n"
+        result = filter_heartbeat_by_scope(content, "local")
+        assert "local content here" in result
+
+    def test_keeps_all_section(self):
+        content = f"{ALL_MARKER}\nshared content\n"
+        result = filter_heartbeat_by_scope(content, "local")
+        assert "shared content" in result
+
+    def test_mixed_sections_local(self):
+        content = (
+            f"{HQ_MARKER}\nhq task\n"
+            f"{LOCAL_MARKER}\nlocal task\n"
+            f"{ALL_MARKER}\nshared task\n"
+        )
+        result = filter_heartbeat_by_scope(content, "local")
+        assert "hq task" not in result
+        assert "local task" in result
+        assert "shared task" in result
+
+
+# ---------------------------------------------------------------------------
+# Unknown scope: keeps everything (fallback)
+# ---------------------------------------------------------------------------
+class TestUnknownScope:
+    def test_unknown_scope_keeps_all_sections(self):
+        content = (
+            f"{HQ_MARKER}\nhq content\n"
+            f"{LOCAL_MARKER}\nlocal content\n"
+            f"{ALL_MARKER}\nshared content\n"
+        )
+        result = filter_heartbeat_by_scope(content, "bogus_scope")
+        assert "hq content" in result
+        assert "local content" in result
+        assert "shared content" in result
+
+    def test_empty_scope_string_keeps_everything(self):
+        content = f"{HQ_MARKER}\nhq only\n"
+        result = filter_heartbeat_by_scope(content, "")
+        assert "hq only" in result
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — marker formatting
+# ---------------------------------------------------------------------------
+class TestMarkerFormatting:
+    def test_marker_with_extra_spaces(self):
+        content = "<!--  scope:hq  -->\nhq content\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "hq content" in result
+
+    def test_marker_with_leading_whitespace(self):
+        content = "   <!-- scope:local -->\nlocal content\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "local content" not in result
+
+    def test_inline_marker_not_treated_as_scope_marker(self):
+        # Marker embedded inside text (not on its own line) should NOT split
+        content = "text <!-- scope:local --> more text"
+        result = filter_heartbeat_by_scope(content, "global")
+        # Since the regex requires the marker on its own line, the content
+        # has no split and is returned as-is.
+        assert result == content
+
+    def test_multiple_hq_sections_all_kept_for_global(self):
+        content = (
+            f"{HQ_MARKER}\nfirst hq block\n"
+            f"{HQ_MARKER}\nsecond hq block\n"
+        )
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "first hq block" in result
+        assert "second hq block" in result
+
+    def test_multiple_local_sections_dropped_for_global(self):
+        content = (
+            f"{LOCAL_MARKER}\nfirst local block\n"
+            f"{LOCAL_MARKER}\nsecond local block\n"
+        )
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "first local block" not in result
+        assert "second local block" not in result
+
+
+# ---------------------------------------------------------------------------
+# Output shape
+# ---------------------------------------------------------------------------
+class TestOutputShape:
+    def test_result_stripped_and_newline_terminated(self):
+        content = f"\n\n{HQ_MARKER}\nhq section\n\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert result.endswith("\n")
+        assert not result.startswith("\n")
+
+    def test_empty_section_text_excluded(self):
+        # Section with only whitespace should not add empty chunks
+        content = f"{HQ_MARKER}\n   \n{ALL_MARKER}\nreal content\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert "real content" in result
+        # Whitespace-only hq section should not appear as content
+        assert result.strip() != ""
+
+    def test_returns_string(self):
+        content = f"{HQ_MARKER}\nhq content\n"
+        result = filter_heartbeat_by_scope(content, "global")
+        assert isinstance(result, str)

--- a/tests/unit/test_security_paths.py
+++ b/tests/unit/test_security_paths.py
@@ -1,0 +1,231 @@
+"""Unit tests for security_paths.py — path containment and session ID validation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from universal_agent import security_paths
+
+
+# ---------------------------------------------------------------------------
+# is_valid_session_id
+# ---------------------------------------------------------------------------
+class TestIsValidSessionId:
+    def test_simple_alphanumeric(self):
+        assert security_paths.is_valid_session_id("abc123") is True
+
+    def test_single_character(self):
+        assert security_paths.is_valid_session_id("a") is True
+
+    def test_single_digit(self):
+        assert security_paths.is_valid_session_id("0") is True
+
+    def test_allows_dot(self):
+        assert security_paths.is_valid_session_id("session.v2") is True
+
+    def test_allows_hyphen(self):
+        assert security_paths.is_valid_session_id("session-abc") is True
+
+    def test_allows_underscore(self):
+        assert security_paths.is_valid_session_id("session_abc") is True
+
+    def test_max_length_128_chars(self):
+        value = "a" + "b" * 127  # 128 chars total
+        assert security_paths.is_valid_session_id(value) is True
+
+    def test_too_long_129_chars(self):
+        value = "a" + "b" * 128  # 129 chars total
+        assert security_paths.is_valid_session_id(value) is False
+
+    def test_empty_string(self):
+        assert security_paths.is_valid_session_id("") is False
+
+    def test_whitespace_only(self):
+        assert security_paths.is_valid_session_id("   ") is False
+
+    def test_leading_underscore_invalid(self):
+        assert security_paths.is_valid_session_id("_bad") is False
+
+    def test_leading_hyphen_invalid(self):
+        assert security_paths.is_valid_session_id("-bad") is False
+
+    def test_leading_dot_invalid(self):
+        assert security_paths.is_valid_session_id(".bad") is False
+
+    def test_slash_disallowed(self):
+        assert security_paths.is_valid_session_id("a/b") is False
+
+    def test_space_disallowed(self):
+        assert security_paths.is_valid_session_id("a b") is False
+
+    def test_newline_disallowed(self):
+        assert security_paths.is_valid_session_id("a\nb") is False
+
+    def test_null_byte_disallowed(self):
+        assert security_paths.is_valid_session_id("a\x00b") is False
+
+    @pytest.mark.parametrize("value", [
+        "abc",
+        "ABC123",
+        "a.b.c",
+        "my-session-42",
+        "session_v1.2",
+    ])
+    def test_valid_parametrized(self, value):
+        assert security_paths.is_valid_session_id(value) is True
+
+    @pytest.mark.parametrize("value", [
+        "",
+        "   ",
+        "../bad",
+        "/absolute",
+        "a b",
+        "a@b",
+        "!invalid",
+    ])
+    def test_invalid_parametrized(self, value):
+        assert security_paths.is_valid_session_id(value) is False
+
+
+# ---------------------------------------------------------------------------
+# validate_session_id
+# ---------------------------------------------------------------------------
+class TestValidateSessionId:
+    def test_valid_returns_stripped(self):
+        assert security_paths.validate_session_id("  abc123  ") == "abc123"
+
+    def test_valid_no_strip_needed(self):
+        assert security_paths.validate_session_id("abc") == "abc"
+
+    def test_invalid_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid session id format"):
+            security_paths.validate_session_id("../traversal")
+
+    def test_empty_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid session id format"):
+            security_paths.validate_session_id("")
+
+    def test_none_equivalent_raises(self):
+        with pytest.raises((ValueError, AttributeError)):
+            security_paths.validate_session_id(None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# _is_within
+# ---------------------------------------------------------------------------
+class TestIsWithin:
+    def test_child_is_within_parent(self, tmp_path: Path):
+        child = tmp_path / "subdir" / "file.txt"
+        assert security_paths._is_within(tmp_path, child) is True
+
+    def test_parent_itself_is_within(self, tmp_path: Path):
+        assert security_paths._is_within(tmp_path, tmp_path) is True
+
+    def test_sibling_not_within(self, tmp_path: Path):
+        sibling = tmp_path.parent / "other"
+        assert security_paths._is_within(tmp_path, sibling) is False
+
+    def test_parent_dir_not_within_child(self, tmp_path: Path):
+        child = tmp_path / "subdir"
+        assert security_paths._is_within(child, tmp_path) is False
+
+    def test_traversal_path_not_within(self, tmp_path: Path):
+        traversal = tmp_path / ".." / "escape"
+        assert security_paths._is_within(tmp_path, traversal) is False
+
+    def test_deep_nested_is_within(self, tmp_path: Path):
+        deep = tmp_path / "a" / "b" / "c" / "d"
+        assert security_paths._is_within(tmp_path, deep) is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_workspace_dir
+# ---------------------------------------------------------------------------
+class TestResolveWorkspaceDir:
+    def test_none_requested_returns_none(self, tmp_path: Path):
+        result = security_paths.resolve_workspace_dir(tmp_path, None)
+        assert result is None
+
+    def test_empty_string_returns_none(self, tmp_path: Path):
+        result = security_paths.resolve_workspace_dir(tmp_path, "")
+        assert result is None
+
+    def test_relative_path_resolved_under_workspaces(self, tmp_path: Path):
+        result = security_paths.resolve_workspace_dir(tmp_path, "myworkspace")
+        assert result == str((tmp_path / "myworkspace").resolve())
+
+    def test_absolute_path_within_workspaces_ok(self, tmp_path: Path):
+        child = tmp_path / "session123"
+        result = security_paths.resolve_workspace_dir(tmp_path, str(child))
+        assert result == str(child.resolve())
+
+    def test_path_traversal_raises(self, tmp_path: Path):
+        escape = str(tmp_path / ".." / "escape")
+        with pytest.raises(ValueError, match="must remain under UA_WORKSPACES_DIR"):
+            security_paths.resolve_workspace_dir(tmp_path, escape)
+
+    def test_absolute_outside_raises_without_flag(self, tmp_path: Path):
+        outside = str(tmp_path.parent / "external_dir")
+        with pytest.raises(ValueError, match="must remain under UA_WORKSPACES_DIR"):
+            security_paths.resolve_workspace_dir(tmp_path, outside)
+
+    def test_allow_external_bypasses_containment_check(self, tmp_path: Path):
+        outside = str(tmp_path.parent / "external_dir")
+        result = security_paths.resolve_workspace_dir(tmp_path, outside, allow_external=True)
+        assert result == str(Path(outside).resolve())
+
+    def test_allow_external_still_resolves_relative(self, tmp_path: Path):
+        result = security_paths.resolve_workspace_dir(tmp_path, "rel", allow_external=True)
+        assert result == str((tmp_path / "rel").resolve())
+
+
+# ---------------------------------------------------------------------------
+# resolve_ops_log_path
+# ---------------------------------------------------------------------------
+class TestResolveOpsLogPath:
+    def test_relative_path_resolved_under_workspaces(self, tmp_path: Path):
+        result = security_paths.resolve_ops_log_path(tmp_path, "ops.log")
+        assert result == (tmp_path / "ops.log").resolve()
+
+    def test_absolute_within_workspaces_ok(self, tmp_path: Path):
+        log = tmp_path / "subdir" / "ops.log"
+        result = security_paths.resolve_ops_log_path(tmp_path, str(log))
+        assert result == log.resolve()
+
+    def test_traversal_raises(self, tmp_path: Path):
+        escape = str(tmp_path / ".." / "etc" / "passwd")
+        with pytest.raises(ValueError, match="must remain under UA_WORKSPACES_DIR"):
+            security_paths.resolve_ops_log_path(tmp_path, escape)
+
+    def test_absolute_outside_raises(self, tmp_path: Path):
+        outside = "/tmp/injected.log"
+        with pytest.raises(ValueError, match="must remain under UA_WORKSPACES_DIR"):
+            security_paths.resolve_ops_log_path(tmp_path, outside)
+
+    def test_returns_path_object(self, tmp_path: Path):
+        result = security_paths.resolve_ops_log_path(tmp_path, "ops.log")
+        assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# allow_external_workspaces_from_env
+# ---------------------------------------------------------------------------
+class TestAllowExternalWorkspacesFromEnv:
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on", "True", "YES", "ON"])
+    def test_truthy_values(self, value, monkeypatch):
+        monkeypatch.setenv("UA_ALLOW_EXTERNAL_WORKSPACES", value)
+        assert security_paths.allow_external_workspaces_from_env() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "nope", "2"])
+    def test_falsy_values(self, value, monkeypatch):
+        monkeypatch.setenv("UA_ALLOW_EXTERNAL_WORKSPACES", value)
+        assert security_paths.allow_external_workspaces_from_env() is False
+
+    def test_unset_returns_false(self, monkeypatch):
+        monkeypatch.delenv("UA_ALLOW_EXTERNAL_WORKSPACES", raising=False)
+        assert security_paths.allow_external_workspaces_from_env() is False
+
+    def test_whitespace_around_value(self, monkeypatch):
+        monkeypatch.setenv("UA_ALLOW_EXTERNAL_WORKSPACES", "  true  ")
+        assert security_paths.allow_external_workspaces_from_env() is True


### PR DESCRIPTION
## Summary

- **\`security_paths.py\`** had zero unit tests despite containing security-critical path containment and session ID validation logic (6 functions). Added 55 tests covering all functions, including path traversal attack vectors, session ID boundary cases, and env var flag parsing.
- **\`heartbeat_scope_filter.py\`** had zero unit tests despite its non-trivial regex-split scope filtering used by all Simone heartbeat loading paths (1 complex function). Added 37 tests covering all three scope labels, unknown scope fallback, marker formatting edge cases, inline markers, and output shape invariants.

## Changed files

- tests/unit/test_security_paths.py — 55 new tests (new file)
- tests/unit/test_heartbeat_scope_filter.py — 37 new tests (new file)

No production code changed.

## Tests run

92 passed in 0.28s (targeted). Full suite: 1255 passed, 1 pre-existing failure (test_digest_delivery_reminder confirmed on main before this branch).

## Red-green evidence

Red-green TDD not applicable: tests for existing, already-correct production code with no prior test coverage. Behavior verified by source inspection; tests serve as regression net.

Lint: ruff check clean after auto-fix of import ordering.

## Why this scope

Both modules are pure/deterministic utilities with zero external dependencies. security_paths.py is security-relevant (path traversal prevention); heartbeat_scope_filter.py contains unique regex-split logic exercised on every heartbeat load. Both confirmed zero existing tests before this PR.

## Risks

None — test-only changes. No production code modified, no behavior changed.

## Rollback

Delete or revert the two test files.