### PR TITLE
fix(csi): inject Infisical secrets into csi_run.sh wrapped subprocesses (unblocks Path B)

### DIFF
--- a/CSI_Ingester/development/scripts/csi_run.sh
+++ b/CSI_Ingester/development/scripts/csi_run.sh
@@ -10,5 +10,34 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
-exec "$@"
+# On the production VPS this script's parent systemd units load bootstrap
+# Infisical creds from /opt/universal_agent/.env. When those creds are
+# present, log in and run the wrapped command through `infisical run` so
+# secrets like UA_YOUTUBE_INGEST_TOKEN are injected as env vars into the
+# child process — never landing in the wrapper's own env or on disk.
+#
+# When the creds are absent (local dev, CI), pass through unchanged so
+# scripts can resolve secrets from local .env files or their own
+# fallback paths.
+if [ -n "${INFISICAL_CLIENT_ID:-}" ] \
+   && [ -n "${INFISICAL_CLIENT_SECRET:-}" ] \
+   && [ -n "${INFISICAL_PROJECT_ID:-}" ]; then
+  INFISICAL_ENV="${INFISICAL_ENVIRONMENT:-production}"
+  # `--plain --silent` gives just the token on stdout; the login itself never
+  # prints the value of the bootstrap secret.
+  if ! TOK=$(infisical login --method=universal-auth \
+              --client-id="$INFISICAL_CLIENT_ID" \
+              --client-secret="$INFISICAL_CLIENT_SECRET" \
+              --plain --silent 2>/dev/null); then
+    echo "csi_run.sh: infisical login failed; falling back to pass-through" >&2
+    exec "$@"
+  fi
+  export INFISICAL_TOKEN="$TOK"
+  exec infisical run \
+       --projectId="$INFISICAL_PROJECT_ID" \
+       --env="$INFISICAL_ENV" \
+       --silent \
+       -- "$@"
+fi
 
+exec "$@"


### PR DESCRIPTION
## Summary
Patches the `csi_run.sh` wrapper (invoked by every CSI cron systemd unit) to detect Infisical bootstrap creds in its env and, when present, wrap the supplied command in `infisical run --env=\$INFISICAL_ENVIRONMENT --`. This injects production secrets — `UA_YOUTUBE_INGEST_TOKEN`, `UA_INTERNAL_API_TOKEN`, etc. — as env vars into the child process without landing them on disk. Follows the canonical CLAUDE.md "Self-Service Infisical Secret Access" pattern.

## Why now
Today's diagnostic found the CSI RSS semantic-enrich timer has been producing zero transcript analyses since 2026-05-19. Root cause: the script calls `http://127.0.0.1:8002/api/v1/youtube/ingest` but its `_resolve_setting`/`resolve_token_from_infisical` chain returns empty under the systemd timer's environment → unauthenticated request → 401 → `transcript_status=failed` → no `summary_text` → LLM judge skips → no `tutorial_build` Task Hub items → Cody-demo Path B silent for a week. Full diagnosis in `docs/proactive_signals/youtube_demo_unification_plan.md` 2026-05-23 entry.

## Verification
- **VPS smoke test** (bootstrap creds present): wrapper injects 279 secrets, all three candidate auth tokens (`UA_YOUTUBE_INGEST_TOKEN`, `UA_INTERNAL_API_TOKEN`, `CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN`) visible to the child.
- **Local pass-through test** (bootstrap creds absent): wrapper just `exec "$@"`, no behavioral change in dev or CI.
- **Login-failure fallback**: if `infisical login` fails (e.g. network or rotated creds), wrapper falls through to plain pass-through with stderr breadcrumb so the systemd journal records the failure instead of swallowing it.

## Side effects worth knowing
Other CSI cron units that share `csi_run.sh` (e.g. `csi-ingester.service` for batch-brief) automatically inherit secret injection. They were likely also quietly degraded — this should restore them.

## Test plan
- [ ] PR-validate green
- [ ] After merge + deploy, manually trigger one run: `sudo systemctl start csi-rss-semantic-enrich.service && sleep 90 && sqlite3 /var/lib/universal-agent/csi/csi.db "SELECT count(*) FROM rss_event_analysis WHERE transcript_status='ok' AND created_at > date('now','-1 hour');"`
- [ ] Expect `RSS_ENRICH_TRANSCRIPT_OK > 0` in journal logs
- [ ] After 24 hours, check `tutorial_build_judge` table for fresh verdicts with `method != 'no_summary'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)