### PR TITLE
fix(notifications): per-(kind, scope) cooldown so different tasks alert independently

### DIFF
--- a/src/universal_agent/services/notification_dispatcher.py
+++ b/src/universal_agent/services/notification_dispatcher.py
@@ -37,7 +37,41 @@ logger = logging.getLogger(__name__)
 
 
 _DELIVERABLE_SEVERITIES = frozenset({"error", "warning"})
-_DEFAULT_COOLDOWN_SECONDS = 300.0  # 5 min per-kind cooldown
+_DEFAULT_COOLDOWN_SECONDS = 300.0  # 5 min per-(kind, scope) cooldown
+
+
+def _scope_key_for_record(record: dict) -> str:
+    """Extract the per-notification dedup scope from a record.
+
+    The cooldown key is ``(kind, scope, channel)`` rather than just
+    ``(kind, channel)`` — that way two genuinely-different
+    ``execution_missing_lifecycle_mutation`` events for different
+    task_ids (or different sessions) can alert independently within
+    the cooldown window, while a single misbehaving task that keeps
+    firing the same kind gets coalesced.
+
+    Resolution order:
+      1. ``metadata.task_id`` (Task Hub item id)
+      2. ``entity_ref.task_id`` or ``entity_ref.id``
+      3. ``metadata.job_id`` (cron job id)
+      4. ``metadata.run_id``
+      5. ``session_id``
+      6. ``""`` — falls back to legacy per-kind behaviour
+    """
+    metadata = record.get("metadata") if isinstance(record.get("metadata"), dict) else {}
+    entity_ref = record.get("entity_ref") if isinstance(record.get("entity_ref"), dict) else {}
+    for key, source in (
+        ("task_id", metadata),
+        ("task_id", entity_ref),
+        ("id", entity_ref),
+        ("job_id", metadata),
+        ("run_id", metadata),
+    ):
+        value = str(source.get(key) or "").strip()
+        if value:
+            return value
+    session_id = str(record.get("session_id") or "").strip()
+    return session_id
 
 
 def _delivery_state_for_channel(record: dict, channel: str) -> Optional[dict]:
@@ -137,17 +171,20 @@ class NotificationDispatcher:
         self._telegram_chat_id = telegram_chat_id
         self._cooldown_seconds = max(1.0, float(cooldown_seconds))
         self._now = now_fn
-        # Per-kind+channel last-send timestamps for cooldown enforcement.
-        self._last_send_at: dict[tuple[str, str], float] = {}
+        # Per-(kind, scope, channel) last-send timestamps for cooldown
+        # enforcement. ``scope`` is a task_id / job_id / session_id
+        # extracted by ``_scope_key_for_record`` so different tasks of the
+        # same kind alert independently within the cooldown window.
+        self._last_send_at: dict[tuple[str, str, str], float] = {}
 
-    def _within_cooldown(self, kind: str, channel: str) -> bool:
-        last = self._last_send_at.get((kind, channel))
+    def _within_cooldown(self, kind: str, scope: str, channel: str) -> bool:
+        last = self._last_send_at.get((kind, scope, channel))
         if last is None:
             return False
         return (self._now() - last) < self._cooldown_seconds
 
-    def _record_send(self, kind: str, channel: str) -> None:
-        self._last_send_at[(kind, channel)] = self._now()
+    def _record_send(self, kind: str, scope: str, channel: str) -> None:
+        self._last_send_at[(kind, scope, channel)] = self._now()
 
     async def _deliver_email_for_row(self, record: dict, summary: dict) -> None:
         if "email" not in _channels_list(record):
@@ -155,7 +192,8 @@ class NotificationDispatcher:
         if _row_already_delivered(record, "email"):
             return
         kind = str(record.get("kind") or "")
-        if self._within_cooldown(kind, "email"):
+        scope = _scope_key_for_record(record)
+        if self._within_cooldown(kind, scope, "email"):
             summary["email_cooldown_skipped"] += 1
             return
         if not self._email_targets:
@@ -182,12 +220,12 @@ class NotificationDispatcher:
                 delivered_any = True
             except Exception:
                 logger.exception(
-                    "notification_dispatcher: email send failed for kind=%s target=%s",
-                    kind, target,
+                    "notification_dispatcher: email send failed for kind=%s scope=%s target=%s",
+                    kind, scope, target,
                 )
 
         if delivered_any:
-            self._record_send(kind, "email")
+            self._record_send(kind, scope, "email")
             try:
                 self._mark_delivered(str(record.get("id") or ""), "email")
             except Exception:
@@ -202,7 +240,8 @@ class NotificationDispatcher:
         if _row_already_delivered(record, "telegram"):
             return
         kind = str(record.get("kind") or "")
-        if self._within_cooldown(kind, "telegram"):
+        scope = _scope_key_for_record(record)
+        if self._within_cooldown(kind, scope, "telegram"):
             summary["telegram_cooldown_skipped"] += 1
             return
         if self._telegram_chat_id is None or str(self._telegram_chat_id).strip() == "":
@@ -217,13 +256,13 @@ class NotificationDispatcher:
             )
         except Exception:
             logger.exception(
-                "notification_dispatcher: telegram send failed for kind=%s",
-                kind,
+                "notification_dispatcher: telegram send failed for kind=%s scope=%s",
+                kind, scope,
             )
             summary["telegram_failed"] += 1
             return
 
-        self._record_send(kind, "telegram")
+        self._record_send(kind, scope, "telegram")
         try:
             self._mark_delivered(str(record.get("id") or ""), "telegram")
         except Exception:

--- a/tests/gateway/test_notification_dispatcher.py
+++ b/tests/gateway/test_notification_dispatcher.py
@@ -163,9 +163,11 @@ async def test_dispatcher_skips_already_delivered_rows():
 
 @pytest.mark.asyncio
 async def test_dispatcher_cooldown_prevents_flapping_kind_spam():
-    """Two rows of the same kind delivered within the cooldown window
-    should only produce one set of sends — protects email/Telegram
-    from a flapping cron job."""
+    """Two rows of the same (kind, scope) delivered within the cooldown
+    window should only produce one set of sends — protects email/Telegram
+    from a flapping cron job. Scope defaults to "" when no metadata
+    provides task_id/job_id/session_id, so the dedup matches the legacy
+    per-kind behaviour for non-scoped events."""
     rows = [
         _row(event_id="ntf_a", kind="cron_run_failed"),
         _row(event_id="ntf_b", kind="cron_run_failed"),
@@ -188,6 +190,121 @@ async def test_dispatcher_cooldown_prevents_flapping_kind_spam():
 
     assert len(email.calls) == 1, f"cooldown should suppress 2nd kind=cron_run_failed; got {len(email.calls)} sends"
     assert len(telegram.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_cooldown_scopes_independently_by_task_id():
+    """2026-05-25: per-task dedup. Two rows of the same kind but for
+    DIFFERENT task_ids should both alert within the cooldown window —
+    they represent independent failures, not a flapping single source.
+    Before this change, the cooldown was per-kind and would have
+    suppressed the second."""
+    rows = [
+        _row(
+            event_id="ntf_task_a",
+            kind="execution_missing_lifecycle_mutation",
+            metadata={"task_id": "proactive_signal_discord:abc_2026-05-25"},
+        ),
+        _row(
+            event_id="ntf_task_b",
+            kind="execution_missing_lifecycle_mutation",
+            metadata={"task_id": "proactive_signal_discord:xyz_2026-05-25"},
+        ),
+    ]
+    email = _Recorder()
+    telegram = _Recorder()
+
+    dispatcher = NotificationDispatcher(
+        get_pending_rows=lambda: list(rows),
+        mark_delivered=lambda *args: None,
+        send_email=email,
+        send_telegram=telegram,
+        email_targets=["test@example.com"],
+        telegram_chat_id="1234",
+        cooldown_seconds=600,
+        now_fn=lambda: time.time(),
+    )
+
+    await dispatcher.dispatch_pending_once()
+
+    assert len(email.calls) == 2, (
+        f"different task_ids should alert independently; got {len(email.calls)} sends"
+    )
+    assert len(telegram.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_cooldown_collapses_same_task_repeats():
+    """The flip side: two rows of the same kind AND same task_id
+    (e.g., a single task crashing twice in a row) get collapsed to one
+    email — that's the legacy spam-suppression behaviour preserved
+    under the new keying."""
+    rows = [
+        _row(
+            event_id="ntf_dup_a",
+            kind="execution_missing_lifecycle_mutation",
+            metadata={"task_id": "proactive_signal_discord:abc_2026-05-25"},
+        ),
+        _row(
+            event_id="ntf_dup_b",
+            kind="execution_missing_lifecycle_mutation",
+            metadata={"task_id": "proactive_signal_discord:abc_2026-05-25"},
+        ),
+    ]
+    email = _Recorder()
+    telegram = _Recorder()
+
+    dispatcher = NotificationDispatcher(
+        get_pending_rows=lambda: list(rows),
+        mark_delivered=lambda *args: None,
+        send_email=email,
+        send_telegram=telegram,
+        email_targets=["test@example.com"],
+        telegram_chat_id="1234",
+        cooldown_seconds=600,
+        now_fn=lambda: time.time(),
+    )
+
+    await dispatcher.dispatch_pending_once()
+
+    assert len(email.calls) == 1
+    assert len(telegram.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_cooldown_falls_back_to_job_id_then_session():
+    """Cooldown scope resolution order is task_id → entity_ref → job_id
+    → run_id → session_id. Confirm fallback path works for cron-style
+    events that have no task_id."""
+    rows = [
+        _row(
+            event_id="ntf_cron_x",
+            kind="cron_run_failed",
+            metadata={"job_id": "cron_paper_to_podcast"},
+        ),
+        _row(
+            event_id="ntf_cron_y",
+            kind="cron_run_failed",
+            metadata={"job_id": "cron_youtube_digest"},
+        ),
+    ]
+    email = _Recorder()
+    telegram = _Recorder()
+
+    dispatcher = NotificationDispatcher(
+        get_pending_rows=lambda: list(rows),
+        mark_delivered=lambda *args: None,
+        send_email=email,
+        send_telegram=telegram,
+        email_targets=["test@example.com"],
+        telegram_chat_id="1234",
+        cooldown_seconds=600,
+        now_fn=lambda: time.time(),
+    )
+
+    await dispatcher.dispatch_pending_once()
+
+    assert len(email.calls) == 2, "different job_ids should alert independently"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
The notification dispatcher's cooldown is currently keyed \`(kind, channel)\`. That's too coarse: when two genuinely-different tasks fire the same kind (e.g., two distinct \`proactive_signal_discord\` tasks both hit \`execution_missing_lifecycle_mutation\` from independent SDK crashes), only ONE email reaches the operator. The second task's failure is dedup'd away.

This PR derives a per-record scope and keys the cooldown \`(kind, scope, channel)\`. Different tasks alert independently; same-task repeats still get collapsed.

## Resolution order for scope
1. \`metadata.task_id\` (Task Hub item id)
2. \`entity_ref.task_id\` or \`entity_ref.id\`
3. \`metadata.job_id\` (cron job id)
4. \`metadata.run_id\`
5. \`session_id\`
6. \`""\` (empty — matches legacy per-kind behaviour for non-scoped events)

## Why this matters now
- Tonight's audit found 4 \`execution_missing_lifecycle_mutation\` emails across 3 distinct task_ids spread over 1.5 hours.
- PR #454 (manager-first posture) is expected to reduce the failure rate by routing most work to Atlas — but when failures DO occur, each one needs to be visible.
- PR #455's SDK-crash recovery (Task #27) will eventually suppress most of these emails entirely. Until that ships, the per-scope dedup ensures we don't accidentally hide an unrelated task's failure when one task is crashing repeatedly.

## Test plan
- [x] 3 new tests in \`tests/gateway/test_notification_dispatcher.py\`:
  - \`scopes_independently_by_task_id\`: two different task_ids → 2 emails
  - \`collapses_same_task_repeats\`: same task_id twice → 1 email (legacy)
  - \`falls_back_to_job_id_then_session\`: cron events without task_id still scope by job_id
- [x] 34 existing dispatcher tests pass unchanged (the empty-scope fallback matches the legacy keying)
- [x] \`py_compile\` + \`ruff E9,F\` clean
- [ ] Post-deploy: observe the next round of guardrail failures (likely from the same underlying SDK crashes) and confirm the email log shows distinct emails per task_id rather than just one

## Independent followups
- **Task #26 — task_delegate verb**: still pending; not blocked by this PR
- **Task #27 — SDK crash recovery**: still the deeper fix; this PR is the interim noise mitigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)