### PR TITLE
fix(cron-disclosure): await notifier inline + INFO-level logs

### DIFF
--- a/src/universal_agent/cron_service.py
+++ b/src/universal_agent/cron_service.py
@@ -2462,27 +2462,47 @@ class CronService:
                                                 # Artifact-disclosure rail. Fires only on
                                                 # clean_exit_zero AND when the cron has
                                                 # ``metadata.notify_on_artifact`` opted in.
-                                                # Best-effort; the notifier swallows every
-                                                # error path so the cron close-out is
-                                                # never disrupted by a mail or LLM hiccup.
+                                                #
+                                                # AWAIT inline (not fire-and-forget). The
+                                                # 2026-05-24 verification showed that
+                                                # ``asyncio.get_running_loop().create_task(...)``
+                                                # without retaining the task reference got
+                                                # garbage-collected when the cron coroutine
+                                                # broke out of its loop. The notifier itself
+                                                # swallows every exception path internally,
+                                                # so awaiting it never raises — at worst we
+                                                # add a few seconds to the close-out, which
+                                                # is fine because this is the cron's last
+                                                # step before the heartbeat-wake. Logs at
+                                                # INFO/WARNING so verification is
+                                                # observable in journalctl.
                                                 if (
                                                     _f_rc_equiv_llm == 0
                                                     and bool((job.metadata or {}).get("notify_on_artifact"))
                                                 ):
+                                                    logger.info(
+                                                        "Phase F.1 cron_artifact_notifier triggered for job %s (opted in)",
+                                                        job.job_id,
+                                                    )
                                                     try:
                                                         from universal_agent import gateway_server as _f_gw_llm
                                                         from universal_agent.services.cron_artifact_notifier import (
-                                                            notify_cron_artifact_fire_and_forget as _f_notify_llm,
+                                                            notify_cron_artifact as _f_notify_llm,
                                                         )
                                                         _f_mail_svc_llm = getattr(_f_gw_llm, "_agentmail_service", None)
-                                                        if _f_mail_svc_llm is not None:
+                                                        if _f_mail_svc_llm is None:
+                                                            logger.warning(
+                                                                "Phase F.1 cron_artifact_notifier SKIPPED for %s: AgentMail service not initialized",
+                                                                job.job_id,
+                                                            )
+                                                        else:
                                                             _f_recipient_llm = _f_gw_llm._proactive_review_recipient("")
                                                             _f_dashboard_base_llm = (
                                                                 os.getenv("FRONTEND_URL", "")
                                                                 or os.getenv("UA_PUBLIC_BASE_URL", "")
                                                                 or "https://app.clearspringcg.com"
                                                             )
-                                                            _f_notify_llm(
+                                                            _f_notify_result_llm = await _f_notify_llm(
                                                                 conn=_f_conn_llm,
                                                                 mail_service=_f_mail_svc_llm,
                                                                 job_id=job.job_id,
@@ -2496,10 +2516,22 @@ class CronService:
                                                                 recipient=_f_recipient_llm,
                                                                 dashboard_base_url=_f_dashboard_base_llm,
                                                             )
+                                                            if _f_notify_result_llm:
+                                                                logger.info(
+                                                                    "Phase F.1 cron_artifact_notifier delivered artifact %s for job %s",
+                                                                    _f_notify_result_llm.get("artifact_id"),
+                                                                    job.job_id,
+                                                                )
+                                                            else:
+                                                                logger.warning(
+                                                                    "Phase F.1 cron_artifact_notifier returned None for job %s (no artifacts or opt-out)",
+                                                                    job.job_id,
+                                                                )
                                                     except Exception as _f_notify_exc_llm:
-                                                        logger.debug(
-                                                            "Phase F.1 cron_artifact_notifier wiring skipped for job %s: %s",
+                                                        logger.warning(
+                                                            "Phase F.1 cron_artifact_notifier RAISED for job %s: %s",
                                                             job.job_id, _f_notify_exc_llm,
+                                                            exc_info=True,
                                                         )
                                             finally:
                                                 _f_conn_llm.close()


### PR DESCRIPTION
## Summary
Tonight's verification of PR #446 + #448 surfaced a silent failure: the cron reached \`clean_exit_zero\` but the disclosure rail never ran. No artifact row, no email, no \`project_key\` promotion, no journal trace.

## Root cause
Two compounding bugs:

1. **Fire-and-forget task GC'd.** The hook called \`asyncio.get_running_loop().create_task(_wrapper())\` without retaining the task reference. The cron coroutine \`break\`s out of its loop immediately after, and Python garbage-collects the orphan task before it runs. Known asyncio footgun.
2. **All exceptions logged at \`logger.debug\`.** Default systemd journal level is INFO+, so any failure inside the hook was invisible — we couldn't tell whether the hook never ran, ran-and-skipped, or ran-and-raised.

## Verification trace (asg_cron_92505bedff3547a9)
- 21:14:42 cron started
- 21:26:09 \`Phase F.1 LLM cron job 2afe05ab96 exit classified as clean_exit_zero\`
- 21:26:10 \`Heartbeat wake-next requested for cron_paper_to_podcast\`
- **Zero log lines in between** — exactly where my hook should have logged its INFO trace.

\`proactive_artifacts\` query: no \`cron_run_output\` rows. \`task_hub_items.project_key\`: still \`immediate\`. The hook code IS deployed on prod (verified file mtime + grep'd content) — it just didn't make any observable progress.

## Fix
- Switch from \`notify_cron_artifact_fire_and_forget\` to \`await notify_cron_artifact(...)\` inline. The notifier already catches every internal exception, so awaiting can't raise. Adds at most a few seconds to the close-out, which is fine — the cron is already done by this point.
- Bump every branch log to INFO/WARNING with explicit messages:
  - "triggered for job X (opted in)" before the call
  - "delivered artifact pa_X for job Y" on success
  - "SKIPPED ... AgentMail service not initialized" when \`_agentmail_service is None\`
  - "returned None ... (no artifacts or opt-out)" when notifier short-circuits
  - "RAISED ... %s" with \`exc_info=True\` for tracebacks
- Now every dispatch outcome is observable in journalctl without bumping the global log level.

## Test plan
- [x] \`pytest tests/unit/test_cron_artifact_notifier.py\` — 15 tests still pass (the change is in cron_service.py call site, not the notifier itself)
- [x] \`pytest tests/unit/test_cron_llm_path_f_observability.py\` — 8 tests pass, F.1 close-out path regression-clean
- [x] \`py_compile\` + \`ruff E9,F\` clean
- [ ] Post-deploy: fire paper_to_podcast manually; expect:
  - journalctl shows "Phase F.1 cron_artifact_notifier triggered for job 2afe05ab96 (opted in)"
  - journalctl shows "Phase F.1 cron_artifact_notifier delivered artifact pa_X for job 2afe05ab96"
  - Email arrives at kevinjdragan@gmail.com with subject "[2afe05ab96] ..." or "[paper_to_podcast_daily] ..."
  - \`proactive_artifacts\` has a new \`cron_run_output\` row
  - \`task_hub_items.project_key\` flips to 'proactive'

🤖 Generated with [Claude Code](https://claude.com/claude-code)