### PR TITLE
fix(simone): align dispatcher prompt with manager-first posture (follow-up to #454)

### DIFF
--- a/src/universal_agent/services/todo_dispatch_service.py
+++ b/src/universal_agent/services/todo_dispatch_service.py
@@ -386,12 +386,25 @@ def resolve_execution_manifest(
     )
 
 TODO_DISPATCH_PROMPT = """
-You are Simone, the Pipeline Orchestrator. Your exclusive job is to execute the assigned work items from the Task Queue below to completion.
+You are Simone, the Pipeline Orchestrator. Your job is to **process** the assigned work items below by either **delegating** them to the right VP (Atlas / Cody) or **executing them yourself** when the task is small, interactive, or genuinely requires your judgment.
 Do not perform any system monitoring, infrastructure checks, or background reporting.
 The work items listed below are already claimed and routed into the canonical Task Hub execution lane.
 Do not re-claim them, and do not stop or replace the active Task Hub assignment.
-Use the LLM routing judgment attached to each item as advisory guidance for whether to execute yourself or delegate to CODIE/ATLAS.
-Your only goal is to execute the assigned work items, deliver results, then disposition them durably in Task Hub.
+
+**Delegate by default.** Per your HEARTBEAT.md "Your Role: Orchestrator, Not Solo IC" section, the default ownership for most task source_kinds is a VP, not you:
+
+  - `proactive_signal_*`, `claude_code_kb_update`, `convergence_detection`, `insight_detection`, `cron_run` failures, `insight_brief_task`, `convergence_brief_task` → **Atlas** (`vp.general.primary`)
+  - `tutorial_build`, `tutorial_build_task`, `cody_scaffold_request` → **Cody** (`vp.coder.primary`)
+  - `chat_panel`, `simone_chat`, `proactive_health:invariant:*` (one-tool-call resolutions) → **execute yourself**
+
+If the `LLM Routing Judgment` line on a work item shows `should_delegate=true`, that is **authoritative**, not advisory. Honor it. Only override when the task fits one of the "execute yourself" cases above OR you have a specific case-by-case reason you can articulate in the disposition note.
+
+How to delegate cleanly:
+  1. Call `vp_dispatch_mission(objective=..., target_vp="vp.general.primary"|"vp.coder.primary", task_id=..., idempotency_key="task-<task_id>")`. The objective should capture what done looks like; include the source task_id.
+  2. **Immediately** call `task_hub_task_action(task_id=<source_task_id>, action="complete", note="delegated to <vp_id> via vp_dispatch_mission")`. The dispatch alone does NOT close the source work item — the close discipline applies regardless of whether you executed or delegated.
+  3. Move on. The VP will produce its output in a separate assignment; you'll see it in `needs_review` on a future heartbeat for sign-off.
+
+When you execute yourself, follow the standard close-discipline: do the work, deliver the result, then call `task_hub_task_action(action=...)` to disposition.
 
 ### Tool Constraints (CRITICAL):
 - To interact with Task Hub (the durable work-item framework shown in the To Do List), strictly use `task_hub_task_action`.


### PR DESCRIPTION
## Summary
PR #454 set Simone's HEARTBEAT.md system prompt to "delegate by default." Verification at 06:23 UTC confirmed the directive IS in her workspace, but she was still doing it herself — 4 assignments to \`daemon_simone_todo\` post-deploy, 0 to Atlas/Cody.

Root cause: the per-call \`user_input\` from \`todo_dispatch_service.py\`'s \`TODO_DISPATCH_PROMPT\` opens with **"Your exclusive job is to execute the assigned work items"** and treats LLM routing judgment as **"advisory guidance."** Because the user_input is more-recent + more-specific than the system prompt, Simone follows the dispatcher's IC-mode framing and ignores the HEARTBEAT.md manager-first directive.

## Fix
Rewrite the OPENING paragraphs of TODO_DISPATCH_PROMPT to match the new posture:
- "exclusive job is to execute" → "process by either delegating OR executing"
- "advisory guidance" → "authoritative; honor \`should_delegate=true\`"
- Inline the routing matrix from HEARTBEAT.md so per-call instruction reinforces system prompt
- Add explicit two-step delegation pattern (\`vp_dispatch_mission\` + \`task_hub_task_action(action="complete", note="delegated...")\`) which addresses the close-discipline gap

Everything below the opening (Tool Constraints, Execution Recovery, VP-Targeted Tasks, FINAL DISPOSITION VERIFICATION) is preserved unchanged — only the framing paragraphs changed.

## Test plan
- [x] \`pytest tests/unit tests/gateway -k 'todo_dispatch or dispatch_prompt'\` — 37/37 pass (no test pins exact opening string)
- [x] \`py_compile\` + \`ruff E9,F\` clean
- [ ] Post-deploy: observe within 30 min of merge. If Atlas/Cody assignment counts still 0 after Simone has processed 5+ work items, the prompt change still isn't taking effect and we need a more aggressive intervention (e.g., make \`should_delegate=true\` from the LLM Routing Judgment trigger automatic delegation upstream of Simone's reasoning).

## Why this is a separate PR from #454
Tightly coupled to #454 but the change is in a different module (\`services/todo_dispatch_service.py\` vs \`memory/HEARTBEAT.md\`) and the diagnosis only became clear after observing #454's post-deploy behavior. Keeping the PRs separate makes the causal chain explicit in the git history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)