### PR TITLE
fix(cron-disclosure): surface cron artifacts in Proactive Task History tab

### DIFF
--- a/src/universal_agent/services/cron_artifact_notifier.py
+++ b/src/universal_agent/services/cron_artifact_notifier.py
@@ -122,6 +122,14 @@ async def notify_cron_artifact(
             title=title,
         )
 
+        # Task Hub cross-reference. The F.1 close-out path creates a
+        # ``cron:<job_id>`` row in ``task_hub_items``. We link the
+        # artifact to that task_id so the Proactive Task History tab's
+        # cross-join (gateway_server._proactive_artifacts_by_task) finds
+        # it. Without this link, the artifact lives in proactive_artifacts
+        # but never surfaces alongside the cron task in the dashboard.
+        linked_task_id = f"cron:{job_id}"
+
         proactive_artifacts.ensure_schema(conn)
         artifact = proactive_artifacts.upsert_artifact(
             conn,
@@ -136,6 +144,7 @@ async def notify_cron_artifact(
             artifact_path=str(workspace_dir),
             metadata={
                 "job_id": job_id,
+                "task_id": linked_task_id,
                 "started_at_epoch": started_at,
                 "finished_at_epoch": finished_at,
                 "workspace_dir": str(workspace_dir),
@@ -143,6 +152,26 @@ async def notify_cron_artifact(
                 "reminder": _seed_reminder_state(finished_at),
             },
         )
+
+        # Promote the cron's Task Hub row from ``project_key='immediate'``
+        # to ``project_key='proactive'`` so the Proactive Task History
+        # tab's WHERE clause picks it up. Bounded scope: only opted-in
+        # crons (this code path requires notify_on_artifact=true) get
+        # promoted, so non-disclosure crons stay out of the proactive
+        # surface. Best-effort UPDATE; missing row is a no-op.
+        try:
+            conn.execute(
+                "UPDATE task_hub_items SET project_key = 'proactive', "
+                "updated_at = ? WHERE task_id = ? AND project_key != 'proactive'",
+                (datetime.now(timezone.utc).isoformat(), linked_task_id),
+            )
+            conn.commit()
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.debug(
+                "cron_artifact_notifier: project_key promotion skipped for %s: %s",
+                linked_task_id,
+                exc,
+            )
 
         ack_url = _build_ack_url(artifact_id, dashboard_base_url)
         subject, text_body, html_body = _compose_initial_email(

--- a/tests/unit/test_cron_artifact_notifier.py
+++ b/tests/unit/test_cron_artifact_notifier.py
@@ -241,6 +241,121 @@ async def test_email_delivery_recorded(conn, mail_service, workspace) -> None:
     assert rows[0][2] == "kevinjdragan@gmail.com"
 
 
+# ── Task Hub linkage for Proactive Task History tab ───────────────────
+
+
+def _create_cron_task_hub_row(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    project_key: str = "immediate",
+) -> None:
+    """Seed a task_hub_items row that mirrors what the F.1 close-out
+    creates for a cron — so the notifier's promotion path has something
+    to update."""
+    # Schema is defined in task_hub.ensure_schema; create a minimal one
+    # for the test rather than importing the full module side effects.
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS task_hub_items (
+            task_id TEXT PRIMARY KEY,
+            source_kind TEXT NOT NULL,
+            source_ref TEXT,
+            title TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            project_key TEXT NOT NULL DEFAULT 'immediate',
+            priority INTEGER NOT NULL DEFAULT 1,
+            status TEXT NOT NULL DEFAULT 'open',
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO task_hub_items "
+        "(task_id, source_kind, title, project_key, created_at, updated_at) "
+        "VALUES (?, 'cron_run', ?, ?, '2026-05-24T00:00:00Z', '2026-05-24T00:00:00Z')",
+        (task_id, "Cron: paper_to_podcast_daily", project_key),
+    )
+    conn.commit()
+
+
+@pytest.mark.asyncio
+async def test_notifier_links_artifact_to_cron_task(
+    conn, mail_service, workspace
+) -> None:
+    _create_cron_task_hub_row(conn, task_id="cron:paper_to_podcast")
+    _write_manifest(workspace, [{"title": "x", "path": "work_products/x"}])
+    artifact = await notify_cron_artifact(
+        conn=conn,
+        mail_service=mail_service,
+        job_id="paper_to_podcast",
+        job_metadata={"notify_on_artifact": True},
+        job_command="run",
+        workspace_dir=workspace,
+        started_at=1779600000.0,
+        finished_at=1779600300.0,
+        recipient="kevinjdragan@gmail.com",
+    )
+    assert artifact is not None
+    meta = artifact.get("metadata") or {}
+    assert meta["task_id"] == "cron:paper_to_podcast"
+
+
+@pytest.mark.asyncio
+async def test_notifier_promotes_cron_task_to_proactive(
+    conn, mail_service, workspace
+) -> None:
+    _create_cron_task_hub_row(
+        conn,
+        task_id="cron:paper_to_podcast",
+        project_key="immediate",
+    )
+    _write_manifest(workspace, [{"title": "x", "path": "work_products/x"}])
+    await notify_cron_artifact(
+        conn=conn,
+        mail_service=mail_service,
+        job_id="paper_to_podcast",
+        job_metadata={"notify_on_artifact": True},
+        job_command="run",
+        workspace_dir=workspace,
+        started_at=1779600000.0,
+        finished_at=1779600300.0,
+        recipient="kevinjdragan@gmail.com",
+    )
+    row = conn.execute(
+        "SELECT project_key FROM task_hub_items WHERE task_id=?",
+        ("cron:paper_to_podcast",),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "proactive"
+
+
+@pytest.mark.asyncio
+async def test_notifier_missing_task_hub_row_no_crash(
+    conn, mail_service, workspace
+) -> None:
+    """If the cron's task_hub_items row doesn't exist yet (race or
+    skip_task_hub_link cron), the promotion UPDATE is a no-op and the
+    artifact still gets emailed."""
+    # NOTE: no _create_cron_task_hub_row call here
+    _write_manifest(workspace, [{"title": "x", "path": "work_products/x"}])
+    artifact = await notify_cron_artifact(
+        conn=conn,
+        mail_service=mail_service,
+        job_id="orphan_cron",
+        job_metadata={"notify_on_artifact": True},
+        job_command="run",
+        workspace_dir=workspace,
+        started_at=1779600000.0,
+        finished_at=1779600300.0,
+        recipient="kevinjdragan@gmail.com",
+    )
+    assert artifact is not None
+    mail_service.send_email.assert_called_once()
+
+
 # ── HMAC ack token sign/verify ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
PR #446 shipped the email rail but the dashboard's Proactive Task History tab didn't pick up cron-disclosure artifacts. This fixes both gaps.

## The two gaps
1. **Missing artifact↔task linkage.** Notifier was storing only \`job_id\` in artifact metadata. The gateway's \`_proactive_artifacts_by_task\` cross-join keys on \`metadata.task_id\` or \`source_ref\`, so the artifact was orphaned from its cron task in the UI.
2. **Cron rows are filtered out by the tab's WHERE clause.** \`task_hub.py:2814-2825\` selects items where \`project_key='proactive'\` OR \`source_kind IN (12-item whitelist)\`. Cron items have \`project_key='immediate'\` and \`source_kind='cron_run'\` — neither qualifies.

## Fix
- Notifier now stores \`metadata.task_id = "cron:<job_id>"\` so the cross-join finds the artifact.
- Notifier issues a one-shot UPDATE to flip the cron's \`task_hub_items\` row to \`project_key='proactive'\` on first opt-in fire. Bounded scope — only crons with \`notify_on_artifact=true\` participate, so heartbeat / housekeeping crons stay out of the proactive surface.

## Test plan
- [x] \`pytest tests/unit/test_cron_artifact_notifier.py\` — 15 tests pass (3 new: linkage written, project_key promoted, no crash when row missing).
- [x] Regression: 28 tests across notifier + reminders + ack pass.
- [x] \`py_compile\` + \`ruff --select E9,F\` clean.
- [ ] Post-deploy: trigger a manual paper_to_podcast fire and confirm it appears in the Proactive Task History tab with its artifact list.

## Follow-up (separate PR, your direction)
Operator asked for sub-tabbed UX on this page so each view has its own tailored layout instead of filter chips on a single output style. Proposed top-level split: \`Activity History\` (executed work) vs \`Opportunities\` (candidate signals). Activity History sub-tabs: Pending Review, Recent Artifacts, Active Work, Completed. That's a meaningful UX redesign — will land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)