### PR TITLE
fix(nightly-wiki): read proactive_signal_cards from activity_state.db

### DIFF
--- a/src/universal_agent/scripts/nightly_wiki_agent.py
+++ b/src/universal_agent/scripts/nightly_wiki_agent.py
@@ -6,7 +6,7 @@ import os
 import sqlite3
 import sys
 
-from universal_agent.durable.db import connect_runtime_db, get_runtime_db_path
+from universal_agent.durable.db import connect_runtime_db, get_activity_db_path
 from universal_agent.infisical_loader import initialize_runtime_secrets
 from universal_agent.proactive_signals import CARD_STATUS_PENDING, list_cards
 
@@ -26,8 +26,14 @@ async def main():
     
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-    # Connect to DB to load pending cards
-    db_path = get_runtime_db_path()
+    # Connect to DB to load pending cards.
+    # IMPORTANT: proactive_signal_cards lives in activity_state.db, NOT
+    # runtime_state.db. The dashboard endpoint /api/v1/dashboard/proactive-signals
+    # and the "Create Wiki" button both write to activity_state.db via
+    # gateway_server._activity_connect. Reading runtime_state.db here will
+    # silently return zero pending cards even when the dashboard shows dozens.
+    # Same DB-path pattern as the May-20 watchdog incident (PRs #389/#390/#392/#396).
+    db_path = get_activity_db_path()
     conn = connect_runtime_db(db_path)
     
     # Read the pending signals

--- a/tests/unit/test_nightly_wiki_agent_db_path.py
+++ b/tests/unit/test_nightly_wiki_agent_db_path.py
@@ -1,0 +1,78 @@
+"""Regression guard for the nightly_wiki_agent cron's DB-path choice.
+
+Background: proactive_signal_cards lives in activity_state.db, NOT
+runtime_state.db. The dashboard "Create Wiki" button + gateway endpoint
+write there. Before this fix, nightly_wiki_agent.py read runtime_state.db
+and silently saw zero pending cards while the dashboard showed dozens.
+
+Same root-cause pattern as the May-20 watchdog incident
+(PRs #389/#390/#392/#396 fixed four invariants pointing at runtime_conn
+when the data lived in activity_conn). The nightly_wiki_agent callsite
+was missed and only caught on 2026-05-24 during the Knowledge Vault
+explainer investigation.
+
+These tests are static-source assertions. They are cheap, deterministic,
+and catch the exact regression mode (someone swaps the import back).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "universal_agent"
+    / "scripts"
+    / "nightly_wiki_agent.py"
+)
+
+
+def _script_source() -> str:
+    return _SCRIPT_PATH.read_text(encoding="utf-8")
+
+
+def test_nightly_wiki_imports_activity_db_path() -> None:
+    """The cron must import get_activity_db_path, not get_runtime_db_path,
+    because proactive_signal_cards rows are written to activity_state.db
+    by the dashboard endpoint and the Create Wiki button.
+    """
+    source = _script_source()
+    assert "get_activity_db_path" in source, (
+        "nightly_wiki_agent must import get_activity_db_path — "
+        "proactive_signal_cards lives in activity_state.db"
+    )
+    assert "from universal_agent.durable.db import" in source
+    # The wrong import must NOT be present. If someone reintroduces it,
+    # the cron will silently read zero pending cards again.
+    import_line = next(
+        line for line in source.splitlines()
+        if "from universal_agent.durable.db import" in line
+    )
+    assert "get_runtime_db_path" not in import_line, (
+        "nightly_wiki_agent must NOT import get_runtime_db_path — "
+        "that points at runtime_state.db where pending cards do not live"
+    )
+
+
+def test_nightly_wiki_calls_get_activity_db_path() -> None:
+    """The actual call site must use get_activity_db_path()."""
+    source = _script_source()
+    assert "db_path = get_activity_db_path()" in source, (
+        "nightly_wiki_agent must call get_activity_db_path() to resolve "
+        "the proactive_signal_cards database"
+    )
+
+
+def test_nightly_wiki_documents_db_path_rationale() -> None:
+    """A comment near the connection call must explain why activity_state.db
+    is the right DB. The May-20 watchdog incident showed this footgun is
+    easy to re-introduce when the explanatory comment is missing.
+    """
+    source = _script_source()
+    assert "activity_state.db" in source, (
+        "nightly_wiki_agent must document the activity_state.db choice "
+        "in a comment near the connection call so future edits do not "
+        "re-introduce the runtime_state.db regression"
+    )


### PR DESCRIPTION
## Summary

The `nightly_wiki_agent` cron has been firing cleanly at 3:15 AM CT for weeks but producing zero wikis because it reads the wrong database. This PR is the one-line fix + a regression test.

## The fault

`src/universal_agent/scripts/nightly_wiki_agent.py:30` opened `runtime_state.db` via `get_runtime_db_path()`. The dashboard endpoint `/api/v1/dashboard/proactive-signals` and the "Create Wiki" button both write `proactive_signal_cards` rows to `activity_state.db`. The two diverged.

**Production evidence (this afternoon):**

```
$ sqlite3 runtime_state.db   "SELECT status, COUNT(*) FROM proactive_signal_cards GROUP BY status"
dismissed | 20
promoted  | 11
(no pending rows)

$ sqlite3 activity_state.db  "SELECT status, COUNT(*) FROM proactive_signal_cards GROUP BY status"
deleted | 344
pending | 80          ← dashboard sees these; cron did not

$ tail -2 /opt/universal_agent/AGENT_RUN_WORKSPACES/cron_nightly_wiki/run.log
=== cron run_id=48e8a3e8afbc ... finished_at=2026-05-24T08:15:06Z exit_code=0 ===
INFO:__main__:No pending cards available for proactive wiki generation.
```

The cron classifies as healthy (exit 0) while the actual workload is silently starved.

## Root-cause pattern

This is the **same DB-path mismatch** as the May-20 watchdog incident:
- PR #376: queried wrong DB
- PR #392: picked another wrong DB
- PR #396 (P0b): fixed four invariants by re-pointing from `runtime_conn` to `activity_conn`

The `nightly_wiki_agent.py` callsite was missed. Caught on 2026-05-24 during the Knowledge Vault explainer investigation (Doc 134, PR #447) when production evidence was gathered for the recommended-approach section.

## The fix

```diff
-from universal_agent.durable.db import connect_runtime_db, get_runtime_db_path
+from universal_agent.durable.db import connect_runtime_db, get_activity_db_path
 ...
-    db_path = get_runtime_db_path()
+    db_path = get_activity_db_path()
     conn = connect_runtime_db(db_path)
```

`connect_runtime_db()` is a generic SQLite opener (sets WAL + busy_timeout + row_factory) — it takes any path, no rename needed.

Added a comment block at the call site documenting the activity-vs-runtime distinction so future edits don't re-introduce the regression.

## Regression test

`tests/unit/test_nightly_wiki_agent_db_path.py` (new) — three static-source assertions:
1. `get_activity_db_path` is imported and called
2. `get_runtime_db_path` is NOT imported (catches a future revert)
3. The rationale comment mentions `activity_state.db` (catches accidental comment removal during refactor)

Static-source assertions are cheap, deterministic, and catch the exact regression mode (someone swaps the import back). 3/3 pass.

## Verification

```
uv run ruff check ...                                     # exit 0, no findings
uv run python -m py_compile ...                           # exit 0
uv run pytest tests/unit/test_nightly_wiki_agent_db_path.py -v   # 3 passed in 0.21s
```

## Post-deploy smoke

The cron fires at 3:15 AM CT. The first post-deploy run after this PR merges should:
1. See the ~80 pending cards in `activity_state.db`
2. Generate `UA_DAILY_PROACTIVE_WIKI_COUNT` wikis (default 1)
3. Write `nightly_wiki_{today}.md` artifact for the morning briefing
4. Log `[N] pending cards available for proactive wiki generation` (or similar) instead of the current "No pending cards" line

Verification commands the morning after merge:
```bash
ssh ua@uaonvps tail -20 /opt/universal_agent/AGENT_RUN_WORKSPACES/cron_nightly_wiki/run.log
ssh ua@uaonvps ls -la /opt/universal_agent/artifacts/nightly_wikis/
```

If the cron still logs "No pending cards" after the fix, the next investigation step is whether `proactive_signals.list_cards` itself filters out the pending rows for some reason (e.g., a status filter mismatch). That would be a follow-up PR.

## Test plan

- [x] Ruff clean
- [x] py_compile clean (pr-validate gate)
- [x] Three new regression tests pass
- [ ] Post-deploy: 3:15 AM CT run on production produces ≥1 wiki

## Risks

- Behavior change: the cron will start actually doing work where it previously did nothing. With 80 cards backed up, the first run will pick the top 1 most-interesting topic (per `UA_DAILY_PROACTIVE_WIKI_COUNT`). If quality is bad, raise the cron's frequency cap or set `UA_PROACTIVE_WIKI_ENABLED=0` to disable. There is no destructive operation in the cron — it only creates new NotebookLM notebooks and writes new vault `sources/` pages.
- Rollback: revert this PR. No schema migration, no data migration.

## Doc cross-references

- `docs/03_Operations/134_Knowledge_Vault_System_Explainer_2026-05-24.md` § 10.1 (this fault is the P0 item)
- `docs/03_Operations/134_Knowledge_Vault_System_Explainer_2026-05-24.md` § 11 Phase A1 (this is that item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)