### PR TITLE
fix(cron-disclosure): use derive_cron_task_id; recipient fix via Infisical

### DIFF
--- a/src/universal_agent/services/cron_artifact_notifier.py
+++ b/src/universal_agent/services/cron_artifact_notifier.py
@@ -123,12 +123,20 @@ async def notify_cron_artifact(
         )
 
         # Task Hub cross-reference. The F.1 close-out path creates a
-        # ``cron:<job_id>`` row in ``task_hub_items``. We link the
-        # artifact to that task_id so the Proactive Task History tab's
-        # cross-join (gateway_server._proactive_artifacts_by_task) finds
-        # it. Without this link, the artifact lives in proactive_artifacts
-        # but never surfaces alongside the cron task in the dashboard.
-        linked_task_id = f"cron:{job_id}"
+        # ``cron:<system_job>`` row in ``task_hub_items`` via
+        # ``derive_cron_task_id`` (cron_task_hub_link.py:82). Use that
+        # same helper so our linkage matches — using ``cron:<job_id>``
+        # (the hash) would point at a row that doesn't exist and the
+        # Proactive Task History tab's cross-join would silently miss
+        # the artifact.
+        from universal_agent.services.cron_task_hub_link import (
+            derive_cron_task_id,
+        )
+        _system_job = str((job_metadata or {}).get("system_job") or "").strip()
+        linked_task_id = derive_cron_task_id(
+            system_job=_system_job or None,
+            job_id=job_id,
+        ) or f"cron:{job_id}"
 
         proactive_artifacts.ensure_schema(conn)
         artifact = proactive_artifacts.upsert_artifact(

--- a/tests/unit/test_cron_artifact_notifier.py
+++ b/tests/unit/test_cron_artifact_notifier.py
@@ -333,6 +333,45 @@ async def test_notifier_promotes_cron_task_to_proactive(
 
 
 @pytest.mark.asyncio
+async def test_notifier_uses_system_job_for_task_id_when_present(
+    conn, mail_service, workspace
+) -> None:
+    """Regression for 2026-05-24: the prod cron has job_id='2afe05ab96'
+    (a hash) but metadata.system_job='paper_to_podcast_daily'. The
+    canonical Task Hub row is cron:paper_to_podcast_daily, NOT
+    cron:2afe05ab96. The notifier must use the system_job-derived
+    task_id (matching derive_cron_task_id in cron_task_hub_link.py)
+    or the project_key promotion silently matches zero rows."""
+    _create_cron_task_hub_row(conn, task_id="cron:paper_to_podcast_daily")
+    _write_manifest(workspace, [{"title": "x", "path": "work_products/x"}])
+    artifact = await notify_cron_artifact(
+        conn=conn,
+        mail_service=mail_service,
+        job_id="2afe05ab96",  # hash, NOT the canonical name
+        job_metadata={
+            "notify_on_artifact": True,
+            "system_job": "paper_to_podcast_daily",
+        },
+        job_command="run",
+        workspace_dir=workspace,
+        started_at=1779600000.0,
+        finished_at=1779600300.0,
+        recipient="kevinjdragan@gmail.com",
+    )
+    assert artifact is not None
+    meta = artifact.get("metadata") or {}
+    # CRITICAL: task_id derived from system_job, not job_id
+    assert meta["task_id"] == "cron:paper_to_podcast_daily"
+    # And the promotion landed on the right row:
+    row = conn.execute(
+        "SELECT project_key FROM task_hub_items WHERE task_id=?",
+        ("cron:paper_to_podcast_daily",),
+    ).fetchone()
+    assert row is not None
+    assert row[0] == "proactive"
+
+
+@pytest.mark.asyncio
 async def test_notifier_missing_task_hub_row_no_crash(
     conn, mail_service, workspace
 ) -> None:


### PR DESCRIPTION
## Summary
The 22:06 verification (PR #450 deployed) confirmed the disclosure rail is alive — artifact created, email sent, journal logs visible — but surfaced two real bugs:

1. **Wrong recipient.** Email went to \`kevin.dragan@outlook.com\` instead of \`kevinjdragan@gmail.com\`. \`UA_PRIMARY_EMAIL\` was outlook in Infisical and beat \`UA_NOTIFICATION_EMAIL\` in the resolver's priority order. Per operator preference memory, gmail is the durable address.

2. **\`task_id\` mismatch in artifact linkage.** My notifier used \`f"cron:{job_id}"\` → \`cron:2afe05ab96\` (the hash). But the canonical Task Hub task_id (created by \`derive_cron_task_id\` in \`cron_task_hub_link.py\`) is \`cron:{system_job}\` → \`cron:paper_to_podcast_daily\`. The UPDATE matched zero rows; the dashboard cross-join misses the artifact.

## Fixes

### Code (this PR)
- Import \`derive_cron_task_id\` from \`cron_task_hub_link\` and use it inside the notifier so the linkage matches the F.1 close-out's convention.
- Falls back to \`cron:{job_id}\` if neither \`system_job\` nor \`job_id\` is usable (matches the helper's contract).
- New regression test \`test_notifier_uses_system_job_for_task_id_when_present\` — exercises the prod scenario (hash \`job_id="2afe05ab96"\` + named \`system_job="paper_to_podcast_daily"\`) and asserts the artifact \`metadata.task_id\` is the named form AND the Task Hub row is promoted to \`project_key='proactive'\`. The existing tests passed before this regression because they used matching \`job_id\` and seeded task_id — only this new test catches the prod failure mode.

### Infisical (applied directly to production)
- Set \`UA_PROACTIVE_REVIEW_EMAIL=kevinjdragan@gmail.com\` in the production env. This is the highest-priority env in \`_proactive_review_recipient\`, so it overrides the existing \`UA_PRIMARY_EMAIL=kevin.dragan@outlook.com\` for proactive-review surfaces only. Surgical — leaves UA_PRIMARY_EMAIL alone in case other services intentionally depend on it.

## Verification target
After this PR ships, fire \`paper_to_podcast_daily\` and confirm:
- Email lands at \`kevinjdragan@gmail.com\` (not outlook)
- \`proactive_artifacts.metadata.task_id = 'cron:paper_to_podcast_daily'\`
- \`task_hub_items WHERE task_id='cron:paper_to_podcast_daily'\` has \`project_key='proactive'\`
- Cron now appears in the Proactive Task History dashboard tab

## Test plan
- [x] \`pytest tests/unit/test_cron_artifact_notifier.py\` — 16 tests pass (1 new)
- [x] \`py_compile\` + \`ruff E9,F\` clean
- [ ] Post-deploy: re-fire cron, validate email recipient + task_id + project_key + tab visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)