### PR TITLE
fix(email-noise): CSI 402 backoff + cron_artifact_reminders_sweep self-contained mail

### DIFF
--- a/src/universal_agent/scripts/claude_code_intel_run_report.py
+++ b/src/universal_agent/scripts/claude_code_intel_run_report.py
@@ -258,19 +258,35 @@ async def main() -> int:
             all_results.append(handle_payload)
             if result.ok:
                 any_ok = True
-                # Emit CSI activity event for dashboard visibility
-                try:
-                    emit_csi_activity_event(
-                        conn,
-                        handle=handle,
-                        new_post_count=result.new_post_count,
-                        action_count=result.action_count,
-                        queued_task_count=int(post_process.get("queued_task_count") or result.queued_task_count),
-                        packet_dir=result.packet_dir or "",
-                        actions=result.actions,
+                # X API quota cooldown short-circuit. When run_sync
+                # detected a prior HTTP 402 (CreditsDepleted) and
+                # short-circuited this fire, ``quota_cooldown_until_iso``
+                # is set. Skip the activity-event emission entirely so
+                # the operator does not receive one "sync completed"
+                # email per scheduled fire while credits are depleted.
+                # The first 402 that triggered the cooldown already
+                # fired its csi_sync_failed alarm — that one email is
+                # the operator's signal to act.
+                if getattr(result, "quota_cooldown_until_iso", ""):
+                    logger.info(
+                        "Handle @%s: silent skip — X API quota cooldown "
+                        "active until %s. No activity event emitted.",
+                        handle, result.quota_cooldown_until_iso,
                     )
-                except Exception:
-                    logger.warning("Failed to emit CSI activity event for @%s", handle, exc_info=True)
+                else:
+                    # Emit CSI activity event for dashboard visibility
+                    try:
+                        emit_csi_activity_event(
+                            conn,
+                            handle=handle,
+                            new_post_count=result.new_post_count,
+                            action_count=result.action_count,
+                            queued_task_count=int(post_process.get("queued_task_count") or result.queued_task_count),
+                            packet_dir=result.packet_dir or "",
+                            actions=result.actions,
+                        )
+                    except Exception:
+                        logger.warning("Failed to emit CSI activity event for @%s", handle, exc_info=True)
                 # Write a per-handle operator report only when there are actual
                 # new posts — empty polls don't need operator reports.
                 if result.packet_dir and result.new_post_count > 0:

--- a/src/universal_agent/scripts/cron_artifact_reminders_sweep.py
+++ b/src/universal_agent/scripts/cron_artifact_reminders_sweep.py
@@ -3,45 +3,208 @@
 Invoked by the gateway-registered ``cron_artifact_reminders_sweep``
 system cron (default every 30 minutes during 6 AM – 10 PM Houston).
 Calls ``cron_artifact_reminders.sweep_pending_artifact_reminders``
-and exits 0 on success, 1 if no mail service is available.
+and exits 0 on success.
 
-Designed to be lightweight: no SDK turn, just direct DB + AgentMail.
+Design notes
+------------
+
+The original (2026-05-24 / PR #446) version tried to share the
+gateway's ``_agentmail_service`` singleton via
+``getattr(gateway_server, "_agentmail_service", None)``. That always
+returned ``None`` because:
+
+  1. The gateway runs as ``python -m universal_agent.gateway_server``,
+     so its live module is ``sys.modules['__main__']``.
+  2. The cron-service ``!script`` runner spawns this file as a FRESH
+     Python subprocess. The subprocess's import path loads the gateway
+     under the qualified name ``universal_agent.gateway_server`` — a
+     SEPARATE module copy whose ``_agentmail_service`` is the pristine
+     ``None`` declaration.
+
+So we have to use a send path that does not depend on the parent
+gateway's in-memory state. This module wraps ``AsyncAgentMail``
+directly to give the reminder sweep an interface-compatible mail
+service shim it can call.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import sys
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
 
+# ── Send-only mail service shim ────────────────────────────────────────
+
+
+class _SubprocessMailService:
+    """Minimal interface matching ``AgentMailService.send_email`` that the
+    reminder sweep depends on.
+
+    Initialised lazily; resolves the inbox on first send by hitting the
+    AgentMail control plane. Reuses the same ``AsyncAgentMail`` SDK
+    client the parent gateway uses, so deliverability behaviour matches.
+    """
+
+    def __init__(self) -> None:
+        self._client: Any = None
+        self._inbox_id: Optional[str] = None
+        self._inbox_address: Optional[str] = None
+
+    async def _ensure_ready(self) -> bool:
+        if self._client is not None and self._inbox_id:
+            return True
+        try:
+            from agentmail import AsyncAgentMail  # type: ignore[import]
+        except ImportError:
+            logger.warning(
+                "cron_artifact_reminders_sweep: agentmail SDK not installed; "
+                "cannot send reminder emails."
+            )
+            return False
+
+        api_key = (os.getenv("AGENTMAIL_API_KEY") or "").strip()
+        if not api_key:
+            logger.warning(
+                "cron_artifact_reminders_sweep: AGENTMAIL_API_KEY not set; "
+                "cannot send reminder emails."
+            )
+            return False
+
+        self._client = AsyncAgentMail(api_key=api_key, timeout=30)
+        configured = (os.getenv("UA_AGENTMAIL_INBOX_ADDRESS") or "").strip()
+        try:
+            if configured:
+                inbox = await self._client.inboxes.get(inbox_id=configured)
+            else:
+                # No address pinned — resolve via the list endpoint and
+                # pick the first inbox. Operator typically has a single
+                # inbox (Simone's), so this is unambiguous in practice.
+                listing = await self._client.inboxes.list()
+                inboxes = getattr(listing, "inboxes", None) or getattr(listing, "data", None) or []
+                if not inboxes:
+                    logger.warning(
+                        "cron_artifact_reminders_sweep: AgentMail has no inboxes; "
+                        "cannot send reminder emails."
+                    )
+                    return False
+                inbox = inboxes[0]
+            self._inbox_id = str(getattr(inbox, "inbox_id", None) or getattr(inbox, "id", "") or "")
+            self._inbox_address = str(getattr(inbox, "address", "") or self._inbox_id)
+            return bool(self._inbox_id)
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning(
+                "cron_artifact_reminders_sweep: inbox resolution failed: %s", exc
+            )
+            return False
+
+    async def send_email(
+        self,
+        *,
+        to: str,
+        subject: str,
+        text: str,
+        html: Optional[str] = None,
+        force_send: bool = True,
+        require_approval: bool = False,
+        action: Any = None,
+        kind: Any = None,
+        source: Optional[str] = None,
+        related: Any = None,
+        attachments: Optional[list[dict[str, Any]]] = None,
+        labels: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        """Send the email via the AgentMail SDK and return a result dict
+        with ``status``, ``message_id``, ``thread_id`` to match the
+        gateway's ``AgentMailService.send_email`` shape (reminder code
+        reads ``message_id`` / ``thread_id`` from this dict)."""
+        if not await self._ensure_ready():
+            return {"status": "skipped", "message_id": "", "thread_id": ""}
+
+        # Apply [ACTION/KIND] subject prefix + banner if both tags are
+        # provided, mirroring AgentMailService.send_email so categorised
+        # reminders look identical to those from the parent gateway.
+        try:
+            if action is not None and kind is not None:
+                from universal_agent.services.email_tags import (
+                    format_body_header,
+                    format_tagged_subject,
+                )
+
+                subject = format_tagged_subject(action, kind, subject)
+                html_banner, text_banner = format_body_header(
+                    action, kind, source or "", related=related,
+                )
+                text = text_banner + (text or "")
+                if html:
+                    html = html_banner + html
+        except Exception:  # noqa: BLE001 — formatting is decorative
+            pass
+
+        kwargs: dict[str, Any] = {
+            "inbox_id": self._inbox_id,
+            "to": to,
+            "subject": subject,
+            "text": text,
+        }
+        if html:
+            kwargs["html"] = html
+        if attachments:
+            kwargs["attachments"] = attachments
+        if labels:
+            kwargs["labels"] = labels
+
+        try:
+            msg = await self._client.inboxes.messages.send(**kwargs)
+            message_id = str(getattr(msg, "message_id", "") or "")
+            thread_id = str(getattr(msg, "thread_id", "") or "")
+            logger.info(
+                "cron_artifact_reminders_sweep: sent email to=%s subject=%r message_id=%s",
+                to, subject, message_id,
+            )
+            return {
+                "status": "sent",
+                "message_id": message_id,
+                "thread_id": thread_id,
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "cron_artifact_reminders_sweep: send_email failed: %s", exc
+            )
+            return {"status": "failed", "message_id": "", "thread_id": "", "error": str(exc)}
+
+
+# ── Cron entry point ───────────────────────────────────────────────────
+
+
 async def _async_main() -> int:
     # Lazy imports so a partial install doesn't crash before logging is configured.
-    from universal_agent import gateway_server
+    from universal_agent.durable.db import connect_runtime_db, get_activity_db_path
     from universal_agent.services.cron_artifact_reminders import (
         sweep_pending_artifact_reminders,
     )
 
-    mail_service = getattr(gateway_server, "_agentmail_service", None)
-    if mail_service is None:
-        logger.warning(
-            "cron_artifact_reminders_sweep: AgentMail service not initialized; nothing to do"
-        )
-        return 1
+    mail_service = _SubprocessMailService()
 
-    recipient = gateway_server._proactive_review_recipient("")
-    import os as _os
+    # Recipient resolver (replicates gateway_server._proactive_review_recipient).
+    recipient = (
+        os.getenv("UA_PROACTIVE_REVIEW_EMAIL", "").strip()
+        or os.getenv("UA_MORNING_REPORT_EMAIL", "").strip()
+        or os.getenv("UA_PRIMARY_EMAIL", "").strip()
+        or os.getenv("UA_NOTIFICATION_EMAIL", "").strip()
+        or "kevinjdragan@gmail.com"
+    )
     dashboard_base_url = (
-        _os.getenv("FRONTEND_URL", "")
-        or _os.getenv("UA_PUBLIC_BASE_URL", "")
+        os.getenv("FRONTEND_URL", "")
+        or os.getenv("UA_PUBLIC_BASE_URL", "")
         or "https://app.clearspringcg.com"
     )
 
-    # Use the gateway's own activity connection helper to share the
-    # same SQLite tuning (busy_timeout etc.) as every other writer.
-    conn = gateway_server._activity_connect()
+    conn = connect_runtime_db(get_activity_db_path())
     try:
         report = await sweep_pending_artifact_reminders(
             conn=conn,

--- a/src/universal_agent/services/claude_code_intel.py
+++ b/src/universal_agent/services/claude_code_intel.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import hashlib
 import hmac
 import json
@@ -19,7 +19,7 @@ from pathlib import Path
 import re
 import sqlite3
 import time
-from typing import Any
+from typing import Any, Optional
 from urllib.parse import quote, urlsplit
 
 import httpx
@@ -245,6 +245,13 @@ class ClaudeCodeIntelRun:
     artifact_id: str = ""
     error: str = ""
     actions: list[dict[str, Any]] = field(default_factory=list)
+    # 2026-05-25: quota cooldown. When the X API returns HTTP 402
+    # (CreditsDepleted), subsequent runs within the cooldown window
+    # short-circuit and set ``quota_cooldown_until_iso``. The cron
+    # script reads this and suppresses the failure-event email so the
+    # operator gets ONE alarm per cooldown window, not one per
+    # scheduled fire.
+    quota_cooldown_until_iso: str = ""
 
 
 def resolve_lane_root(artifacts_root: Path | None = None) -> Path:
@@ -266,6 +273,106 @@ def get_x_bearer_token() -> str:
     return ""
 
 
+# ── X API quota cooldown (HTTP 402 backoff) ─────────────────────────────
+#
+# Background: the X API can return HTTP 402 "CreditsDepleted" when the
+# account's monthly credits are exhausted. Without a cooldown, every
+# scheduled CSI sync (8am/4pm/10pm Houston × 2 handles × N restart
+# catch-ups) keeps hammering the API and fires an error email each time —
+# tonight's run produced 12 csi_sync_failed events for what is really a
+# single operational state: "credits empty, top up needed."
+#
+# The cooldown writes a small JSON state file per handle. Subsequent
+# runs within the window short-circuit before hitting the API. The
+# first 402 of a new window still fires its alarm (one email per
+# cooldown window). Default 24h; configurable via
+# UA_CSI_QUOTA_COOLDOWN_HOURS.
+
+
+_DEFAULT_QUOTA_COOLDOWN_HOURS = 24.0
+
+
+def _quota_cooldown_path(lane_root: Path, handle: str) -> Path:
+    safe_handle = re.sub(r"[^A-Za-z0-9_.-]+", "-", handle.strip().lstrip("@")) or DEFAULT_HANDLE
+    return lane_root / f"quota_cooldown__{safe_handle}.json"
+
+
+def _quota_cooldown_hours() -> float:
+    raw = (os.getenv("UA_CSI_QUOTA_COOLDOWN_HOURS") or "").strip()
+    if raw:
+        try:
+            return max(0.5, float(raw))
+        except ValueError:
+            pass
+    return _DEFAULT_QUOTA_COOLDOWN_HOURS
+
+
+def _read_quota_cooldown(path: Path) -> Optional[dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _cooldown_active(record: Optional[dict[str, Any]]) -> Optional[str]:
+    """Return the ``until_iso`` string if the cooldown is still in effect,
+    else None. ``record`` is the parsed cooldown JSON."""
+    if not record:
+        return None
+    until_iso = str(record.get("until_iso") or "").strip()
+    if not until_iso:
+        return None
+    try:
+        until_dt = datetime.fromisoformat(until_iso.replace("Z", "+00:00"))
+        if until_dt.tzinfo is None:
+            until_dt = until_dt.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) < until_dt:
+            return until_iso
+    except (ValueError, TypeError):
+        return None
+    return None
+
+
+def _write_quota_cooldown(path: Path, *, reason: str, hours: float) -> str:
+    """Write a cooldown file blocking subsequent runs for ``hours``.
+
+    Returns the ``until_iso`` timestamp written. Best-effort — if the
+    write fails (read-only FS, race), returns "" and the caller falls
+    through to the normal error path.
+    """
+    now = datetime.now(timezone.utc)
+    until = now + timedelta(hours=hours)
+    until_iso = until.isoformat()
+    payload = {
+        "set_at_iso": now.isoformat(),
+        "until_iso": until_iso,
+        "reason": reason,
+        "cooldown_hours": hours,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return until_iso
+    except OSError as exc:
+        logger.warning(
+            "CSI quota cooldown write failed for %s: %s", path, exc
+        )
+        return ""
+
+
+def _is_quota_exhausted_error(error_text: str) -> bool:
+    """Heuristic match for X API HTTP 402 / credits-depleted responses."""
+    lowered = (error_text or "").lower()
+    return ("http 402" in lowered) or ("creditsdepleted" in lowered) or (
+        "credits depleted" in lowered
+    )
+
+
 def run_sync(
     *,
     config: ClaudeCodeIntelConfig | None = None,
@@ -281,6 +388,29 @@ def run_sync(
     cfg = config or ClaudeCodeIntelConfig.from_env()
     generated_at = _now_iso()
     lane_root = resolve_lane_root(cfg.artifacts_root)
+
+    # Quota-cooldown short-circuit. If a previous run hit HTTP 402 and
+    # the cooldown window hasn't expired, return early without touching
+    # the X API. ``ok=True`` so the cron script doesn't emit a
+    # csi_sync_failed event (which would mail the operator). The
+    # quota_cooldown_until_iso field tells the cron script this was a
+    # silent skip, not a real success.
+    cooldown_path = _quota_cooldown_path(lane_root, cfg.handle)
+    cooldown_record = _read_quota_cooldown(cooldown_path)
+    cooldown_until = _cooldown_active(cooldown_record)
+    if cooldown_until:
+        logger.info(
+            "📡 CSI poll @%s: skipped — X API quota cooldown active until %s",
+            cfg.handle,
+            cooldown_until,
+        )
+        return ClaudeCodeIntelRun(
+            ok=True,
+            generated_at=generated_at,
+            handle=cfg.handle,
+            quota_cooldown_until_iso=cooldown_until,
+        )
+
     packet_dir = _new_packet_dir(lane_root, handle=cfg.handle, generated_at=generated_at)
     packet_dir.mkdir(parents=True, exist_ok=True)
     if conn is not None and conn.row_factory is None:
@@ -486,6 +616,24 @@ def run_sync(
         return run
     except Exception as exc:
         error = str(exc)
+        # X API HTTP 402 detection. Write a cooldown file so subsequent
+        # scheduled fires short-circuit instead of hammering the API and
+        # producing one error email per fire. The FIRST 402 of a fresh
+        # cycle still emits its csi_sync_failed event (the operator's
+        # alarm to top up credits); subsequent fires in the cooldown
+        # window are silenced upstream by the cooldown check in run_sync.
+        if _is_quota_exhausted_error(error):
+            hours = _quota_cooldown_hours()
+            until_iso = _write_quota_cooldown(
+                cooldown_path, reason=error, hours=hours,
+            )
+            if until_iso:
+                logger.warning(
+                    "CSI @%s: X API quota exhausted (%s). Cooldown set "
+                    "for %.1fh — next attempt after %s.",
+                    cfg.handle, error[:200], hours, until_iso,
+                )
+                run.quota_cooldown_until_iso = until_iso
         write_reference_kb_update(
             packet_dir=packet_dir,
             handle=cfg.handle,

--- a/tests/unit/test_cron_artifact_reminders_sweep.py
+++ b/tests/unit/test_cron_artifact_reminders_sweep.py
@@ -1,0 +1,137 @@
+"""Tests for the cron_artifact_reminders_sweep script's mail-service shim.
+
+PR #446 wired the sweep as a !script subprocess that called
+``getattr(gateway_server, '_agentmail_service', None)`` — which always
+returned None in a subprocess because the gateway's lifespan startup
+never runs there (separate module copy). This test guards the
+replacement shim: a self-contained ``AsyncAgentMail`` wrapper that
+matches the parent gateway's ``send_email`` interface.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from universal_agent.scripts.cron_artifact_reminders_sweep import (
+    _SubprocessMailService,
+)
+
+
+@pytest.mark.asyncio
+async def test_send_email_returns_skipped_when_no_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENTMAIL_API_KEY", raising=False)
+    svc = _SubprocessMailService()
+    result = await svc.send_email(
+        to="kevinjdragan@gmail.com",
+        subject="test",
+        text="hi",
+    )
+    assert result["status"] == "skipped"
+    assert result["message_id"] == ""
+
+
+@pytest.mark.asyncio
+async def test_send_email_succeeds_when_sdk_returns_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stub the ``AsyncAgentMail`` SDK to confirm the shim parses its
+    response into the expected ``{status, message_id, thread_id}``
+    shape — matching what the cron_artifact_reminders sweep expects."""
+    monkeypatch.setenv("AGENTMAIL_API_KEY", "test-key-123")
+    monkeypatch.setenv("UA_AGENTMAIL_INBOX_ADDRESS", "test@agentmail.to")
+
+    fake_inbox = MagicMock()
+    fake_inbox.inbox_id = "inbox_abc"
+    fake_inbox.address = "test@agentmail.to"
+
+    fake_msg = MagicMock()
+    fake_msg.message_id = "msg_xyz"
+    fake_msg.thread_id = "thread_xyz"
+
+    fake_client = MagicMock()
+    fake_client.inboxes.get = AsyncMock(return_value=fake_inbox)
+    fake_client.inboxes.messages.send = AsyncMock(return_value=fake_msg)
+
+    # Stub the SDK import so we don't need the real package.
+    import sys
+    import types
+    fake_module = types.ModuleType("agentmail")
+    fake_module.AsyncAgentMail = MagicMock(return_value=fake_client)
+    monkeypatch.setitem(sys.modules, "agentmail", fake_module)
+
+    svc = _SubprocessMailService()
+    result = await svc.send_email(
+        to="kevinjdragan@gmail.com",
+        subject="Test artifact reminder",
+        text="reminder text",
+        html="<p>reminder html</p>",
+    )
+
+    assert result["status"] == "sent"
+    assert result["message_id"] == "msg_xyz"
+    assert result["thread_id"] == "thread_xyz"
+    # Confirm the SDK was called with the resolved inbox + recipient
+    fake_client.inboxes.messages.send.assert_called_once()
+    call_kwargs = fake_client.inboxes.messages.send.call_args.kwargs
+    assert call_kwargs["inbox_id"] == "inbox_abc"
+    assert call_kwargs["to"] == "kevinjdragan@gmail.com"
+
+
+@pytest.mark.asyncio
+async def test_send_email_returns_failed_on_sdk_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTMAIL_API_KEY", "test-key-123")
+    monkeypatch.setenv("UA_AGENTMAIL_INBOX_ADDRESS", "test@agentmail.to")
+
+    fake_inbox = MagicMock()
+    fake_inbox.inbox_id = "inbox_abc"
+
+    fake_client = MagicMock()
+    fake_client.inboxes.get = AsyncMock(return_value=fake_inbox)
+    fake_client.inboxes.messages.send = AsyncMock(
+        side_effect=RuntimeError("AgentMail upstream 503")
+    )
+
+    import sys
+    import types
+    fake_module = types.ModuleType("agentmail")
+    fake_module.AsyncAgentMail = MagicMock(return_value=fake_client)
+    monkeypatch.setitem(sys.modules, "agentmail", fake_module)
+
+    svc = _SubprocessMailService()
+    result = await svc.send_email(
+        to="kevinjdragan@gmail.com",
+        subject="test",
+        text="hi",
+    )
+    assert result["status"] == "failed"
+    assert "AgentMail upstream 503" in result.get("error", "")
+
+
+@pytest.mark.asyncio
+async def test_send_email_returns_skipped_when_sdk_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the agentmail package isn't installed, the shim must return
+    skipped (not crash). Production has the SDK, but tests / dev boxes
+    might not."""
+    monkeypatch.setenv("AGENTMAIL_API_KEY", "test-key-123")
+
+    import sys
+    # Force the import to fail by shadowing with a non-module sentinel.
+    real_module = sys.modules.pop("agentmail", None)
+    monkeypatch.setitem(sys.modules, "agentmail", None)
+    try:
+        svc = _SubprocessMailService()
+        result = await svc.send_email(
+            to="kevinjdragan@gmail.com", subject="test", text="hi",
+        )
+        assert result["status"] == "skipped"
+    finally:
+        if real_module is not None:
+            sys.modules["agentmail"] = real_module

--- a/tests/unit/test_csi_quota_cooldown.py
+++ b/tests/unit/test_csi_quota_cooldown.py
@@ -1,0 +1,115 @@
+"""Tests for the CSI X-API quota cooldown.
+
+When the X API returns HTTP 402 (CreditsDepleted), the next ~24 hours
+of scheduled CSI syncs should short-circuit before hitting the API and
+NOT emit csi_sync_failed events (which would mail the operator every
+fire). The FIRST 402 of a fresh cycle still alarms; subsequent fires
+are silent until the cooldown expires.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from universal_agent.services.claude_code_intel import (
+    _cooldown_active,
+    _is_quota_exhausted_error,
+    _quota_cooldown_hours,
+    _quota_cooldown_path,
+    _read_quota_cooldown,
+    _write_quota_cooldown,
+)
+
+
+def test_402_error_string_detected() -> None:
+    assert _is_quota_exhausted_error("X API request failed: HTTP 402: CreditsDepleted")
+    assert _is_quota_exhausted_error("Got HTTP 402 from upstream")
+    assert _is_quota_exhausted_error("creditsdepleted error from twitter")
+
+
+def test_other_errors_not_detected() -> None:
+    assert not _is_quota_exhausted_error("HTTP 500 internal server error")
+    assert not _is_quota_exhausted_error("missing X_BEARER_TOKEN")
+    assert not _is_quota_exhausted_error("")
+    assert not _is_quota_exhausted_error("HTTP 401: Unauthorized")
+
+
+def test_cooldown_path_per_handle(tmp_path: Path) -> None:
+    p1 = _quota_cooldown_path(tmp_path, "bcherny")
+    p2 = _quota_cooldown_path(tmp_path, "ClaudeDevs")
+    assert p1 != p2
+    assert p1.name == "quota_cooldown__bcherny.json"
+    assert p2.name == "quota_cooldown__ClaudeDevs.json"
+    # Leading @ stripped.
+    p3 = _quota_cooldown_path(tmp_path, "@bcherny")
+    assert p3 == p1
+
+
+def test_write_and_read_cooldown_round_trip(tmp_path: Path) -> None:
+    path = _quota_cooldown_path(tmp_path, "bcherny")
+    until_iso = _write_quota_cooldown(path, reason="HTTP 402", hours=24.0)
+    assert until_iso
+    assert path.exists()
+    record = _read_quota_cooldown(path)
+    assert record is not None
+    assert record["reason"] == "HTTP 402"
+    assert record["cooldown_hours"] == 24.0
+    assert record["until_iso"] == until_iso
+
+
+def test_cooldown_active_returns_until_iso_when_in_window(tmp_path: Path) -> None:
+    path = _quota_cooldown_path(tmp_path, "bcherny")
+    _write_quota_cooldown(path, reason="HTTP 402", hours=24.0)
+    record = _read_quota_cooldown(path)
+    assert _cooldown_active(record) is not None
+
+
+def test_cooldown_expired_returns_none(tmp_path: Path) -> None:
+    """Cooldown record whose ``until_iso`` is in the past should not
+    suppress subsequent syncs."""
+    record = {
+        "set_at_iso": "2026-05-01T00:00:00+00:00",
+        "until_iso": "2026-05-02T00:00:00+00:00",  # well in the past
+        "reason": "HTTP 402",
+        "cooldown_hours": 24.0,
+    }
+    assert _cooldown_active(record) is None
+
+
+def test_cooldown_missing_file_returns_none(tmp_path: Path) -> None:
+    path = _quota_cooldown_path(tmp_path, "bcherny")
+    # No file written.
+    assert _read_quota_cooldown(path) is None
+    assert _cooldown_active(None) is None
+
+
+def test_cooldown_corrupt_file_returns_none(tmp_path: Path) -> None:
+    path = _quota_cooldown_path(tmp_path, "bcherny")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("not valid json {{", encoding="utf-8")
+    assert _read_quota_cooldown(path) is None
+
+
+def test_cooldown_hours_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UA_CSI_QUOTA_COOLDOWN_HOURS", "6")
+    assert _quota_cooldown_hours() == 6.0
+    monkeypatch.setenv("UA_CSI_QUOTA_COOLDOWN_HOURS", "not-a-number")
+    assert _quota_cooldown_hours() == 24.0  # default fallback
+    monkeypatch.delenv("UA_CSI_QUOTA_COOLDOWN_HOURS", raising=False)
+    assert _quota_cooldown_hours() == 24.0
+    # Floor at 0.5h so an accidental "0" doesn't disable the cooldown.
+    monkeypatch.setenv("UA_CSI_QUOTA_COOLDOWN_HOURS", "0")
+    assert _quota_cooldown_hours() == 0.5
+
+
+def test_cooldown_record_with_malformed_until_iso_returns_none() -> None:
+    record = {
+        "set_at_iso": "2026-05-25T00:00:00+00:00",
+        "until_iso": "not-a-timestamp",
+        "reason": "HTTP 402",
+    }
+    assert _cooldown_active(record) is None


### PR DESCRIPTION
## Summary
Two independent fixes for the email noise surfaced in tonight's audit (20:00 UTC → 03:00 UTC, 27 emails, 24 errors).

### #1 — CSI X-API quota cooldown
12 of the 24 errors were paired \`csi_sync_failed\` events from \`@bcherny\` + \`@ClaudeDevs\` getting \`HTTP 402: CreditsDepleted\` from the X API. The cron has no backoff; every scheduled fire (and every catch-up after a restart) re-hits the empty-credits state and mails the operator.

Fix: on first 402, write a per-handle JSON cooldown file (default 24h, env override). At the start of \`run_sync\`, check the cooldown — if active, short-circuit before touching the X API and return \`ok=True\` with \`quota_cooldown_until_iso\` set. The cron script (\`claude_code_intel_run_report.py\`) now suppresses \`emit_csi_activity_event\` when that field is set, so silent skips don't queue emails. The first 402 of a fresh cycle still alarms (one email per cooldown window).

### #2 — cron_artifact_reminders_sweep mail-service rewrite
PR #446's sweep script tried to share the gateway's in-memory \`_agentmail_service\` singleton via \`getattr(gateway_server, "_agentmail_service", None)\`. That always returned \`None\` in a subprocess: the gateway runs as \`__main__\` (live), the subprocess imports the gateway under its qualified name (separate module copy with the pristine \`None\` declaration). Same \`__main__\` vs imported-module gotcha I diagnosed and fixed in PR #450 — but that fix only worked for the in-process F.1 hook; subprocess scripts need a different approach.

Fix: new \`_SubprocessMailService\` class wraps \`AsyncAgentMail\` directly. Resolves the inbox lazily on first send via the AgentMail control plane. Implements the same \`send_email\` signature the reminder sweep expects (including \`ActionTag\`/\`KindTag\` subject prefix + banner formatting). Returns \`{"status": "skipped"}\` gracefully when the SDK or API key are missing.

## Test plan
- [x] \`pytest tests/unit/test_csi_quota_cooldown.py\` — 10 tests cover 402-detection heuristic, path resolution, write/read round-trip, expiry, env override, malformed record handling
- [x] \`pytest tests/unit/test_cron_artifact_reminders_sweep.py\` — 4 tests cover no-API-key, successful send (with stubbed SDK), send failure, missing SDK
- [x] \`py_compile\` + \`ruff E9,F\` clean
- [ ] Post-deploy: confirm the next CSI cron fire (with credits still empty) short-circuits silently — no new \`csi_sync_failed\` event in \`activity_events\` until the cooldown expires OR credits are topped up. Confirm the next \`cron_artifact_reminders_sweep\` cron fire exits 0 and (if there are pending reminders due) actually sends emails.

## Independent followup not in this PR
- **Top up X API credits** (operator action) — separate from the code fix; credits being empty is what TRIGGERS the cooldown. Without the topup, the dashboard will show a 24h-quiet period (no new failure events) but no new CSI data either. With the topup, the cron will run successfully again immediately after the cooldown expires.
- **\`claude_code_intel_run_report\` exited 1** (1 event at 00:33 UTC) — unrelated script, not the same root cause as either #1 or #2. Worth investigating separately if it recurs.
- **Execution Missing Lifecycle Mutation** (4 events) — agent-behavior issue; needs an investigation of which agent/session is failing to close tasks. Tracked but not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)