### PR TITLE
fix(csi): prefer gateway-accepted tokens in transcript-auth resolution (Path B end-to-end)

### DIFF
--- a/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py
+++ b/CSI_Ingester/development/scripts/csi_rss_semantic_enrich.py
@@ -426,14 +426,23 @@ def main() -> int:
         transcript_endpoints_raw,
         fallback=args.transcript_endpoint.strip(),
     )
+    # NOTE: order matters. The gateway's `_require_youtube_ingest_auth` only
+    # accepts UA_YOUTUBE_INGEST_TOKEN or UA_INTERNAL_API_TOKEN — it does NOT
+    # accept CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN (which exists in Infisical prod
+    # but for a different purpose). Try the gateway-accepted tokens FIRST;
+    # CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN is kept as a last-resort env override
+    # only because it was historically the documented override key.
+    # Diagnosed 2026-05-24 when the csi_run.sh Infisical wrap exposed all
+    # three keys to the script and the wrong one (mismatched token) was
+    # being picked first → HTTP 401 from /api/v1/youtube/ingest.
     transcript_token = _resolve_setting(
-        ["CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN", "UA_YOUTUBE_INGEST_TOKEN", "UA_INTERNAL_API_TOKEN"],
+        ["UA_YOUTUBE_INGEST_TOKEN", "UA_INTERNAL_API_TOKEN", "CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN"],
         merged_env_values,
     )
     if not transcript_token:
-        # systemd does not wrap this unit in `infisical run`, and the env files
-        # only carry Infisical *bootstrap* creds, not the resolved secrets. Pull
-        # UA_INTERNAL_API_TOKEN directly so /api/v1/youtube/ingest auth succeeds.
+        # Fallback: systemd may not always wrap this unit in `infisical run`.
+        # If the env-file resolution returned empty, pull directly from
+        # Infisical so /api/v1/youtube/ingest auth still succeeds.
         transcript_token = resolve_token_from_infisical(
             ["UA_YOUTUBE_INGEST_TOKEN", "UA_INTERNAL_API_TOKEN"],
             log_prefix="RSS_ENRICH",


### PR DESCRIPTION
## Summary
PR #440 (the `csi_run.sh` Infisical wrap, just merged) made an underlying bug visible: the script's token-resolution chain tried `CSI_RSS_ANALYSIS_TRANSCRIPT_TOKEN` first. That key exists in Infisical production env (for a different purpose) but the gateway's `_require_youtube_ingest_auth` only accepts `UA_YOUTUBE_INGEST_TOKEN` and `UA_INTERNAL_API_TOKEN`. So the script picked the wrong token → HTTP 401 → `transcript_status=failed`.

One-line reorder. Now the gateway-accepted tokens are tried first; the historical key stays as last-resort fallback.

## Verification on the VPS
Ran the patched script via the same `csi_run.sh` wrapper that `csi-rss-semantic-enrich.service` uses:

| Run | TRANSCRIPT_OK |
|---|---:|
| Before fix (with PR #440 wrap) | 0 / 4 events |
| After fix (this PR) | **3 / 3 events** |

Also observed: `RSS_ENRICH_ENDPOINT_OK host=127.0.0.1:8002 count=3` (all gateway calls succeeded), and the channel-reclassifier fired (`RECLASSIFY noise -> ai_coding_and_agents`), proving the downstream LLM analysis path is healthy too.

## End-to-end impact
Together with PR #440, this restores the full Path B pipeline for the first time since 2026-05-19:
- CSI RSS event arrives
- → transcript fetched via gateway (auth now works)
- → LLM judge in `is_video_buildable_with_judge` produces real verdicts (no more `method=no_summary`)
- → buildable videos enqueued as `tutorial_build` Task Hub items
- → Cody picks up and builds the private repo

The ~800-event backlog will drain at 12 events / 4 hours (the timer's `--max-events` arg). Should be empty within ~4 days.

## Test plan
- [ ] PR-validate green
- [ ] After deploy, the next scheduled `csi-rss-semantic-enrich.timer` (every 4 hours) should write `transcript_status='ok'` for most events
- [ ] After 24 hours, `tutorial_build_judge` table starts accumulating verdicts with `method != 'no_summary'`
- [ ] After ~24 hours, fresh `tutorial_build` rows in Task Hub for buildable videos

🤖 Generated with [Claude Code](https://claude.com/claude-code)