### PR TITLE
fix(proactive): scope preference gate to explicit signals + funnel invariant

### DIFF
--- a/src/universal_agent/scripts/preference_signal_detox.py
+++ b/src/universal_agent/scripts/preference_signal_detox.py
@@ -1,0 +1,131 @@
+"""One-shot detox of poisoned implicit-outcome preference signals.
+
+Background: prior to the gate-scoping fix in `proactive_preferences.py`,
+`should_block_proactive_task` counted both explicit feedback and implicit
+terminal-state outcomes (park/block/complete) toward the same per-key
+weight. A 224-event one-day park burst on 2026-04-18→19 against the
+convergence/insight pipeline saturated `source:convergence_detection`,
+`topic:convergence`, `topic:atlas`, `topic:research` at -1.0 and silently
+suppressed every brief produced thereafter (1119 insight + 571 convergence
+artifacts stuck as `candidate`, zero downstream task_hub_items).
+
+With the gate now scoped to `signal_type='explicit_feedback'`, those
+implicit rows no longer block. They are still noise in the snapshot
+(skewing weights used for ranking and the weekly digest), so this script
+deletes them and rebuilds the snapshot.
+
+Idempotent. Re-running finds zero rows and exits clean. Defaults to
+dry-run; pass `--commit` to actually delete.
+
+Usage:
+    uv run python -m universal_agent.scripts.preference_signal_detox \\
+        [--db /path/to/activity_state.db] [--commit] [--signal-type implicit_outcome]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import sys
+
+from universal_agent.durable.db import connect_runtime_db, get_activity_db_path
+from universal_agent.services.proactive_preferences import (
+    ensure_schema,
+    rebuild_preference_snapshot,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SIGNAL_TYPE = "implicit_outcome"
+
+
+def detox(
+    conn: sqlite3.Connection,
+    *,
+    signal_type: str = DEFAULT_SIGNAL_TYPE,
+    commit: bool = False,
+) -> dict[str, int]:
+    """Delete rows of the given signal_type and rebuild the snapshot.
+
+    Returns a report dict with `total_before`, `target_rows`, `deleted`,
+    `total_after`, and `model_signals_after`.
+    """
+    ensure_schema(conn)
+
+    total_before = conn.execute(
+        "SELECT COUNT(*) FROM proactive_preference_signals"
+    ).fetchone()[0]
+    target_rows = conn.execute(
+        "SELECT COUNT(*) FROM proactive_preference_signals WHERE signal_type = ?",
+        (signal_type,),
+    ).fetchone()[0]
+
+    if not commit:
+        return {
+            "total_before": int(total_before),
+            "target_rows": int(target_rows),
+            "deleted": 0,
+            "total_after": int(total_before),
+            "model_signals_after": -1,
+            "dry_run": 1,
+        }
+
+    cur = conn.execute(
+        "DELETE FROM proactive_preference_signals WHERE signal_type = ?",
+        (signal_type,),
+    )
+    deleted = cur.rowcount
+    conn.commit()
+
+    model = rebuild_preference_snapshot(conn)
+    total_after = conn.execute(
+        "SELECT COUNT(*) FROM proactive_preference_signals"
+    ).fetchone()[0]
+    return {
+        "total_before": int(total_before),
+        "target_rows": int(target_rows),
+        "deleted": int(deleted),
+        "total_after": int(total_after),
+        "model_signals_after": int(model.get("meta", {}).get("total_signals_processed", 0)),
+        "dry_run": 0,
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--db", default=None, help="Path to activity_state.db (default: get_activity_db_path())")
+    p.add_argument("--signal-type", default=DEFAULT_SIGNAL_TYPE, help=f"signal_type to delete (default: {DEFAULT_SIGNAL_TYPE})")
+    p.add_argument("--commit", action="store_true", help="Actually delete (default: dry-run)")
+    p.add_argument("--verbose", "-v", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    db_path = args.db or str(get_activity_db_path())
+    logger.info("Opening activity DB at %s", db_path)
+    with connect_runtime_db(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        report = detox(conn, signal_type=args.signal_type, commit=args.commit)
+
+    mode = "DRY-RUN" if not args.commit else "COMMITTED"
+    logger.info(
+        "%s | signals_before=%d target=%d deleted=%d signals_after=%d model_processed_after=%d",
+        mode,
+        report["total_before"],
+        report["target_rows"],
+        report["deleted"],
+        report["total_after"],
+        report["model_signals_after"],
+    )
+    if not args.commit and report["target_rows"] > 0:
+        logger.info("Re-run with --commit to actually delete %d rows.", report["target_rows"])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/universal_agent/services/invariants/proactive_pipeline_invariants.py
+++ b/src/universal_agent/services/invariants/proactive_pipeline_invariants.py
@@ -52,6 +52,19 @@ CSI_DEMO_TRIAGE_MAX_AGE_HOURS = 6.0  # twice-daily cron
 PAPER_TO_PODCAST_MAX_AGE_HOURS = 30.0  # daily 9 PM Houston + 6h grace
 VAULT_LINT_DAY_OF_MONTH_GATE = 2  # only probe after the 2nd to give the 1st's cron full day
 
+# Brief→task funnel (added 2026-05-24). Each proactive source_kind should
+# produce roughly one task_hub_items row per artifact. A wide gap (lots of
+# artifacts, zero tasks) means the preference gate / queue insert path is
+# silently dropping work — which is exactly the failure mode that the
+# 2026-04-18 implicit-park-poison incident exposed.
+BRIEF_TASK_FUNNEL_WINDOW_HOURS = 48
+BRIEF_TASK_FUNNEL_MIN_ARTIFACTS = 5  # below this it's plausibly just slow CSI inputs
+BRIEF_TASK_FUNNEL_SOURCE_KINDS = (
+    "convergence_detection",
+    "insight_detection",
+    "tutorial_build",
+)
+
 
 def _today_houston() -> str:
     return datetime.now(HOUSTON_TZ).strftime("%Y-%m-%d")
@@ -804,4 +817,85 @@ def vault_lint_contradictions_monthly(ctx: Dict[str, Any]) -> Optional[Dict[str,
             "for another month."
         ),
         "threshold_text": "≥1 contradiction-report-*.md file dated current month",
+    }
+
+
+# ---------------------------------------------------------------------------
+# 11. proactive brief → task_hub funnel coverage
+# ---------------------------------------------------------------------------
+
+
+@invariant(
+    id="proactive_brief_task_funnel",
+    title="Proactive artifacts produce matching task_hub_items",
+    description=(
+        "Each proactive source_kind (convergence_detection, insight_detection, "
+        "tutorial_build) should produce roughly one task_hub_items row per "
+        "artifact. A wide gap (≥N artifacts, 0 tasks in 48h) means the "
+        "preference gate, dedup logic, or queue insert path is silently "
+        "dropping work. This is the failure mode that hid the 2026-04-18 "
+        "implicit-park preference poison incident for ~5 weeks."
+    ),
+    severity="warn",
+    runbook_command=(
+        "sqlite3 \"$UA_ACTIVITY_DB_PATH\" \""
+        "SELECT source_kind, COUNT(*) AS arts FROM proactive_artifacts "
+        "WHERE source_kind IN ('convergence_detection','insight_detection','tutorial_build') "
+        "AND created_at >= datetime('now','-48 hours') GROUP BY source_kind;\""
+    ),
+    metadata={
+        "pipeline": "proactive_brief_funnel",
+        "tables": ["proactive_artifacts", "task_hub_items"],
+    },
+)
+def proactive_brief_task_funnel(ctx: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    conn = ctx.get("activity_conn")
+    if conn is None:
+        return None
+    starved: list[dict[str, Any]] = []
+    for source_kind in BRIEF_TASK_FUNNEL_SOURCE_KINDS:
+        try:
+            arts = conn.execute(
+                """
+                SELECT COUNT(*) FROM proactive_artifacts
+                WHERE source_kind = ?
+                  AND created_at >= datetime('now', ?)
+                """,
+                (source_kind, f"-{BRIEF_TASK_FUNNEL_WINDOW_HOURS} hours"),
+            ).fetchone()[0]
+            tasks = conn.execute(
+                """
+                SELECT COUNT(*) FROM task_hub_items
+                WHERE source_kind = ?
+                  AND created_at >= datetime('now', ?)
+                """,
+                (source_kind, f"-{BRIEF_TASK_FUNNEL_WINDOW_HOURS} hours"),
+            ).fetchone()[0]
+        except sqlite3.Error as exc:
+            logger.debug("proactive_brief_task_funnel: query failed for %s (%s)", source_kind, exc)
+            continue
+        if arts >= BRIEF_TASK_FUNNEL_MIN_ARTIFACTS and tasks == 0:
+            starved.append({
+                "source_kind": source_kind,
+                "artifacts_48h": int(arts),
+                "task_hub_items_48h": 0,
+            })
+    if not starved:
+        return None
+    return {
+        "observed_value": {
+            "starved_pipelines": starved,
+            "window_hours": BRIEF_TASK_FUNNEL_WINDOW_HOURS,
+        },
+        "message": (
+            f"{len(starved)} proactive pipeline(s) produced ≥"
+            f"{BRIEF_TASK_FUNNEL_MIN_ARTIFACTS} artifacts in "
+            f"{BRIEF_TASK_FUNNEL_WINDOW_HOURS}h but zero task_hub_items. "
+            "The preference gate or queue insert path is silently dropping "
+            "work. Check proactive_preference_signals for poison and "
+            "should_block_proactive_task call sites."
+        ),
+        "threshold_text": (
+            f"if artifacts_48h ≥ {BRIEF_TASK_FUNNEL_MIN_ARTIFACTS} then task_hub_items_48h > 0"
+        ),
     }

--- a/src/universal_agent/services/proactive_preferences.py
+++ b/src/universal_agent/services/proactive_preferences.py
@@ -246,39 +246,66 @@ def should_block_proactive_task(
     task_type: str = "",
     topic_tags: list[str] | None = None,
     block_threshold: float = -0.5,
+    half_life_days: float = 14.0,
 ) -> tuple[bool, str]:
     """Hard gate: return (True, reason) if preferences strongly oppose this task.
 
-    A task is blocked when *every* matching preference key carries a weight
-    at or below ``block_threshold`` (default -0.5).  If there are no matching
-    signals at all the task is allowed through (benefit of the doubt).
+    Counts ONLY ``signal_type='explicit_feedback'`` rows. Implicit outcome
+    signals (auto-fired by the outcome tracker when tasks reach a terminal
+    state like park/block) are deliberately excluded — they conflate
+    "Kevin disliked this" with "no consumer claimed it / stale cleanup",
+    and a single burst of system parks can otherwise saturate a key's
+    weight at -1.0 and silently suppress an entire pipeline. Implicit
+    signals still contribute to ranking via ``score_artifact_for_review``,
+    just never to the hard gate.
 
-    Returns:
-        (should_block, reason) — ``should_block`` is True when the task
-        should be silently dropped, and ``reason`` explains why.
-
+    A task is blocked when *every* matching preference key carries an
+    explicit weight at or below ``block_threshold`` (default -0.5). If there
+    are no matching explicit signals at all the task is allowed through
+    (benefit of the doubt).
     """
     ensure_schema(conn)
-    model = get_preference_snapshot(conn)
-    preferences = model.get("topic_preferences") if isinstance(model.get("topic_preferences"), dict) else {}
     keys = _context_keys(task_type=task_type, topic_tags=topic_tags or [])
     if not keys:
         return False, ""
 
-    matched = [(k, preferences[k]) for k in keys if k in preferences]
-    if not matched:
-        return False, ""  # No signal → allow
+    placeholders = ",".join("?" for _ in keys)
+    rows = conn.execute(
+        f"""
+        SELECT signal_key, weight, created_at
+        FROM proactive_preference_signals
+        WHERE signal_type = 'explicit_feedback'
+          AND signal_key IN ({placeholders})
+        """,
+        tuple(keys),
+    ).fetchall()
+    if not rows:
+        return False, ""
+
+    now = datetime.now(timezone.utc)
+    weights: dict[str, float] = {}
+    for row in rows:
+        key = str(row["signal_key"] or "").strip()
+        if not key:
+            continue
+        decayed = float(row["weight"] or 0.0) * _decay_multiplier(
+            _age_days(str(row["created_at"] or ""), now=now), half_life_days
+        )
+        weights[key] = weights.get(key, 0.0) + decayed
+
+    if not weights:
+        return False, ""
 
     negative_keys: list[str] = []
-    for key, value in matched:
-        weight = float((value or {}).get("weight") or 0.0)
-        if weight > block_threshold:
+    for key, weight_sum in weights.items():
+        clipped = max(-1.0, min(1.0, weight_sum))
+        if clipped > block_threshold:
             return False, ""  # At least one dimension is neutral/positive → allow
-        negative_keys.append(f"{key}={weight:.2f}")
+        negative_keys.append(f"{key}={clipped:.2f}")
 
     reason = (
-        f"All {len(negative_keys)} preference dimension(s) are strongly negative "
-        f"(threshold {block_threshold}): {', '.join(negative_keys)}. "
+        f"All {len(negative_keys)} explicit-feedback dimension(s) are strongly "
+        f"negative (threshold {block_threshold}): {', '.join(negative_keys)}. "
         f"Proactive task suppressed."
     )
     return True, reason

--- a/tests/unit/test_preference_gate_scoping.py
+++ b/tests/unit/test_preference_gate_scoping.py
@@ -1,0 +1,229 @@
+"""Tests covering the preference-gate scoping fix and the detox migration.
+
+These tests pin the 2026-05-24 behaviour change: `should_block_proactive_task`
+counts only `signal_type='explicit_feedback'` rows, so a burst of implicit
+park/block outcomes can never silently suppress a whole pipeline. The
+detox script removes pre-existing implicit poison and rebuilds the
+snapshot.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sqlite3
+
+import pytest
+
+from universal_agent.scripts.preference_signal_detox import detox
+from universal_agent.services.proactive_preferences import (
+    ensure_schema,
+    rebuild_preference_snapshot,
+    should_block_proactive_task,
+)
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    ensure_schema(conn)
+    return conn
+
+
+def _insert_signal(
+    conn: sqlite3.Connection,
+    *,
+    signal_key: str,
+    weight: float,
+    signal_type: str = "implicit_outcome",
+    created_at: datetime | None = None,
+    artifact_id: str = "art-x",
+    text: str = "",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO proactive_preference_signals
+          (artifact_id, signal_key, signal_type, weight, score, text, created_at, metadata_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, '{}')
+        """,
+        (
+            artifact_id,
+            signal_key,
+            signal_type,
+            weight,
+            None,
+            text,
+            (created_at or datetime.now(timezone.utc)).isoformat(),
+        ),
+    )
+    conn.commit()
+
+
+# ── Gate scoping ──────────────────────────────────────────────────────────
+
+
+def test_gate_ignores_implicit_park_burst(tmp_path):
+    """A 224-event implicit park burst must not block new briefs."""
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        # Replay the April 2026 poison: 224 implicit park signals against
+        # the convergence pipeline's matching keys.
+        for i in range(224):
+            for key in (
+                "type:convergence_detection",
+                "topic:convergence",
+                "topic:atlas",
+                "topic:research",
+            ):
+                _insert_signal(
+                    conn,
+                    signal_key=key,
+                    weight=-0.1,
+                    signal_type="implicit_outcome",
+                    artifact_id=f"conv-{i}",
+                    text="Outcome: park",
+                )
+        rebuild_preference_snapshot(conn)
+
+        blocked, reason = should_block_proactive_task(
+            conn,
+            task_type="convergence_detection",
+            topic_tags=["convergence", "atlas", "research"],
+        )
+    assert blocked is False, f"implicit-only signals must not block; got reason={reason!r}"
+
+
+def test_gate_blocks_on_strong_explicit_negative(tmp_path):
+    """Explicit feedback at -0.8 across every matching key still blocks."""
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        for key in (
+            "type:tutorial_build",
+            "topic:tutorial",
+            "topic:codie",
+        ):
+            for i in range(3):
+                _insert_signal(
+                    conn,
+                    signal_key=key,
+                    weight=-0.8,
+                    signal_type="explicit_feedback",
+                    artifact_id=f"tut-{key}-{i}",
+                    text="thumbs down",
+                )
+
+        blocked, reason = should_block_proactive_task(
+            conn,
+            task_type="tutorial_build",
+            topic_tags=["tutorial", "codie"],
+        )
+    assert blocked is True
+    assert "explicit-feedback" in reason
+
+
+def test_gate_allows_when_any_explicit_key_is_neutral(tmp_path):
+    """One neutral/positive explicit key short-circuits the block."""
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        _insert_signal(conn, signal_key="type:insight_detection", weight=-0.9, signal_type="explicit_feedback")
+        _insert_signal(conn, signal_key="topic:atlas", weight=-0.9, signal_type="explicit_feedback")
+        # topic:insight has one positive explicit signal — that's enough.
+        _insert_signal(conn, signal_key="topic:insight", weight=0.5, signal_type="explicit_feedback")
+
+        blocked, _ = should_block_proactive_task(
+            conn,
+            task_type="insight_detection",
+            topic_tags=["insight", "atlas"],
+        )
+    assert blocked is False
+
+
+def test_gate_allows_when_only_implicit_signals_exist(tmp_path):
+    """Mixing implicit poison with zero explicit signals → no block."""
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        for _ in range(50):
+            _insert_signal(conn, signal_key="topic:atlas", weight=-0.1, signal_type="implicit_outcome")
+        blocked, _ = should_block_proactive_task(
+            conn, task_type="insight_detection", topic_tags=["atlas"]
+        )
+    assert blocked is False
+
+
+def test_gate_short_circuits_on_no_keys(tmp_path):
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        blocked, reason = should_block_proactive_task(conn, task_type="", topic_tags=[])
+    assert blocked is False
+    assert reason == ""
+
+
+def test_gate_decays_old_explicit_signals(tmp_path):
+    """A very old explicit -0.8 signal decays below the block threshold."""
+    db = tmp_path / "activity_state.db"
+    very_old = datetime.now(timezone.utc) - timedelta(days=120)
+    with _connect(db) as conn:
+        _insert_signal(
+            conn,
+            signal_key="type:insight_detection",
+            weight=-0.8,
+            signal_type="explicit_feedback",
+            created_at=very_old,
+        )
+        blocked, _ = should_block_proactive_task(
+            conn, task_type="insight_detection", topic_tags=[]
+        )
+    # 120 days at 14-day half-life is ~1/365 of original → well above -0.5.
+    assert blocked is False
+
+
+# ── Detox migration ──────────────────────────────────────────────────────
+
+
+def test_detox_dry_run_changes_nothing(tmp_path):
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        for i in range(5):
+            _insert_signal(conn, signal_key="topic:atlas", weight=-0.1, signal_type="implicit_outcome", artifact_id=f"a-{i}")
+        _insert_signal(conn, signal_key="topic:atlas", weight=0.9, signal_type="explicit_feedback", artifact_id="exp-1")
+
+        report = detox(conn, commit=False)
+        rows_after = conn.execute("SELECT COUNT(*) FROM proactive_preference_signals").fetchone()[0]
+
+    assert report["target_rows"] == 5
+    assert report["deleted"] == 0
+    assert report["dry_run"] == 1
+    assert rows_after == 6  # unchanged
+
+
+def test_detox_commit_removes_only_target_type(tmp_path):
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        for i in range(10):
+            _insert_signal(conn, signal_key="topic:atlas", weight=-0.1, signal_type="implicit_outcome", artifact_id=f"a-{i}")
+        _insert_signal(conn, signal_key="topic:atlas", weight=0.9, signal_type="explicit_feedback", artifact_id="exp-1")
+        _insert_signal(conn, signal_key="topic:atlas", weight=-0.8, signal_type="explicit_feedback", artifact_id="exp-2")
+
+        report = detox(conn, commit=True)
+        remaining_types = [
+            r[0] for r in conn.execute(
+                "SELECT DISTINCT signal_type FROM proactive_preference_signals"
+            ).fetchall()
+        ]
+
+    assert report["deleted"] == 10
+    assert report["total_after"] == 2
+    assert remaining_types == ["explicit_feedback"]
+
+
+def test_detox_is_idempotent(tmp_path):
+    db = tmp_path / "activity_state.db"
+    with _connect(db) as conn:
+        for i in range(3):
+            _insert_signal(conn, signal_key="topic:atlas", weight=-0.1, artifact_id=f"a-{i}")
+
+        first = detox(conn, commit=True)
+        second = detox(conn, commit=True)
+
+    assert first["deleted"] == 3
+    assert second["deleted"] == 0
+    assert second["target_rows"] == 0

--- a/tests/unit/test_proactive_pipeline_invariants.py
+++ b/tests/unit/test_proactive_pipeline_invariants.py
@@ -704,5 +704,99 @@ def test_all_ten_invariants_register_on_import() -> None:
         "csi_demo_triage_rank_artifact",
         "paper_to_podcast_email_delivery",
         "vault_lint_contradictions_monthly",
+        "proactive_brief_task_funnel",
     }
     assert expected.issubset(ids)
+
+
+# --- 11. proactive_brief_task_funnel ---
+
+
+def _seeded_funnel_conn() -> sqlite3.Connection:
+    """In-memory activity DB with proactive_artifacts + task_hub_items columns
+    used by the funnel invariant. Schema is the minimal subset we read."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE proactive_artifacts (
+            artifact_id TEXT PRIMARY KEY,
+            source_kind TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        CREATE TABLE task_hub_items (
+            task_id TEXT PRIMARY KEY,
+            source_kind TEXT NOT NULL,
+            created_at TEXT NOT NULL
+        );
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def _seed_artifacts(conn: sqlite3.Connection, *, source_kind: str, n: int, hours_old: float = 1.0) -> None:
+    ts = (datetime.now(UTC) - timedelta(hours=hours_old)).isoformat()
+    for i in range(n):
+        conn.execute(
+            "INSERT INTO proactive_artifacts (artifact_id, source_kind, created_at) VALUES (?, ?, ?)",
+            (f"art-{source_kind}-{i}", source_kind, ts),
+        )
+    conn.commit()
+
+
+def _seed_tasks(conn: sqlite3.Connection, *, source_kind: str, n: int, hours_old: float = 1.0) -> None:
+    ts = (datetime.now(UTC) - timedelta(hours=hours_old)).isoformat()
+    for i in range(n):
+        conn.execute(
+            "INSERT INTO task_hub_items (task_id, source_kind, created_at) VALUES (?, ?, ?)",
+            (f"task-{source_kind}-{i}", source_kind, ts),
+        )
+    conn.commit()
+
+
+def test_funnel_quiet_when_artifacts_and_tasks_keep_pace() -> None:
+    conn = _seeded_funnel_conn()
+    _seed_artifacts(conn, source_kind="convergence_detection", n=12)
+    _seed_tasks(conn, source_kind="convergence_detection", n=10)
+    findings = run_invariants({"activity_conn": conn})
+    assert _only(findings, "proactive_brief_task_funnel") == []
+
+
+def test_funnel_warns_when_artifacts_produce_zero_tasks() -> None:
+    """Replays the May-2026 incident shape: many artifacts, zero queued tasks."""
+    conn = _seeded_funnel_conn()
+    _seed_artifacts(conn, source_kind="insight_detection", n=40)
+    _seed_artifacts(conn, source_kind="convergence_detection", n=30)
+    # tutorial_build is healthy in this scenario — only insight/convergence
+    # pipelines should fire.
+    _seed_artifacts(conn, source_kind="tutorial_build", n=6)
+    _seed_tasks(conn, source_kind="tutorial_build", n=6)
+
+    findings = run_invariants({"activity_conn": conn})
+    matches = _only(findings, "proactive_brief_task_funnel")
+    assert len(matches) == 1
+    obs = matches[0].observed_value
+    starved_kinds = {row["source_kind"] for row in obs["starved_pipelines"]}
+    assert starved_kinds == {"insight_detection", "convergence_detection"}
+
+
+def test_funnel_quiet_when_artifact_volume_below_floor() -> None:
+    """Genuinely slow CSI input — don't false-fire."""
+    conn = _seeded_funnel_conn()
+    _seed_artifacts(conn, source_kind="convergence_detection", n=2)  # below MIN=5
+    findings = run_invariants({"activity_conn": conn})
+    assert _only(findings, "proactive_brief_task_funnel") == []
+
+
+def test_funnel_ignores_artifacts_outside_window() -> None:
+    """Old artifacts past the 48h window shouldn't count."""
+    conn = _seeded_funnel_conn()
+    _seed_artifacts(conn, source_kind="convergence_detection", n=20, hours_old=72.0)
+    findings = run_invariants({"activity_conn": conn})
+    assert _only(findings, "proactive_brief_task_funnel") == []
+
+
+def test_funnel_quiet_when_no_activity_conn() -> None:
+    findings = run_invariants({})
+    assert _only(findings, "proactive_brief_task_funnel") == []


### PR DESCRIPTION
## Summary

The preference gate's hard-block check (`should_block_proactive_task`) was treating implicit park/block outcomes the same as explicit Kevin feedback. A 224-event one-day implicit park burst on 2026-04-18/19 against the convergence/insight pipeline saturated 4 keys at -1.0 and silently suppressed every brief produced afterwards.

**Impact:** Activity DB had **1119 insight + 571 convergence `candidate` artifacts** with zero matching `task_hub_items` rows. The last brief that escaped the gate was 2026-05-18 22:38 UTC. The `csi_convergence_sync` cron was running successfully and writing 397+ artifacts/day — they just had nowhere to land. This is the actual upstream of the digest's "VP Executions = 0 / execution is the bottleneck" line.

## Changes
- **`services/proactive_preferences.py`** — `should_block_proactive_task` now reads only `signal_type='explicit_feedback'` rows (filtered + decayed inline). Implicit outcome signals still feed `score_artifact_for_review` for ranking, just never the hard gate.
- **`scripts/preference_signal_detox.py`** *(new)* — one-shot migration that deletes `signal_type='implicit_outcome'` rows and rebuilds the snapshot. Dry-run by default; `--commit` to apply. Idempotent.
- **`services/invariants/proactive_pipeline_invariants.py`** — new `proactive_brief_task_funnel` invariant. Fires when any proactive `source_kind` shows ≥5 artifacts in 48h with zero matching `task_hub_items` — would have caught this exact failure mode within one watchdog cycle instead of ~5 weeks.
- **Tests** — 9 new gate/detox cases + 5 new funnel cases. 338 proactive/preference/invariant tests pass.

## Post-merge runbook
After deploy completes:
1. Confirm the deploy SHA via `/api/v1/version`.
2. Dry-run the detox: `uv run python -m universal_agent.scripts.preference_signal_detox`.
3. If `target_rows` looks right (~2648 in prod), apply: `... --commit`.
4. Wait one `csi_convergence_sync` cycle (≤30 min) and check `task_hub_items` for new `source_kind=convergence_detection|insight_detection` rows.

## Test plan
- [x] `uv run pytest tests/unit/test_preference_gate_scoping.py` (9 new)
- [x] `uv run pytest tests/unit/test_proactive_pipeline_invariants.py` (28 incl. 5 new)
- [x] `uv run pytest tests/unit/ -k 'proactive or preference or invariant'` (338 pass)
- [x] `uv run ruff check` on changed files
- [x] `py_compile` on changed files
- [ ] Post-deploy: detox dry-run shows expected target row count
- [ ] Post-deploy: convergence briefs produce `task_hub_items` within 30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)